### PR TITLE
fix: removed label key from ci.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Issue.yml
@@ -1,7 +1,6 @@
 name: 🐛 Issue Report
 description: Create an Issue to help us improve.
 title: "[Bug]:"
-label: "bug"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
- removed `label `key from CI.yml . This is unnecessarily causing errors in `Issue_template` form  .
- I have removed it in the` pre-commit ` branch in #79  but still it is getting displayed .
- @sh3pik  , Thanks for pointing it in that PR , I have it removed it and committed in pre-commit branch. but not sure how again it got added again . Sorry for the inconvenience.