### PR TITLE
feat: http client

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": [
+      "Bash(curl:*)",
       "Bash(poetry run behave:*)",
       "Bash(poetry run pytest:*)"
     ],

--- a/alumnium/__init__.py
+++ b/alumnium/__init__.py
@@ -1,5 +1,4 @@
 import logging
-from os import getenv
 
 from .server.logutils import configure_logging, get_logger
 

--- a/alumnium/alumni.py
+++ b/alumnium/alumni.py
@@ -4,6 +4,7 @@ from retry import retry
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from .area import Area
+from .cache import Cache
 from .clients.http_client import HttpClient
 from .clients.native_client import NativeClient
 from .drivers import Element
@@ -50,7 +51,7 @@ class Alumni:
             logger.info("Using native client")
             self.client = NativeClient(self.model, self.tools)
 
-        self.cache = self.client.cache
+        self.cache = Cache(self.client)
 
     def quit(self):
         self.client.quit()

--- a/alumnium/area.py
+++ b/alumnium/area.py
@@ -1,6 +1,7 @@
 from retry import retry
 
-from .client import Client
+from .clients.http_client import HttpClient
+from .clients.native_client import NativeClient
 from .drivers import Element
 from .drivers.base_driver import BaseDriver
 from .server.agents.retriever_agent import Data
@@ -14,7 +15,7 @@ class Area:
         description: str,
         driver: BaseDriver,
         tools: dict[str, BaseTool],
-        client: Client,
+        client: HttpClient | NativeClient,
     ):
         self.id = id
         self.description = description

--- a/alumnium/cache.py
+++ b/alumnium/cache.py
@@ -1,0 +1,13 @@
+from .clients.http_client import HttpClient
+from .clients.native_client import NativeClient
+
+
+class Cache:
+    def __init__(self, client: HttpClient | NativeClient):
+        self.client = client
+
+    def save(self):
+        self.client.save_cache()
+
+    def discard(self):
+        self.client.discard_cache()

--- a/alumnium/clients/http_client.py
+++ b/alumnium/clients/http_client.py
@@ -1,0 +1,122 @@
+from requests import delete, get, post
+
+from ..server.agents.retriever_agent import Data
+from ..server.models import Model
+from ..tools.base_tool import BaseTool
+from ..tools.tool_to_schema_converter import convert_tools_to_schemas
+
+
+class HttpClient:
+    def __init__(self, base_url: str, model: Model, tools: dict[str, type[BaseTool]]):
+        self.base_url = base_url.rstrip("/")
+        self.session_id = None
+        self.cache = None  # HTTP client doesn't support cache access
+
+        tool_schemas = convert_tools_to_schemas(tools)
+
+        response = post(
+            f"{self.base_url}/v1/sessions",
+            json={"provider": model.provider.value, "name": model.name, "tools": tool_schemas},
+            timeout=30,
+        )
+        response.raise_for_status()
+        self.session_id = response.json()["sessionId"]
+
+    def quit(self):
+        if self.session_id:
+            response = delete(
+                f"{self.base_url}/v1/sessions/{self.session_id}",
+                timeout=30,
+            )
+            response.raise_for_status()
+            self.session_id = None
+
+    def plan_actions(self, goal: str, accessibility_tree: str):
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/plans",
+            json={"goal": goal, "accessibility_tree": accessibility_tree},
+            timeout=120,
+        )
+        response.raise_for_status()
+        return response.json()["steps"]
+
+    def add_example(self, goal: str, actions: list[str]):
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/examples",
+            json={"goal": goal, "actions": actions},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def clear_examples(self):
+        response = delete(
+            f"{self.base_url}/v1/sessions/{self.session_id}/examples",
+            timeout=30,
+        )
+        response.raise_for_status()
+
+    def execute_action(self, goal: str, step: str, accessibility_tree: str):
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/steps",
+            json={"goal": goal, "step": step, "accessibility_tree": accessibility_tree},
+            timeout=120,
+        )
+        response.raise_for_status()
+        return response.json()["actions"]
+
+    def retrieve(
+        self,
+        statement: str,
+        accessibility_tree: str,
+        title: str,
+        url: str,
+        screenshot: bytes | None,
+    ) -> tuple[str, Data]:
+        # Encode screenshot to base64 if provided
+        screenshot_b64 = None
+        if screenshot:
+            screenshot_b64 = b64encode(screenshot).decode("utf-8")
+
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/statements",
+            json={
+                "statement": statement,
+                "accessibility_tree": accessibility_tree,
+                "title": title,
+                "url": url,
+                "screenshot": screenshot_b64,
+            },
+            timeout=120,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data["explanation"], data["result"]
+
+    def find_area(self, description: str, accessibility_tree: str):
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/areas",
+            json={"description": description, "accessibility_tree": accessibility_tree},
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return {"id": data["id"], "explanation": data["explanation"]}
+
+    def find_element(self, description: str, accessibility_tree: str):
+        response = post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/elements",
+            json={"description": description, "accessibility_tree": accessibility_tree},
+            timeout=60,
+        )
+        response.raise_for_status()
+        return response.json()["elements"][0]
+
+    @property
+    def stats(self):
+        response = get(
+            f"{self.base_url}/v1/sessions/{self.session_id}/stats",
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/alumnium/clients/http_client.py
+++ b/alumnium/clients/http_client.py
@@ -70,13 +70,8 @@ class HttpClient:
         accessibility_tree: str,
         title: str,
         url: str,
-        screenshot: bytes | None,
+        screenshot: str | None,
     ) -> tuple[str, Data]:
-        # Encode screenshot to base64 if provided
-        screenshot_b64 = None
-        if screenshot:
-            screenshot_b64 = b64encode(screenshot).decode("utf-8")
-
         response = post(
             f"{self.base_url}/v1/sessions/{self.session_id}/statements",
             json={
@@ -84,7 +79,7 @@ class HttpClient:
                 "accessibility_tree": accessibility_tree,
                 "title": title,
                 "url": url,
-                "screenshot": screenshot_b64,
+                "screenshot": screenshot if screenshot else None,
             },
             timeout=120,
         )
@@ -112,14 +107,14 @@ class HttpClient:
         return response.json()["elements"][0]
 
     def save_cache(self):
-        response = requests.post(
+        response = post(
             f"{self.base_url}/v1/sessions/{self.session_id}/caches",
             timeout=30,
         )
         response.raise_for_status()
 
     def discard_cache(self):
-        response = requests.delete(
+        response = delete(
             f"{self.base_url}/v1/sessions/{self.session_id}/caches",
             timeout=30,
         )

--- a/alumnium/clients/http_client.py
+++ b/alumnium/clients/http_client.py
@@ -10,7 +10,6 @@ class HttpClient:
     def __init__(self, base_url: str, model: Model, tools: dict[str, type[BaseTool]]):
         self.base_url = base_url.rstrip("/")
         self.session_id = None
-        self.cache = None  # HTTP client doesn't support cache access
 
         tool_schemas = convert_tools_to_schemas(tools)
 
@@ -111,6 +110,20 @@ class HttpClient:
         )
         response.raise_for_status()
         return response.json()["elements"][0]
+
+    def save_cache(self):
+        response = requests.post(
+            f"{self.base_url}/v1/sessions/{self.session_id}/caches",
+            timeout=30,
+        )
+        response.raise_for_status()
+
+    def discard_cache(self):
+        response = requests.delete(
+            f"{self.base_url}/v1/sessions/{self.session_id}/caches",
+            timeout=30,
+        )
+        response.raise_for_status()
 
     @property
     def stats(self):

--- a/alumnium/clients/http_client.py
+++ b/alumnium/clients/http_client.py
@@ -19,7 +19,7 @@ class HttpClient:
             timeout=30,
         )
         response.raise_for_status()
-        self.session_id = response.json()["sessionId"]
+        self.session_id = response.json()["session_id"]
 
     def quit(self):
         if self.session_id:

--- a/alumnium/clients/native_client.py
+++ b/alumnium/clients/native_client.py
@@ -41,7 +41,7 @@ class NativeClient:
         accessibility_tree: str,
         title: str,
         url: str,
-        screenshot: str,
+        screenshot: str | None,
     ) -> tuple[str, Data]:
         return self.session.retriever_agent.invoke(
             statement, accessibility_tree, title=title, url=url, screenshot=screenshot

--- a/alumnium/clients/native_client.py
+++ b/alumnium/clients/native_client.py
@@ -1,14 +1,12 @@
-from typing import Dict, Type
-
-from .server.agents.retriever_agent import Data
-from .server.models import Model
-from .server.session_manager import SessionManager
-from .tools.base_tool import BaseTool
-from .tools.tool_to_schema_converter import convert_tools_to_schemas
+from ..server.agents.retriever_agent import Data
+from ..server.models import Model
+from ..server.session_manager import SessionManager
+from ..tools.base_tool import BaseTool
+from ..tools.tool_to_schema_converter import convert_tools_to_schemas
 
 
-class Client:
-    def __init__(self, model: Model, tools: Dict[str, Type[BaseTool]]):
+class NativeClient:
+    def __init__(self, model: Model, tools: dict[str, type[BaseTool]]):
         self.session_manager = SessionManager()
         self.model = model
         self.tools = tools

--- a/alumnium/clients/native_client.py
+++ b/alumnium/clients/native_client.py
@@ -53,6 +53,12 @@ class NativeClient:
     def find_element(self, description: str, accessibility_tree: str):
         return self.session.locator_agent.invoke(description, accessibility_tree)[0]
 
+    def save_cache(self):
+        self.session.cache.save()
+
+    def discard_cache(self):
+        self.session.cache.discard()
+
     @property
     def stats(self):
         return self.session.stats

--- a/alumnium/server/README.md
+++ b/alumnium/server/README.md
@@ -37,21 +37,21 @@ poetry run python -m alumnium.server.main
 ### Session Management
 
 - `POST /v1/sessions` - Create a new session with specific provider and model
-- `DELETE /v1/sessions/{sessionId}` - Delete a session
+- `DELETE /v1/sessions/{session_id}` - Delete a session
 - `GET /v1/sessions` - List all active sessions
-- `GET /v1/sessions/{sessionId}/stats` - Get session token usage statistics
+- `GET /v1/sessions/{session_id}/stats` - Get session token usage statistics
 
 ### Planning & Execution
 
-- `POST /v1/sessions/{sessionId}/plans` - Plan high-level steps to achieve a goal
-- `POST /v1/sessions/{sessionId}/steps` - Generate specific actions for a step
-- `POST /v1/sessions/{sessionId}/statements` - Execute/verify statements against page state
-- `POST /v1/sessions/{sessionId}/areas` - Identify specific areas on a page
+- `POST /v1/sessions/{session_id}/plans` - Plan high-level steps to achieve a goal
+- `POST /v1/sessions/{session_id}/steps` - Generate specific actions for a step
+- `POST /v1/sessions/{session_id}/statements` - Execute/verify statements against page state
+- `POST /v1/sessions/{session_id}/areas` - Identify specific areas on a page
 
 ### Example Management
 
-- `POST /v1/sessions/{sessionId}/examples` - Add training examples to the planner
-- `DELETE /v1/sessions/{sessionId}/examples` - Clear all training examples
+- `POST /v1/sessions/{session_id}/examples` - Add training examples to the planner
+- `DELETE /v1/sessions/{session_id}/examples` - Clear all training examples
 
 ### Cache Management
 
@@ -88,12 +88,12 @@ curl -X POST http://localhost:8013/v1/sessions \
       }
     ]
   }'
-# Response: {"sessionId": "uuid-here", "api_version": "v1"}
+# Response: {"session_id": "uuid-here", "api_version": "v1"}
 ```
 
 ### Plan Actions
 ```bash
-curl -X POST http://localhost:8013/v1/sessions/{sessionId}/plans \
+curl -X POST http://localhost:8013/v1/sessions/{session_id}/plans \
   -H "Content-Type: application/json" \
   -d '{
     "goal": "log in to the application",
@@ -106,7 +106,7 @@ curl -X POST http://localhost:8013/v1/sessions/{sessionId}/plans \
 
 ### Execute Step Actions
 ```bash
-curl -X POST http://localhost:8013/v1/sessions/{sessionId}/steps \
+curl -X POST http://localhost:8013/v1/sessions/{session_id}/steps \
   -H "Content-Type: application/json" \
   -d '{
     "goal": "log in to the application",
@@ -118,7 +118,7 @@ curl -X POST http://localhost:8013/v1/sessions/{sessionId}/steps \
 
 ### Verify Statement
 ```bash
-curl -X POST http://localhost:8013/v1/sessions/{sessionId}/statements \
+curl -X POST http://localhost:8013/v1/sessions/{session_id}/statements \
   -H "Content-Type: application/json" \
   -d '{
     "statement": "user is logged in successfully",
@@ -132,7 +132,7 @@ curl -X POST http://localhost:8013/v1/sessions/{sessionId}/statements \
 
 ### Add Training Example
 ```bash
-curl -X POST http://localhost:8013/v1/sessions/{sessionId}/examples \
+curl -X POST http://localhost:8013/v1/sessions/{session_id}/examples \
   -H "Content-Type: application/json" \
   -d '{
     "goal": "complete user registration",

--- a/alumnium/server/README.md
+++ b/alumnium/server/README.md
@@ -53,6 +53,11 @@ poetry run python -m alumnium.server.main
 - `POST /v1/sessions/{sessionId}/examples` - Add training examples to the planner
 - `DELETE /v1/sessions/{sessionId}/examples` - Clear all training examples
 
+### Cache Management
+
+- `POST /v1/sessions/{session_id}/caches` - Persist the in-memory cache
+- `DELETE /v1/sessions/{session_id}/caches` - Discard the in-memory cache
+
 ### Health Check
 
 - `GET /health` - Health check and current model information

--- a/alumnium/server/api_models.py
+++ b/alumnium/server/api_models.py
@@ -17,7 +17,7 @@ class SessionRequest(VersionedModel):
 
 
 class SessionResponse(VersionedModel):
-    sessionId: str
+    session_id: str
 
 
 class PlanRequest(VersionedModel):

--- a/alumnium/server/api_models.py
+++ b/alumnium/server/api_models.py
@@ -2,6 +2,8 @@ from typing import Any, List, Optional
 
 from pydantic import BaseModel, Field
 
+from .agents.retriever_agent import Data
+
 
 # Base versioned model
 class VersionedModel(BaseModel):
@@ -48,7 +50,8 @@ class StatementRequest(VersionedModel):
 
 
 class StatementResponse(VersionedModel):
-    result: str
+    # TODO: Move typecasting to the client
+    result: Data
     explanation: str
 
 

--- a/alumnium/server/api_models.py
+++ b/alumnium/server/api_models.py
@@ -86,6 +86,11 @@ class ClearExamplesResponse(VersionedModel):
     message: str
 
 
+class CacheResponse(VersionedModel):
+    success: bool
+    message: str
+
+
 class ErrorResponse(VersionedModel):
     error: str
     detail: Optional[str] = None

--- a/alumnium/server/main.py
+++ b/alumnium/server/main.py
@@ -1,4 +1,3 @@
-import base64
 import importlib.metadata
 from contextlib import asynccontextmanager
 from typing import List
@@ -150,21 +149,13 @@ async def execute_statement(session_id: str, request: StatementRequest):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
 
     try:
-        # Decode screenshot if provided
-        screenshot_bytes = None
-        if request.screenshot:
-            try:
-                screenshot_bytes = base64.b64decode(request.screenshot)
-            except Exception as e:
-                logger.warning(f"Failed to decode screenshot: {e}")
-
         # Use retriever agent to execute the statement
         explanation, value = session.retriever_agent.invoke(
             request.statement,
             request.accessibility_tree,
             title=request.title,
             url=request.url,
-            screenshot=screenshot_bytes,
+            screenshot=request.screenshot,
         )
 
         return StatementResponse(result=value, explanation=explanation)

--- a/alumnium/server/main.py
+++ b/alumnium/server/main.py
@@ -75,7 +75,7 @@ async def create_session(request: SessionRequest):
     """Create a new session."""
     try:
         session_id = session_manager.create_session(request.provider, request.name, request.tools)
-        return SessionResponse(sessionId=session_id)
+        return SessionResponse(session_id=session_id)
     except Exception as e:
         logger.error(f"Failed to create session: {e}")
         raise HTTPException(

--- a/alumnium/server/main.py
+++ b/alumnium/server/main.py
@@ -167,7 +167,7 @@ async def execute_statement(session_id: str, request: StatementRequest):
             screenshot=screenshot_bytes,
         )
 
-        return StatementResponse(result=str(value), explanation=explanation)
+        return StatementResponse(result=value, explanation=explanation)
 
     except Exception as e:
         logger.error(f"Failed to execute statement for session {session_id}: {e}")

--- a/alumnium/server/main.py
+++ b/alumnium/server/main.py
@@ -12,6 +12,7 @@ from .api_models import (
     AddExampleResponse,
     AreaRequest,
     AreaResponse,
+    CacheResponse,
     ClearExamplesResponse,
     ErrorResponse,
     FindRequest,
@@ -244,6 +245,42 @@ async def clear_examples(session_id: str):
         logger.error(f"Failed to clear examples for session {session_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to clear examples: {str(e)}"
+        )
+
+
+@v1_router.post("/sessions/{session_id}/caches", response_model=CacheResponse)
+async def save_cache(session_id: str):
+    """Save the session cache to disk."""
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+
+    try:
+        session.cache.save()
+        return CacheResponse(success=True, message="Cache saved successfully")
+
+    except Exception as e:
+        logger.error(f"Failed to save cache for session {session_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to save cache: {str(e)}"
+        )
+
+
+@v1_router.delete("/sessions/{session_id}/caches", response_model=CacheResponse)
+async def discard_cache(session_id: str):
+    """Discard unsaved cache changes."""
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+
+    try:
+        session.cache.discard()
+        return CacheResponse(success=True, message="Cache discarded successfully")
+
+    except Exception as e:
+        logger.error(f"Failed to discard cache for session {session_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to discard cache: {str(e)}"
         )
 
 

--- a/examples/behave/features/environment.py
+++ b/examples/behave/features/environment.py
@@ -42,7 +42,7 @@ def driver(context):
 
 @fixture
 def alumnium(context):
-    context.al = Alumni(context.driver)
+    context.al = Alumni(context.driver, url=getenv("ALUMNIUM_SERVER_URL", None))
     if isinstance(context.driver, Appium):
         context.al.learn(
             goal='create a new task "this is Al"',

--- a/examples/pytest/conftest.py
+++ b/examples/pytest/conftest.py
@@ -52,7 +52,7 @@ def driver():
 
 @fixture(scope="session")
 def al(driver):
-    al = Alumni(driver)
+    al = Alumni(driver, url=getenv("ALUMNIUM_SERVER_URL", None))
     if driver_type == "appium":
         al.driver.delay = 0.1
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -50,7 +50,7 @@ def sample_session_id():
         json={"provider": "anthropic", "name": "claude-3-haiku-20240307", "tools": get_sample_tool_schemas()},
     )
     assert response.status_code == 200
-    return response.json()["sessionId"]
+    return response.json()["session_id"]
 
 
 @pytest.fixture
@@ -120,9 +120,9 @@ def test_create_session():
     )
     assert response.status_code == 200
     data = response.json()
-    assert "sessionId" in data
-    assert isinstance(data["sessionId"], str)
-    return data["sessionId"]
+    assert "session_id" in data
+    assert isinstance(data["session_id"], str)
+    return data["session_id"]
 
 
 def test_list_sessions():
@@ -484,7 +484,7 @@ def test_full_session_workflow():
         json={"provider": "anthropic", "name": "claude-3-haiku-20240307", "tools": get_sample_tool_schemas()},
     )
     assert create_response.status_code == 200
-    session_id = create_response.json()["sessionId"]
+    session_id = create_response.json()["session_id"]
 
     # 2. Check it exists in session list
     list_response = client.get("/v1/sessions")
@@ -535,7 +535,7 @@ def test_concurrent_sessions():
             json={"provider": "anthropic", "name": f"test-model-{i}", "tools": get_sample_tool_schemas()},
         )
         assert response.status_code == 200
-        session_ids.append(response.json()["sessionId"])
+        session_ids.append(response.json()["session_id"])
 
     # Verify all exist
     list_response = client.get("/v1/sessions")
@@ -655,10 +655,10 @@ def test_create_session_with_custom_tool_schema():
     )
     assert response.status_code == 200
     data = response.json()
-    assert "sessionId" in data
+    assert "session_id" in data
 
     # Clean up
-    session_id = data["sessionId"]
+    session_id = data["session_id"]
     client.delete(f"/v1/sessions/{session_id}")
 
 
@@ -667,10 +667,10 @@ def test_create_session_with_empty_tool_list():
     response = client.post("/v1/sessions", json={"provider": "anthropic", "name": "test-no-tools", "tools": []})
     assert response.status_code == 200
     data = response.json()
-    assert "sessionId" in data
+    assert "session_id" in data
 
     # Clean up
-    session_id = data["sessionId"]
+    session_id = data["session_id"]
     client.delete(f"/v1/sessions/{session_id}")
 
 


### PR DESCRIPTION
Introduce a new HTTP client that can be used to drive the Python package using the Alumnium server. It is enabled when `url` parameter is passed to `Alumni()`. It's functionally the same as a native client.

Part of a larger #105 work.

<details>
<summary>Checked by running all the tests with an HTTP client against the server.</summary>

```sh
$ make start-server
poetry run alumnium-server
INFO:     Will watch for changes in these directories: ['/Users/p0deje/Development/alumnium']
INFO:     Uvicorn running on http://0.0.0.0:8013 (Press CTRL+C to quit)
INFO:     Started reloader process [6631] using WatchFiles
INFO:     Started server process [6661]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     127.0.0.1:63217 - "POST /v1/sessions HTTP/1.1" 200 OK
INFO:     127.0.0.1:63219 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63221 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63223 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63229 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63232 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63234 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63236 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63238 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63240 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63242 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
/Users/p0deje/Development/alumnium/alumnium/server/cache/filesystem_cache.py:43: LangChainBetaWarning: The function `loads` is in beta. It is actively being worked on, so the API may change.
  response = loads(f.read())
INFO:     127.0.0.1:63244 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63246 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63248 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63250 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63252 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63254 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63256 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63258 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63260 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63262 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63264 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63266 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63268 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63270 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63286 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63291 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63296 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63298 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63300 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63302 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63304 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63306 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63308 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63310 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63312 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63317 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63319 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63321 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63323 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63325 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63327 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63329 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63331 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63333 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63343 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63354 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63356 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63358 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63363 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63365 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63367 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63369 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63371 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63373 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63375 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63377 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63379 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63381 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63383 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63385 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63387 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63390 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63392 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63394 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63396 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63398 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63400 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63402 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63404 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63406 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63408 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63410 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63412 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63414 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63416 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63419 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63421 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63423 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63425 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63427 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63429 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63431 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63433 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63435 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63437 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63439 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63441 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63443 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63445 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63447 - "POST /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63449 - "DELETE /v1/sessions/2421a949-18fb-40b2-b6f9-b030a6627b6d HTTP/1.1" 204 No Content
INFO:     127.0.0.1:63468 - "POST /v1/sessions HTTP/1.1" 200 OK
INFO:     127.0.0.1:63470 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63487 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63489 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63491 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63493 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63497 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63499 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63502 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63504 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63506 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63508 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63510 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63512 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63514 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63516 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63519 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63521 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63523 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63525 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63527 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63529 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63531 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63536 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63538 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63540 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63542 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63544 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63547 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63549 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63551 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63553 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63561 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63563 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63565 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63568 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63570 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63572 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63574 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63576 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63578 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63580 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63582 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63584 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63586 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63588 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63590 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63592 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63594 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63596 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63598 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63600 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63602 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63604 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63606 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63608 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63610 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63612 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63614 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63616 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63618 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63620 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63622 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63624 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63626 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63628 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63630 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63632 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63634 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63636 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63638 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63649 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63651 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63653 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63655 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63657 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63659 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63672 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/elements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63674 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/elements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63676 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/elements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63678 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63680 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63683 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63685 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63701 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63703 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63707 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63716 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63719 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63721 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63725 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63729 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63731 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63733 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63738 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63740 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63742 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63744 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63746 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63748 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63750 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63752 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63754 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63756 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63758 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63760 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63762 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63764 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63766 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63768 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63784 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63786 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63790 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63792 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63794 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63796 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63798 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63800 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63802 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63804 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63806 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63808 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63810 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63812 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63814 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63816 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63818 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63820 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63822 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63824 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63826 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63828 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63830 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63832 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63834 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63839 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63841 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63845 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63847 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63849 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63851 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63854 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63856 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63858 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63860 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63862 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63864 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63866 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63868 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63870 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63877 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63879 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63888 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63894 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63897 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63899 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63901 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63903 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63905 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63907 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63909 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63911 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63913 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63915 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63917 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63919 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63924 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63926 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63928 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63930 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63932 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63934 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63936 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63938 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63940 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63942 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63944 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63946 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63948 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63950 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63952 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63954 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63956 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63958 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63960 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63962 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63964 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63966 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63968 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:63970 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:63972 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63974 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63976 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63978 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/areas HTTP/1.1" 200 OK
INFO:     127.0.0.1:63980 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63982 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63984 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63986 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63988 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63991 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:63993 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:63995 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:63997 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/examples HTTP/1.1" 200 OK
INFO:     127.0.0.1:63999 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:64002 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:64004 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:64007 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:64009 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:64011 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/plans HTTP/1.1" 200 OK
INFO:     127.0.0.1:64013 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/steps HTTP/1.1" 200 OK
INFO:     127.0.0.1:64015 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/statements HTTP/1.1" 200 OK
INFO:     127.0.0.1:64017 - "GET /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/stats HTTP/1.1" 200 OK
INFO:     127.0.0.1:64019 - "POST /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87/caches HTTP/1.1" 200 OK
INFO:     127.0.0.1:64021 - "DELETE /v1/sessions/351298ea-1a09-417c-bf1f-99ff5defce87 HTTP/1.1" 204 No Content
```


```sh
$ ALUMNIUM_SERVER_URL=http://localhost:8013 ALUMNIUM_DRIVER=playwright make test
mkdir -p log/
poetry run behave
Feature: To Do application # examples/behave/features/todo.feature:1

  Background:   # examples/behave/features/todo.feature:3

  Scenario: Create a task                              # examples/behave/features/todo.feature:6
    Given I open application                           # examples/behave/features/steps/todo_al.py:7 0.441s
    When I create a new task "Buy milk"                # examples/behave/features/steps/todo_al.py:18 4.557s
    Then "Buy milk" task is shown in the list of tasks # examples/behave/features/steps/todo_al.py:56 1.815s
    And "Buy milk" task is not marked as completed     # examples/behave/features/steps/todo_al.py:66 1.079s
    And tasks counter is 1                             # examples/behave/features/steps/todo_al.py:88 1.067s

  Scenario: Complete a task                     # examples/behave/features/todo.feature:12
    Given I open application                    # examples/behave/features/steps/todo_al.py:7 0.022s
    When I create a new task "Buy milk"         # examples/behave/features/steps/todo_al.py:18 1.110s
    And I mark the "Buy milk" task as completed # examples/behave/features/steps/todo_al.py:25 2.286s
    Then "Buy milk" task is marked as completed # examples/behave/features/steps/todo_al.py:77 1.470s
    And tasks counter is 0                      # examples/behave/features/steps/todo_al.py:88 1.130s

  Scenario: Uncomplete a task                       # examples/behave/features/todo.feature:18
    Given I open application                        # examples/behave/features/steps/todo_al.py:7 0.018s
    When I create a new task "Buy milk"             # examples/behave/features/steps/todo_al.py:18 1.108s
    And I mark the "Buy milk" task as completed     # examples/behave/features/steps/todo_al.py:25 2.127s
    And I mark the "Buy milk" task as uncompleted   # examples/behave/features/steps/todo_al.py:30 2.465s
    Then "Buy milk" task is not marked as completed # examples/behave/features/steps/todo_al.py:66 4.400s
    And tasks counter is 1                          # examples/behave/features/steps/todo_al.py:88 0.915s

  @web
  Scenario: Complete all tasks                  # examples/behave/features/todo.feature:26
    Given I open application                    # examples/behave/features/steps/todo_al.py:7 0.017s
    When I create a new task "Buy milk"         # examples/behave/features/steps/todo_al.py:18 1.116s
    And I create a new task "Buy bread"         # examples/behave/features/steps/todo_al.py:18 3.847s
    And I mark all tasks as completed           # examples/behave/features/steps/todo_al.py:40 2.401s
    Then "Buy milk" task is marked as completed # examples/behave/features/steps/todo_al.py:77 1.829s
    And "Buy bread" task is marked as completed # examples/behave/features/steps/todo_al.py:77 0.991s
    And tasks counter is 0                      # examples/behave/features/steps/todo_al.py:88 1.051s

  Scenario: Delete a task                                  # examples/behave/features/todo.feature:34
    Given I open application                               # examples/behave/features/steps/todo_al.py:7 0.019s
    When I create a new task "Buy milk"                    # examples/behave/features/steps/todo_al.py:18 1.104s
    And I create a new task "Buy bread"                    # examples/behave/features/steps/todo_al.py:18 4.404s
    And I delete the "Buy milk" task                       # examples/behave/features/steps/todo_al.py:35 3.505s
    Then "Buy milk" task is not shown in the list of tasks # examples/behave/features/steps/todo_al.py:61 1.437s

  @web
  Scenario: Show active tasks                             # examples/behave/features/todo.feature:41
    Given I open application                              # examples/behave/features/steps/todo_al.py:7 0.012s
    When I create a new task "Buy milk"                   # examples/behave/features/steps/todo_al.py:18 1.092s
    And I create a new task "Buy bread"                   # examples/behave/features/steps/todo_al.py:18 1.104s
    And I mark the "Buy milk" task as completed           # examples/behave/features/steps/todo_al.py:25 2.406s
    And I show only "Active" tasks                        # examples/behave/features/steps/todo_al.py:46 1.951s
    Then "Buy bread" task is shown in the list of tasks   # examples/behave/features/steps/todo_al.py:56 1.673s
    But "Buy milk" task is not shown in the list of tasks # examples/behave/features/steps/todo_al.py:61 0.031s

  @web
  Scenario: Show completed tasks                           # examples/behave/features/todo.feature:50
    Given I open application                               # examples/behave/features/steps/todo_al.py:7 0.014s
    When I create a new task "Buy milk"                    # examples/behave/features/steps/todo_al.py:18 1.114s
    And I create a new task "Buy bread"                    # examples/behave/features/steps/todo_al.py:18 1.117s
    And I mark the "Buy milk" task as completed            # examples/behave/features/steps/todo_al.py:25 3.539s
    And I show only "Completed" tasks                      # examples/behave/features/steps/todo_al.py:46 2.383s
    Then "Buy milk" task is shown in the list of tasks     # examples/behave/features/steps/todo_al.py:56 1.808s
    But "Buy bread" task is not shown in the list of tasks # examples/behave/features/steps/todo_al.py:61 0.025s

  @web
  Scenario: Clear completed tasks                         # examples/behave/features/todo.feature:59
    Given I open application                              # examples/behave/features/steps/todo_al.py:7 0.012s
    When I create a new task "Buy milk"                   # examples/behave/features/steps/todo_al.py:18 1.092s
    And I create a new task "Buy bread"                   # examples/behave/features/steps/todo_al.py:18 1.094s
    And I mark the "Buy milk" task as completed           # examples/behave/features/steps/todo_al.py:25 0.594s
    And I clear completed tasks                           # examples/behave/features/steps/todo_al.py:51 2.266s
    Then "Buy bread" task is shown in the list of tasks   # examples/behave/features/steps/todo_al.py:56 1.741s
    But "Buy milk" task is not shown in the list of tasks # examples/behave/features/steps/todo_al.py:61 0.036s

1 feature passed, 0 failed, 0 skipped
8 scenarios passed, 0 failed, 0 skipped
49 steps passed, 0 failed, 0 skipped, 0 undefined
Took 1m12.833s
poetry run pytest examples/pytest
/Users/p0deje/Development/alumnium/.venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
====================================================== test session starts ======================================================
platform darwin -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/p0deje/Development/alumnium
configfile: pyproject.toml
plugins: asyncio-0.24.0, repeat-0.9.4, html-4.1.1, xdist-3.8.0, metadata-3.1.1, anyio-4.10.0, retry-1.7.0, langsmith-0.4.13
asyncio: mode=strict, default_loop_scope=None
collected 17 items                                                                                                              

examples/pytest/bstackdemo_test.py .                                                                                      [  5%]
examples/pytest/calculator_test.py ....                                                                                   [ 29%]
examples/pytest/drag_and_drop_test.py .                                                                                   [ 35%]
examples/pytest/locator_test.py .                                                                                         [ 41%]
examples/pytest/navigation_test.py .                                                                                      [ 47%]
examples/pytest/search_test.py .                                                                                          [ 52%]
examples/pytest/select_test.py .                                                                                          [ 58%]
examples/pytest/swag_labs_test.py ..                                                                                      [ 70%]
examples/pytest/table_test.py ...                                                                                         [ 88%]
examples/pytest/waiting_test.py ..                                                                                        [100%]

================================================ 17 passed in 100.34s (0:01:40) =================================================
````

</details>