### PR TITLE
Fix code formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 format:
 	poetry run autoflake .
 	poetry run black .
-	poetry run flake8 alumnium examples
+	poetry run flake8 alumnium examples tests
 	poetry run isort .
 	poetry run pyprojectsort
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
 [tool.autoflake]
 in-place = true
 recursive = true
+remove-duplicate-keys = true
 remove-unused-variables = true
 
 [tool.black]

--- a/tests/test_aria.py
+++ b/tests/test_aria.py
@@ -1,6 +1,8 @@
 from typing import Any
-import pytest
 from xml.etree.ElementTree import fromstring
+
+import pytest
+
 from alumnium.aria import AriaTree
 
 

--- a/tests/test_llm_response.py
+++ b/tests/test_llm_response.py
@@ -1,50 +1,47 @@
+from unittest.mock import MagicMock, create_autospec, patch
+
 import pytest
-from unittest.mock import patch, MagicMock, create_autospec
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from alumnium.models import Model
 from alumnium.alumni import Alumni
+from alumnium.models import Model
 
 
 @pytest.mark.parametrize(
-        ("model_class", "model", "expected_params"),
-        [
-            (
-                "alumnium.alumni.AzureChatOpenAI",
-                Model.AZURE_OPENAI,
-                {"model":Model.AZURE_OPENAI.value, "api_version":"", "temperature":0, "seed":1}
-            ),
-            (
-                "alumnium.alumni.ChatAnthropic",
-                Model.ANTHROPIC,
-                {"model":Model.ANTHROPIC.value, "temperature":0}
-            ),
-            (
-                "alumnium.alumni.ChatBedrockConverse",
-                Model.AWS_ANTHROPIC,
-                {"model_id":Model.AWS_ANTHROPIC.value, "temperature":0, "aws_access_key_id":"", "aws_secret_access_key":"", "region_name":"us-east-1"}
-            ),
-            (
-                "alumnium.alumni.ChatBedrockConverse",
-                Model.AWS_META,
-                {"model_id":Model.AWS_META.value, "temperature":0, "aws_access_key_id":"", "aws_secret_access_key":"", "region_name":"us-east-1"}
-            ),
-            (
-                "alumnium.alumni.ChatDeepSeek",
-                Model.DEEPSEEK,
-                {"model":Model.DEEPSEEK.value, "temperature":0}
-            ),
-            (
-                "alumnium.alumni.ChatGoogleGenerativeAI",
-                Model.GOOGLE,
-                {"model":Model.GOOGLE.value, "temperature":0}
-            ),
-            (
-                "alumnium.alumni.ChatOpenAI",
-                None,
-                {"model":Model.OPENAI.value, "temperature":0, "seed":1}
-            ),
-        ]
+    ("model_class", "model", "expected_params"),
+    [
+        (
+            "alumnium.alumni.AzureChatOpenAI",
+            Model.AZURE_OPENAI,
+            {"model": Model.AZURE_OPENAI.value, "api_version": "", "temperature": 0, "seed": 1},
+        ),
+        ("alumnium.alumni.ChatAnthropic", Model.ANTHROPIC, {"model": Model.ANTHROPIC.value, "temperature": 0}),
+        (
+            "alumnium.alumni.ChatBedrockConverse",
+            Model.AWS_ANTHROPIC,
+            {
+                "model_id": Model.AWS_ANTHROPIC.value,
+                "temperature": 0,
+                "aws_access_key_id": "",
+                "aws_secret_access_key": "",
+                "region_name": "us-east-1",
+            },
+        ),
+        (
+            "alumnium.alumni.ChatBedrockConverse",
+            Model.AWS_META,
+            {
+                "model_id": Model.AWS_META.value,
+                "temperature": 0,
+                "aws_access_key_id": "",
+                "aws_secret_access_key": "",
+                "region_name": "us-east-1",
+            },
+        ),
+        ("alumnium.alumni.ChatDeepSeek", Model.DEEPSEEK, {"model": Model.DEEPSEEK.value, "temperature": 0}),
+        ("alumnium.alumni.ChatGoogleGenerativeAI", Model.GOOGLE, {"model": Model.GOOGLE.value, "temperature": 0}),
+        ("alumnium.alumni.ChatOpenAI", None, {"model": Model.OPENAI.value, "temperature": 0, "seed": 1}),
+    ],
 )
 @patch("alumnium.alumni.ActorAgent")
 @patch("alumnium.alumni.PlannerAgent")


### PR DESCRIPTION
This PR fixes code formatting after linting violations were introduced in #63.

It also:

- adds the `tests` directory to `flake8` in the `format` target of `Makefile` (to catch future violations)
- adds duplicate key detection to the `autoflake` configuration.