### PR TITLE
revert: retry actions

### DIFF
--- a/alumnium/alumni.py
+++ b/alumnium/alumni.py
@@ -5,6 +5,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 from langchain_google_genai import ChatGoogleGenerativeAI
 
+from retry import retry
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from .agents import ActorAgent, VerifierAgent
@@ -41,6 +42,7 @@ class Alumni:
     def quit(self):
         self.driver.quit()
 
+    @retry(tries=2, delay=0.1)
     def do(self, goal: str):
         self.actor_agent.invoke(goal)
 

--- a/examples/pytest/google_test.py
+++ b/examples/pytest/google_test.py
@@ -13,6 +13,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 def test_google_search(al, driver):
     driver.get("https://www.google.com")
-    al.do("type selenium to search and press enter but do not click on anything")
+    al.do("search for selenium")
     al.check("selenium in page title")
     al.check("selenium.dev is present in the search results")

--- a/poetry.lock
+++ b/poetry.lock
@@ -488,6 +488,17 @@ files = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -1936,6 +1947,17 @@ files = [
 ]
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -2379,6 +2401,21 @@ files = [
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
+
+[[package]]
+name = "retry"
+version = "0.9.2"
+description = "Easy to use retry decorator."
+optional = false
+python-versions = "*"
+files = [
+    {file = "retry-0.9.2-py2.py3-none-any.whl", hash = "sha256:ccddf89761fa2c726ab29391837d4327f819ea14d244c232a1d24c67a2f98606"},
+    {file = "retry-0.9.2.tar.gz", hash = "sha256:f8bfa8b99b69c4506d6f5bd3b0aabf77f98cdb17f3c9fc3f5ca820033336fba4"},
+]
+
+[package.dependencies]
+decorator = ">=3.4.2"
+py = ">=1.4.26,<2.0.0"
 
 [[package]]
 name = "rsa"
@@ -2958,4 +2995,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "99cd8fd54456e0915ddd180fbab2f6923d6d1c064dacb7171fe37695c59bee09"
+content-hash = "6e1ed6a9c821ad0ea092afe2b2e48ce49a8e9102b3c7ae21781264f1946b8010"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,14 @@ langchain = "^0.3"
 langchain-anthropic = "^0.2"
 langchain-google-genai = "^2.0"
 langchain-openai = "^0.2"
+retry = "^0.9"
 selenium = "^4.0"
 
 [tool.poetry.group.dev.dependencies]
 behave = "^1.2.6"
-behave-html-pretty-formatter = "^1.12"
 pytest = "^8.3.3"
 pytest-html = "^4.1.1"
+behave-html-pretty-formatter = "^1.12"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The retry serves as a simplistic manager agent. In a situation when the model attempts to do too much on the page. For example, in Google search it's common to for model to suggest to type word in the search box, press Enter and then click "Search" button. The last step is redundant and causes the test to fail. Retry would attempt to search again and the model would respond that nothing needs to be done since the goal is achieved.

Eventually, we want to replace retry with a more intelligent agent that would constantly evaluate what needs to be done to achieve the goal as the action is executed.

This reverts commits e1b734d, 961d35a and bb6b59d.