### PR TITLE
Add flake8 linting and cleanup violations

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-poetry 2.0.1
+poetry 2.1.1
 python 3.10.16

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 format:
 	poetry run autoflake .
 	poetry run black .
+	poetry run flake8 alumnium examples
 	poetry run isort .
 	poetry run pyprojectsort
 

--- a/alumnium/agents/actor_agent.py
+++ b/alumnium/agents/actor_agent.py
@@ -36,7 +36,7 @@ class ActorAgent(BaseAgent):
         if not step.strip():
             return
 
-        logger.info(f"Starting action:")
+        logger.info("Starting action:")
         logger.info(f"  -> Goal: {goal}")
         logger.info(f"  -> Step: {step}")
 

--- a/alumnium/agents/planner_agent.py
+++ b/alumnium/agents/planner_agent.py
@@ -53,7 +53,7 @@ class PlannerAgent(BaseAgent):
         )
 
     def invoke(self, goal: str) -> list[str]:
-        logger.info(f"Starting planning:")
+        logger.info("Starting planning:")
         logger.info(f"  -> Goal: {goal}")
 
         aria = self.driver.aria_tree

--- a/alumnium/agents/retriever_agent.py
+++ b/alumnium/agents/retriever_agent.py
@@ -20,10 +20,12 @@ class RetrievedInformation(BaseModel):
     """Retrieved information."""
 
     explanation: str = Field(
-        description="Explanation how information was retrieved and why it's related to the requested information. Always include the requested information and its value in the explanation."
+        description="Explanation how information was retrieved and why it's related to the requested information."
+        + "Always include the requested information and its value in the explanation."
     )
     value: str = Field(
-        description="The precise retrieved information value without additional data. If the information is not present in context, reply NOOP."
+        description="The precise retrieved information value without additional data. If the information is not"
+        + "present in context, reply NOOP."
     )
 
 
@@ -45,7 +47,7 @@ class RetrieverAgent(BaseAgent):
         )
 
     def invoke(self, information: str, vision: bool) -> RetrievedInformation:
-        logger.info(f"Starting retrieval:")
+        logger.info("Starting retrieval:")
         logger.info(f"  -> Information: {information}")
 
         aria = self.driver.aria_tree.to_xml()

--- a/alumnium/aria.py
+++ b/alumnium/aria.py
@@ -52,7 +52,7 @@ class AriaTree:
 
             if role_value == "StaticText":
                 parent.text = name_value
-            elif role_value == "none" or ignored == True:
+            elif role_value == "none" or ignored:
                 if children:
                     for child in children:
                         convert_node_to_xml(child, parent)

--- a/alumnium/drivers/playwright_driver.py
+++ b/alumnium/drivers/playwright_driver.py
@@ -120,7 +120,7 @@ class PlaywrightDriver(BaseDriver):
                 raise error
 
     def wait_for_page_to_load(self):
-        logger.info(f"Waiting for page to finish loading")
+        logger.info("Waiting for page to finish loading")
         try:
             self.page.evaluate(f"function() {{ {self.WAITER_SCRIPT} }}")
             error = self.page.evaluate(self.WAIT_FOR_SCRIPT)
@@ -128,7 +128,7 @@ class PlaywrightDriver(BaseDriver):
                 logger.info(f"Failed to wait for page to load: {error}")
         except Error as error:
             if self.CONTEXT_WAS_DESTROYED_ERROR in error.message:
-                logger.info(f"Page context has changed, retrying")
+                logger.info("Page context has changed, retrying")
                 self.wait_for_page_to_load()
             else:
                 raise error

--- a/alumnium/drivers/selenium_driver.py
+++ b/alumnium/drivers/selenium_driver.py
@@ -114,14 +114,14 @@ class SeleniumDriver(BaseDriver):
     # https://github.com/SeleniumHQ/selenium/issues/14799
     def _patch_driver(self, driver: WebDriver):
         if isinstance(driver.command_executor, ChromiumRemoteConnection) and not hasattr(driver, "execute_cdp_cmd"):
-            # Copied from https://github.com/SeleniumHQ/selenium/blob/d6e718d134987d62cd8ffff476821fb3ca1797c2/py/selenium/webdriver/chromium/webdriver.py#L123-L141
+            # Copied from https://github.com/SeleniumHQ/selenium/blob/d6e718d134987d62cd8ffff476821fb3ca1797c2/py/selenium/webdriver/chromium/webdriver.py#L123-L141 # noqa: E501
             def execute_cdp_cmd(self, cmd: str, cmd_args: dict):
                 return self.execute("executeCdpCommand", {"cmd": cmd, "params": cmd_args})["value"]
 
             driver.execute_cdp_cmd = execute_cdp_cmd.__get__(driver)
 
     def wait_for_page_to_load(self):
-        logger.info(f"Waiting for page to finish loading")
+        logger.info("Waiting for page to finish loading")
         self.driver.execute_script(self.WAITER_SCRIPT)
         error = self.driver.execute_async_script(self.WAIT_FOR_SCRIPT)
         if error is not None:

--- a/examples/behave/features/steps/todo_al.py
+++ b/examples/behave/features/steps/todo_al.py
@@ -54,7 +54,7 @@ def step_impl(context, title):
 
 @then('"{title}" task is not shown in the list of tasks')
 def step_impl(context, title):
-    assert not title in context.al.get("titles of tasks")
+    assert title not in context.al.get("titles of tasks")
 
 
 @then('"{title}" task is not marked as completed')

--- a/examples/pytest/table_test.py
+++ b/examples/pytest/table_test.py
@@ -51,4 +51,4 @@ def test_retrieval_of_unavailable_data(al, navigate):
 
     # This data is not available on the page.
     # Even though LLM knows the answer, it should not respond it.
-    assert al.get("atomic number of Selenium") == None
+    assert al.get("atomic number of Selenium") is None

--- a/poetry.lock
+++ b/poetry.lock
@@ -672,6 +672,41 @@ files = [
 ]
 
 [[package]]
+name = "flake8"
+version = "7.2.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "flake8-7.2.0-py2.py3-none-any.whl", hash = "sha256:93b92ba5bdb60754a6da14fa3b93a9361fd00a59632ada61fd7b130436c40343"},
+    {file = "flake8-7.2.0.tar.gz", hash = "sha256:fa558ae3f6f7dbf2b4f22663e5343b6b6023620461f8d4ff2019ef4b5ee70426"},
+]
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.13.0,<2.14.0"
+pyflakes = ">=3.3.0,<3.4.0"
+
+[[package]]
+name = "flake8-pyproject"
+version = "1.2.3"
+description = "Flake8 plug-in loading the configuration from pyproject.toml"
+optional = false
+python-versions = ">= 3.6"
+groups = ["dev"]
+files = [
+    {file = "flake8_pyproject-1.2.3-py3-none-any.whl", hash = "sha256:6249fe53545205af5e76837644dc80b4c10037e73a0e5db87ff562d75fb5bd4a"},
+]
+
+[package.dependencies]
+Flake8 = ">=5"
+TOMLi = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["pyTest", "pyTest-cov"]
+
+[[package]]
 name = "frozenlist"
 version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -1632,6 +1667,18 @@ files = [
 ]
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
 name = "multidict"
 version = "6.1.0"
 description = "multidict implementation"
@@ -2274,6 +2321,18 @@ files = [
 pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
+name = "pycodestyle"
+version = "2.13.0"
+description = "Python style guide checker"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pycodestyle-2.13.0-py2.py3-none-any.whl", hash = "sha256:35863c5974a271c7a726ed228a14a4f6daf49df369d8c50cd9a6f58a5e143ba9"},
+    {file = "pycodestyle-2.13.0.tar.gz", hash = "sha256:c8415bf09abe81d9c7f872502a6eee881fbe85d8763dd5b9924bb0a01d67efae"},
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -2440,14 +2499,14 @@ dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "
 
 [[package]]
 name = "pyflakes"
-version = "3.2.0"
+version = "3.3.2"
 description = "passive checker of Python programs"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
+    {file = "pyflakes-3.3.2-py2.py3-none-any.whl", hash = "sha256:5039c8339cbb1944045f4ee5466908906180f13cc99cc9949348d10f82a5c32a"},
+    {file = "pyflakes-3.3.2.tar.gz", hash = "sha256:6dfd61d87b97fba5dcfaaf781171ac16be16453be6d816147989e7f6e6a9576b"},
 ]
 
 [[package]]
@@ -3349,4 +3408,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "09f91eb2b77aa109e258ba321377eed19dbb5579051749b0a980c0f82a60620e"
+content-hash = "8e1c0eef9f70c594615a56fb9fd31fd4adbca23aea8e39a2248b93c78c42383f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ remove-unused-variables = true
 [tool.black]
 line-length = 119
 
+[tool.flake8]
+max-line-length = 119
+
 [tool.isort]
 profile = "black"
 
@@ -45,6 +48,8 @@ autoflake = "^2.3.1"
 behave = "^1.2.6"
 behave-html-pretty-formatter = "^1.12"
 black = "^25.1.0"
+flake8 = "^7.2.0"
+flake8-pyproject = "^1.2.3"
 isort = "^6.0.0"
 pyprojectsort = "^0.4.0"
 pytest = "^8.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,17 @@ remove-unused-variables = true
 line-length = 119
 
 [tool.flake8]
+ignore = [
+    "E402",
+    "F401",
+    "F403",
+    "F405",
+    "W503",
+]
 max-line-length = 119
+per-file-ignores = [
+    "examples/behave/features/steps/*:F811",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This PR adds the Flake8 linter to the project and fixes (or ignores) all violations it reports.

https://flake8.pycqa.org

Flake8 is a pretty standard tool for checking code style in Python. It is a combination linter that runs checks using the `mccabe`, `pyflakes`, and `pycodestyle` tools. It is not an autoformatter like `black`... it just displays violations that need to be fixed manually. It finds many style issues that `black` doesn't care about.

Changes in this PR:

- Added `flake8` and `flake8-pyproject` dev dependencies to `pyproject.toml`. (`flake8-pyproject` is needed to read Flake8 configuration from `pyproject.toml`)
- Generated new `poetry.lock` file to include the new dependencies.
- Added `flake8` to the `format` task in `Makefile` (configured to scan the entire codebase, including the examples)
- Fixed all violations flagged by Flake8
- Updated the poetry version in `.tools-versions` to match the lock file. The lock file was generated with `poetry 2.1.1`, but `.tools-versions` had `poetry 2.0.1`. This was causing the CI test job to run with different dependencies than would be used for local development.

There are no functional changes in this PR... just cleaner code.
