### PR TITLE
fix: prevent retriever from guessing answer

### DIFF
--- a/alumnium/agents/retriever_prompts/system.md
+++ b/alumnium/agents/retriever_prompts/system.md
@@ -1,4 +1,11 @@
 You are an precise robot who analyzes a screenshot of a webpage, its accessibility (ARIA) tree given as XML, and retrieves requested information from it.
-Avoid duplicates unless they are legitimately repeated.
-Preserve the order of items as they appear in the source.
-If the information is a list, separate the items with {separator} instead of a comma.
+
+CRITICAL INSTRUCTIONS:
+- ONLY retrieve information directly present in the provided webpage, screenshot, or accessibility tree
+- If the requested information is NOT in the source material, RESPOND ONLY WITH: "NOOP"
+- Do NOT use any external or common knowledge to supplement or guess the answer
+- Avoid duplicates unless they are legitimately repeated
+- Preserve the order of items as they appear in the source
+- If the information is a list, separate the items with {separator} instead of a comma
+
+ANY VIOLATION OF THESE INSTRUCTIONS IS NOT PERMITTED

--- a/alumnium/drivers/playwright_driver.py
+++ b/alumnium/drivers/playwright_driver.py
@@ -9,6 +9,7 @@ from .base_driver import BaseDriver
 
 logger = logging.getLogger(__name__)
 
+
 class PlaywrightDriver(BaseDriver):
     CANNOT_FIND_NODE_ERROR = "Could not find node with given id"
     NOT_SELECTABLE_ERROR = "Element is not a <select> element"
@@ -18,7 +19,6 @@ class PlaywrightDriver(BaseDriver):
         WAITER_SCRIPT = f.read()
     with open("./scripts/waitFor.js") as f:
         WAIT_FOR_SCRIPT = f"(...scriptArgs) => new Promise((resolve) => {{ const arguments = [...scriptArgs, resolve]; {f.read()} }})"
-
 
     def __init__(self, page: Page):
         self.client = page.context.new_cdp_session(page)

--- a/examples/pytest/table_test.py
+++ b/examples/pytest/table_test.py
@@ -36,3 +36,11 @@ def test_table_sorting(al, navigate):
     # example 1 table is not affected
     assert al.get("first names from example 1 table") == ["Frank", "Tim", "Jason", "John"]
     assert al.get("last names from example 1 table") == ["Bach", "Conway", "Doe", "Smith"]
+
+
+def test_retrieval_of_unavailable_data(al, navigate):
+    navigate("https://the-internet.herokuapp.com/tables")
+
+    # This data is not available on the page.
+    # Even though LLM knows the answer, it should not respond it.
+    assert al.get("atomic number of Selenium") == None


### PR DESCRIPTION
This commit ensures that retriever only uses the context to extract data and not try to look the answer up using its own knowledge.