### PR TITLE
feat: retry verification if page is loading

### DIFF
--- a/alumnium/agents/__init__.py
+++ b/alumnium/agents/__init__.py
@@ -1,2 +1,3 @@
 from .actor_agent import ActorAgent
+from .loading_detector_agent import LoadingDetectorAgent
 from .verifier_agent import VerifierAgent

--- a/alumnium/agents/loading_detector_agent.py
+++ b/alumnium/agents/loading_detector_agent.py
@@ -1,0 +1,63 @@
+import logging
+from pathlib import Path
+
+from langchain_core.language_models import BaseChatModel
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
+
+
+class Loading(BaseModel):
+    """Result of determining whether a page is loading or being changed dynamically in any other way."""
+
+    result: bool = Field(description="Whether the page is loading or being changed dynamically in any other way.")
+    explanation: str = Field(description="Reason for the result.")
+
+
+class LoadingDetectorAgent:
+    with open(Path(__file__).parent / "loading_detector_prompts/system.md") as f:
+        SYSTEM_MESSAGE = f.read()
+    with open(Path(__file__).parent / "loading_detector_prompts/user.md") as f:
+        USER_MESSAGE = f.read()
+
+    delay = 0.5
+    timeout = 5
+
+    def __init__(self, llm: BaseChatModel):
+        llm = llm.with_structured_output(Loading, include_raw=True)
+        self.chain = llm
+
+    def invoke(self, aria: str, title: str, url: str, screenshot: str = ""):
+        logger.info(f"Starting loading detection:")
+
+        human_messages = [
+            {
+                "type": "text",
+                "text": self.USER_MESSAGE.format(url=url, title=title, aria=aria),
+            }
+        ]
+
+        if screenshot:
+            human_messages.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/png;base64,{screenshot}",
+                    },
+                }
+            )
+
+        message = self.chain.invoke(
+            [
+                ("system", self.SYSTEM_MESSAGE),
+                ("human", human_messages),
+            ]
+        )
+
+        loading = message["parsed"]
+        logger.info(f"  <- Result: {loading.result}")
+        logger.info(f"  <- Reason: {loading.explanation}")
+        logger.info(f'  <- Usage: {message["raw"].usage_metadata}')
+
+        return loading.result

--- a/alumnium/agents/loading_detector_prompts/system.md
+++ b/alumnium/agents/loading_detector_prompts/system.md
@@ -1,0 +1,1 @@
+You are a helpful assistant who analyzes a screenshot of a webpage, its accessibility (ARIA) tree given as XML, and judges whether the page is loading or being changed dynamically in any other way.

--- a/alumnium/agents/loading_detector_prompts/user.md
+++ b/alumnium/agents/loading_detector_prompts/user.md
@@ -1,0 +1,10 @@
+Based on the screenshot, webpage ARIA tree, its title and URL, is the page loading or being changed dynamically in any other way?
+
+- Title: {title}
+- URL: {url}
+
+### Webpage ARIA tree
+
+```xml
+{aria}
+```

--- a/examples/pytest/retry_test.py
+++ b/examples/pytest/retry_test.py
@@ -1,0 +1,6 @@
+def test_retries_assertion_on_loading_content(al, driver):
+    driver.get("https://the-internet.herokuapp.com/dynamic_controls")
+    al.check("text field is disabled")
+    al.do("click Enable button")
+    # It takes few seconds to enable the text field
+    al.check("text field is enabled")


### PR DESCRIPTION
This is a basic retry implementation that catches verification errors and checks whether the page is loading. If it does, it would wait 0.5s and retry up to 5s.

VerifierAgent should not really know about LoadingDetectorAgent, a high-level abstraction is needed here (e.g. CoordinatorAgent). It's worth to add it later when we need to add retries for ActorAgent too.