### PR TITLE
feat: support remote chromium drivers

### DIFF
--- a/alumnium/drivers/selenium_driver.py
+++ b/alumnium/drivers/selenium_driver.py
@@ -1,3 +1,4 @@
+from selenium.webdriver.chrome.remote_connection import ChromiumRemoteConnection
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -10,6 +11,7 @@ from alumnium.aria import AriaTree
 class SeleniumDriver:
     def __init__(self, driver: WebDriver):
         self.driver = driver
+        self._patch_driver(driver)
 
     @property
     def aria_tree(self) -> AriaTree:
@@ -77,3 +79,13 @@ class SeleniumDriver:
             },
         )
         return element
+
+    # Remote Chromium instances support CDP commands, but the Python bindings don't expose them.
+    # https://github.com/SeleniumHQ/selenium/issues/14799
+    def _patch_driver(self, driver: WebDriver):
+        if isinstance(driver.command_executor, ChromiumRemoteConnection) and not hasattr(driver, "execute_cdp_cmd"):
+            # Copied from https://github.com/SeleniumHQ/selenium/blob/d6e718d134987d62cd8ffff476821fb3ca1797c2/py/selenium/webdriver/chromium/webdriver.py#L123-L141
+            def execute_cdp_cmd(self, cmd: str, cmd_args: dict):
+                return self.execute("executeCdpCommand", {"cmd": cmd, "params": cmd_args})["value"]
+
+            driver.execute_cdp_cmd = execute_cdp_cmd.__get__(driver)


### PR DESCRIPTION
This is a workaround for https://github.com/SeleniumHQ/selenium/issues/14799, though we would still need to support the older Selenium versions so it will stick around at least until Selenium 5.

Fixes #11.