### PR TITLE
ci: create release/tag on `release:` commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*.*.*
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -57,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     environment: release
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'release:')
     permissions:
       attestations: write
       contents: write
@@ -72,11 +70,13 @@ jobs:
           key: venv-${{ hashFiles('poetry.lock') }}
       - run: poetry install
       - run: poetry build
+      - run: echo "version=$(poetry version --short)" >> $GITHUB_OUTPUT
+        id: version
       - uses: actions/attest-build-provenance@v1
         with:
           subject-path: dist/*
       - uses: pypa/gh-action-pypi-publish@release/v1
-      - run: gh release create ${{ github.ref_name }} --generate-notes dist/*
+      - run: gh release create ${{ steps.version.outputs.version }} --generate-notes dist/*
         env:
           GH_TOKEN: ${{ github.token }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This simplifies release automation by removing the need to create a tag and run two CI workflows - one for commit and one for the tag.

Instead, simply bump the version in `pyproject.toml` and commit with a message starting with `release:`. The CI workflow will read a version from `pyproject.toml`, build a package, and create a release and a tag on GitHub.