### PR TITLE
Added mistral small in LLM version of Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Issue.yml
@@ -1,6 +1,7 @@
 name: 🐛 Issue Report
 description: Create an Issue to help us improve.
-title: "[🐛 Bug]: <title>"
+title: "[Bug]:"
+label: "bug"
 body:
   - type: markdown
     attributes:
@@ -70,6 +71,7 @@ body:
         - DeepSeek 3.0 (Deepseek)
         - Llama 3.2 90B(Meta)
         - GPT-4.0 Mini(Open AI)
+        - Mistral-small 3.1 24B(Ollama)
         - other
       default: 4
 


### PR DESCRIPTION
-  Added `Mistral-small 3.1 24B(Ollama)` in Issue template form as per `0.9.0` release .
-  Added new field named `label : Bug` in Issue.yml .
-  Modified title field to `title: [Bug]` .