### PR TITLE
fix: syntax error on f-string

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 poetry 2.0.1
-python 3.12.6
+python 3.10.16

--- a/alumnium/agents/retriever_agent.py
+++ b/alumnium/agents/retriever_agent.py
@@ -81,7 +81,7 @@ class RetrieverAgent(BaseAgent):
 
         response = message["parsed"]
         logger.info(f"  <- Result: {response}")
-        logger.info(f"  <- Usage: {message["raw"].usage_metadata}")
+        logger.info(f"  <- Usage: {message['raw'].usage_metadata}")
 
         # Remove when we find a way use `Data` in structured output `value`.
         response.value = self.__loosely_typecast(response.value)


### PR DESCRIPTION
Looks like double-quotes are not allowed in f-strings surrounded by double-quotes on Python 3.10.

```
>>> import alumnium
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/p0deje/.asdf/installs/python/3.10.12/lib/python3.10/site-packages/alumnium/__init__.py", line 17, in <module>
    from .alumni import *
  File "/Users/p0deje/.asdf/installs/python/3.10.12/lib/python3.10/site-packages/alumnium/alumni.py", line 12, in <module>
    from .agents import *
  File "/Users/p0deje/.asdf/installs/python/3.10.12/lib/python3.10/site-packages/alumnium/agents/__init__.py", line 3, in <module>
    from .retriever_agent import RetrieverAgent
  File "/Users/p0deje/.asdf/installs/python/3.10.12/lib/python3.10/site-packages/alumnium/agents/retriever_agent.py", line 86
    logger.info(f"  <- Usage: {message["raw"].usage_metadata}")
                                        ^^^
SyntaxError: f-string: unmatched '['
```