### PR TITLE
Updated llm providers with latest models

### DIFF
--- a/alumnium/models.py
+++ b/alumnium/models.py
@@ -15,14 +15,14 @@ class Provider(Enum):
 
 class Name:
     DEFAULT = {
-        Provider.AZURE_OPENAI: "gpt-4o-mini",  # 2024-07-18
-        Provider.ANTHROPIC: "claude-3-haiku-20240307",
-        Provider.AWS_ANTHROPIC: "anthropic.claude-3-haiku-20240307-v1:0",
-        Provider.AWS_META: "us.meta.llama3-2-90b-instruct-v1:0",
+        Provider.AZURE_OPENAI: "gpt-4.1-nano", #2025-04-14
+        Provider.ANTHROPIC: "claude-3-5-haiku-20241022 ",
+        Provider.AWS_ANTHROPIC: "anthropic.claude-3-5-haiku-20241022-v1:0",
+        Provider.AWS_META: "us.meta.llama4-scout-17b-instruct-v1:0",
         Provider.DEEPSEEK: "deepseek-chat",
         Provider.GOOGLE: "gemini-2.0-flash-001",
         Provider.OLLAMA: "mistral-small3.1",
-        Provider.OPENAI: "gpt-4o-mini-2024-07-18",
+        Provider.OPENAI: "gpt-4.1-nano-2025-04-14",
     }
 
 

--- a/alumnium/models.py
+++ b/alumnium/models.py
@@ -15,14 +15,14 @@ class Provider(Enum):
 
 class Name:
     DEFAULT = {
-        Provider.AZURE_OPENAI: "gpt-4.1-nano", #2025-04-14
-        Provider.ANTHROPIC: "claude-3-5-haiku-20241022 ",
-        Provider.AWS_ANTHROPIC: "anthropic.claude-3-5-haiku-20241022-v1:0",
+        Provider.AZURE_OPENAI: "gpt-4.1-mini", #2025-04-14
+        Provider.ANTHROPIC: "claude-3-5-haiku-20241022",
+        Provider.AWS_ANTHROPIC: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
         Provider.AWS_META: "us.meta.llama4-scout-17b-instruct-v1:0",
         Provider.DEEPSEEK: "deepseek-chat",
         Provider.GOOGLE: "gemini-2.0-flash-001",
         Provider.OLLAMA: "mistral-small3.1",
-        Provider.OPENAI: "gpt-4.1-nano-2025-04-14",
+        Provider.OPENAI: "gpt-4.1-mini-2025-04-14",
     }
 
 


### PR DESCRIPTION
- In `Models.py` file updated the Enum class with specified models.
-  GPT-4.0 upgraded to `gpt-4.1-nano-2025-04-14` 
-  Llama - 3.2 upgraded to `us.meta.llama4-scout-17b-instruct-v1:0`
-  Cluade -3 Haiku upgraded to `claude-3-5-haiku-20241022 ` , `anthropic.claude-3-5-haiku-20241022-v1:0`