### PR TITLE
feat : support ollama config url 

### DIFF
--- a/alumnium/llm_factory.py
+++ b/alumnium/llm_factory.py
@@ -51,7 +51,11 @@ class LLMFactory:
         elif model.provider == Provider.MISTRALAI:
             llm = ChatMistralAI(model=model.name, temperature=0)
         elif model.provider == Provider.OLLAMA:
-            llm = ChatOllama(mdel=model.name, temperature=0)
+            if not getenv("ALUMNIUM_OLLAMA_URL"):
+                llm = ChatOllama(model=model.name, temperature=0)
+            else:
+                cloud_endpoint = getenv("ALUMNIUM_OLLAMA_URL")
+                llm = ChatOllama(model=model.name, base_url=cloud_endpoint, temperature=0)
         elif model.provider == Provider.OPENAI:
             llm = ChatOpenAI(model=model.name, temperature=0, seed=1)
         else:

--- a/alumnium/tools/back_tool.py
+++ b/alumnium/tools/back_tool.py
@@ -18,4 +18,3 @@ class BackTool(BaseTool):
 
     def invoke(self, driver: BaseDriver):
         driver.back()
-

--- a/examples/pytest/navigation_test.py
+++ b/examples/pytest/navigation_test.py
@@ -28,11 +28,7 @@ def test_back_navigation_different_phrases(al, navigate):
     assert "www.iana.org" in al.driver.url
 
     # Test different ways to ask for back navigation
-    test_phrases = [
-        "Go back",
-        "Navigate back",
-        "Return to the previous page"
-    ]
+    test_phrases = ["Go back", "Navigate back", "Return to the previous page"]
 
     for phrase in test_phrases:
         # Go forward again to test going back


### PR DESCRIPTION
Fixes #157  

- If user sets `ALUMNIUM_OLLAMA_URL` environment variable value , in `llm_factory.py` class for `ChatOllama` constructor in place of `base_url` parameter we are passing the value .