### PR TITLE
feat!: upgrade from haiku 3 to haiku 4.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/Issue.yml
+++ b/.github/ISSUE_TEMPLATE/Issue.yml
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Which LLM are you using?
       options:
-        - Claude 3 Haiku (Anthropic)
+        - Claude 4.5 Haiku (Anthropic)
         - DeepSeek V3 (DeepSeek)
         - GPT-4.0 Mini (Open AI)
         - Gemini 2.0 Flash (Google)

--- a/alumnium/server/README.md
+++ b/alumnium/server/README.md
@@ -70,7 +70,7 @@ curl -X POST http://localhost:8013/v1/sessions \
   -H "Content-Type: application/json" \
   -d '{
     "provider": "anthropic",
-    "name": "claude-3-haiku-20240307",
+    "name": "claude-haiku-4-5-20251001",
     "tools": [
       {
         "type": "function",

--- a/alumnium/server/agents/area_agent.py
+++ b/alumnium/server/agents/area_agent.py
@@ -42,14 +42,6 @@ class AreaAgent(BaseAgent):
         )
 
         response = message["parsed"]
-        # Haiku 3 returns tool calls instead of parsed output
-        if not response and message["raw"].tool_calls:
-            args = message["raw"].tool_calls[0]["args"]
-            if "properties" in args:
-                args = args["properties"]
-            if "explanation" not in args:
-                args["explanation"] = "No explanation provided by the model."
-            response = Area(**args)
 
         logger.info(f"  <- Result: {response}")
         logger.info(f"  <- Usage: {message['raw'].usage_metadata}")

--- a/alumnium/server/agents/locator_agent.py
+++ b/alumnium/server/agents/locator_agent.py
@@ -42,14 +42,6 @@ class LocatorAgent(BaseAgent):
         )
 
         response = message["parsed"]
-        # Haiku 3 returns tool calls instead of parsed output
-        if not response and message["raw"].tool_calls:
-            args = message["raw"].tool_calls[0]["args"]
-            if "properties" in args:
-                args = args["properties"]
-            if "explanation" not in args:
-                args["explanation"] = "No explanation provided by the model."
-            response = Locator(**args)
 
         logger.info(f"  <- Result: {response}")
         logger.info(f"  <- Usage: {message['raw'].usage_metadata}")

--- a/alumnium/server/agents/planner_prompts/anthropic/system.md
+++ b/alumnium/server/agents/planner_prompts/anthropic/system.md
@@ -1,7 +1,32 @@
-You are a helpful assistant that plans what actions should be performed to achieve a task on a webpage based on the accessibility tree of the page given as XML.
-If you don't see a way to achieve the goal on the webpage, reply NOOP. Otherwise, reply with a list of steps separated {separator}. Don't include anything else beyond steps.
-Do not include element id in the step.
-Include element tag name in the step.
-Include element text content if it's present.
-Wrap step arguments except tag name in quotes.
-Each step can start with one of the following: click, drag and drop, hover, press key, select, type.
+You are an AI assistant tasked with planning actions to achieve a specific goal on a webpage based on the accessibility tree provided. The accessibility tree is given as XML and represents the structure and elements of the webpage.
+
+Your goal is to determine a series of actions that will accomplish the task described below. When analyzing the accessibility tree:
+
+1. Look for relevant elements that match the task requirements.
+2. Pay attention to element types (buttons, input fields, links, etc.) and their attributes.
+3. Consider the hierarchy and relationships between elements.
+4. Identify any text content that might be useful for locating the correct elements.
+
+When formulating your actions:
+
+1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back.
+2. Include the element's tag name in each action.
+3. If text content is present for an element, include it in quotes.
+4. Do not include element IDs in the actions.
+5. Wrap all action arguments except the tag name in quotes.
+6. Ground the actions in the accessibility tree provided.
+7. Action "drag and drop" is always performed as a single step.
+8. Always aim to minimize the number of actions. If a single step suffices to accomplish the task, do not break it down further.
+
+If you cannot find a way to achieve the goal based on the given accessibility tree, respond with an empty list of actions.
+
+Example:
+Input:
+Given the following XML accessibility tree:
+```xml
+<button label="Foobar" />
+```
+Outline the actions needed to achieve the following goal: perform foobar
+Output:
+Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
+Actions: ['click button "Foobar"']

--- a/alumnium/server/agents/planner_prompts/anthropic/user.md
+++ b/alumnium/server/agents/planner_prompts/anthropic/user.md
@@ -1,5 +1,5 @@
-Goal: {goal}
-Webpage ARIA tree:
+Given the following XML accessibility tree:
 ```xml
 {accessibility_tree}
 ```
+Outline the actions needed to achieve the following goal: {goal}

--- a/alumnium/server/agents/retriever_agent.py
+++ b/alumnium/server/agents/retriever_agent.py
@@ -27,10 +27,6 @@ class RetrieverAgent(BaseAgent):
     def __init__(self, llm: BaseChatModel):
         super().__init__()
 
-        # Haiku violates the separator convention
-        if Model.current.provider in [Provider.ANTHROPIC, Provider.AWS_ANTHROPIC]:
-            self.LIST_SEPARATOR = "%SEP%"
-
         self.chain = llm.with_structured_output(
             RetrievedInformation,
             include_raw=True,

--- a/alumnium/server/models.py
+++ b/alumnium/server/models.py
@@ -17,8 +17,8 @@ class Provider(Enum):
 class Name:
     DEFAULT = {
         Provider.AZURE_OPENAI: "gpt-4o-mini",  # 2024-07-18
-        Provider.ANTHROPIC: "claude-3-haiku-20240307",
-        Provider.AWS_ANTHROPIC: "anthropic.claude-3-haiku-20240307-v1:0",
+        Provider.ANTHROPIC: "claude-haiku-4-5-20251001",
+        Provider.AWS_ANTHROPIC: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         Provider.AWS_META: "us.meta.llama4-maverick-17b-instruct-v1:0",
         Provider.DEEPSEEK: "deepseek-chat",
         Provider.GOOGLE: "gemini-2.0-flash-001",

--- a/examples/pytest/calculator_test.py
+++ b/examples/pytest/calculator_test.py
@@ -9,7 +9,6 @@ alumnium_driver = getenv("ALUMNIUM_DRIVER", "selenium")
 
 @fixture(autouse=True)
 def learn(al):
-    # Haiku cannot correlate '/' button to '÷'.
     # Mistral skips '+' button.
     al.learn(
         goal="4 / 2 =",

--- a/examples/pytest/navigation_test.py
+++ b/examples/pytest/navigation_test.py
@@ -4,10 +4,6 @@ from alumnium import Alumni, Model, Provider
 from alumnium.tools import NavigateBackTool
 
 
-@mark.xfail(
-    Model.current.provider in [Provider.ANTHROPIC, Provider.AWS_ANTHROPIC],
-    reason="https://github.com/alumnium-hq/alumnium/issues/106",
-)
 @mark.xfail(Model.current.provider == Provider.MISTRALAI, reason="Needs more work")
 def test_navigate_back_uses_history(al, driver, navigate):
     al = Alumni(driver, extra_tools=[NavigateBackTool])

--- a/examples/pytest/swag_labs_test.py
+++ b/examples/pytest/swag_labs_test.py
@@ -54,10 +54,6 @@ def login(al, driver, execute_script, navigate):
     al.clear_learn_examples()
 
 
-@mark.xfail(
-    Model.current.provider in [Provider.ANTHROPIC, Provider.AWS_ANTHROPIC],
-    reason="Need to add proper types in `RetrievedInformation.value`.",
-)
 @mark.xfail(Model.current.provider == Provider.OLLAMA, reason="Too hard for Mistral")
 @mark.xfail(
     Model.current.provider == Provider.GOOGLE,

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -52,7 +52,7 @@ def sample_session_id():
         "/v1/sessions",
         json={
             "provider": "anthropic",
-            "name": "claude-3-haiku-20240307",
+            "name": "claude-haiku-4-5-20251001",
             "platform": "chromium",
             "tools": get_sample_tool_schemas(),
         },
@@ -488,7 +488,7 @@ def test_full_session_workflow():
         "/v1/sessions",
         json={
             "provider": "anthropic",
-            "name": "claude-3-haiku-20240307",
+            "name": "claude-haiku-4-5-20251001",
             "platform": "chromium",
             "tools": get_sample_tool_schemas(),
         },


### PR DESCRIPTION
Switches from Haiku 3 to Haiku 4.5. We skipped Haiku 3.5 because it never worked really well for us, but it looks like Haiku 3 will be phased out eventually.

With a new model, we can finally adopt a structured planner similar to the one used in OpenAI, Google, etc. This improves accuracy as it gives an output token space to produce a reasoning first. The next step would be to adopt a thinking mode that this version of Haiku supports.

It's worth calling out that:
- Bedrock rate limits are really low (I hit just after a few requests), hopefully this will get resolved soon
- Bedrock doesn't mention that the model supports vision, even though it works just fine
- price is 4x higher, with $1 vs $0.25 per MToK.

Fixes #106 