### PR TITLE
feat: scrolling with `ScrollTool`

### DIFF
--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -25,7 +25,7 @@ class Alumni:
         self,
         driver: Page | WebDriver,
         model: Model | None = None,
-        extra_tools: list[BaseTool] | None = None,
+        extra_tools: list[type[BaseTool]] | None = None,
         url: str | None = None,
     ):
         self.model = model or Model.current

--- a/packages/python/src/alumnium/drivers/appium_driver.py
+++ b/packages/python/src/alumnium/drivers/appium_driver.py
@@ -94,6 +94,14 @@ class AppiumDriver(BaseDriver):
     def screenshot(self) -> str:
         return self.driver.get_screenshot_as_base64()
 
+    def scroll_to(self, id: int):
+        if self.platform == "xcuitest":
+            element = self.find_element(id)
+            self.driver.execute_script("mobile: scrollToElement", {"elementId": element.id})
+        else:
+            # TODO: Implement scroll functionality on Android
+            raise NotImplementedError("scroll_to is not implemented for Android (uiautomator2) yet.")
+
     def select(self, id: int, option: str):
         # TODO: Implement select functionality and the tool
         pass

--- a/packages/python/src/alumnium/drivers/base_driver.py
+++ b/packages/python/src/alumnium/drivers/base_driver.py
@@ -44,6 +44,10 @@ class BaseDriver(ABC):
     def select(self, id: int, option: str):
         pass
 
+    @abstractmethod
+    def scroll_to(self, id: int):
+        pass
+
     @property
     @abstractmethod
     def title(self) -> str:

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -85,6 +85,10 @@ class PlaywrightDriver(BaseDriver):
     def screenshot(self) -> str:
         return b64encode(self.page.screenshot()).decode()
 
+    def scroll_to(self, id: int):
+        element = self.find_element(id)
+        element.scroll_into_view_if_needed()
+
     def select(self, id: int, option: str):
         element = self.find_element(id)
         tag_name = element.evaluate("el => el.tagName").lower()

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -91,6 +91,10 @@ class SeleniumDriver(BaseDriver):
     def screenshot(self) -> str:
         return self.driver.get_screenshot_as_base64()
 
+    def scroll_to(self, id: int):
+        element = self.find_element(id)
+        self.driver.execute_script("arguments[0].scrollIntoView();", element)
+
     def select(self, id: int, option: str):
         element = self.find_element(id)
         # Anthropic chooses to select using option ID, not select ID

--- a/packages/python/src/alumnium/server/agents/planner_prompts/anthropic/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/anthropic/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/deepseek/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/deepseek/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/google/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/google/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/meta/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/meta/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/mistralai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/mistralai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/openai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/openai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/xai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/xai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, type, navigate back, navigate to URL.
+1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/tools/__init__.py
+++ b/packages/python/src/alumnium/tools/__init__.py
@@ -5,5 +5,6 @@ from .hover_tool import HoverTool
 from .navigate_back_tool import NavigateBackTool
 from .navigate_to_url_tool import NavigateToUrlTool
 from .press_key_tool import PressKeyTool
+from .scroll_tool import ScrollTool
 from .select_tool import SelectTool
 from .type_tool import TypeTool

--- a/packages/python/src/alumnium/tools/scroll_tool.py
+++ b/packages/python/src/alumnium/tools/scroll_tool.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+
+from ..drivers.base_driver import BaseDriver
+from .base_tool import BaseTool
+
+
+class ScrollTool(BaseTool):
+    """Scroll to an element."""
+
+    id: int = Field(description="Element identifier (ID)")
+
+    def invoke(self, driver: BaseDriver):
+        driver.scroll_to(self.id)

--- a/packages/typescript/src/Alumni.ts
+++ b/packages/typescript/src/Alumni.ts
@@ -16,7 +16,6 @@ import { BaseTool, ToolCall, ToolClass } from "./tools/BaseTool.js";
 import { ClickTool } from "./tools/ClickTool.js";
 import { DragAndDropTool } from "./tools/DragAndDropTool.js";
 import { HoverTool } from "./tools/HoverTool.js";
-
 import { PressKeyTool } from "./tools/PressKeyTool.js";
 import { SelectTool } from "./tools/SelectTool.js";
 import { TypeTool } from "./tools/TypeTool.js";

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -14,6 +14,7 @@ export class AppiumDriver extends BaseDriver {
     "DragAndDropTool",
     "NavigateToUrlTool",
     "PressKeyTool",
+    "ScrollTool",
     "SelectTool",
     "TypeTool",
   ]);
@@ -97,6 +98,21 @@ export class AppiumDriver extends BaseDriver {
 
   async visit(url: string): Promise<void> {
     await this.driver.url(url);
+  }
+
+  async scrollTo(id: number): Promise<void> {
+    if (this.platform === "xcuitest") {
+      const element = await this.findElement(id);
+      const elementId = await element.elementId;
+      await this.driver.execute("mobile: scrollToElement", {
+        elementId: elementId,
+      });
+    } else {
+      // Android scroll functionality is not implemented.
+      throw new Error(
+        "scrollTo is not implemented for Android (uiautomator2) platform."
+      );
+    }
   }
 
   async quit(): Promise<void> {

--- a/packages/typescript/src/drivers/BaseDriver.ts
+++ b/packages/typescript/src/drivers/BaseDriver.ts
@@ -18,4 +18,5 @@ export abstract class BaseDriver {
   abstract findElement(id: number): Element | Promise<Element>;
   abstract hover(id: number): void | Promise<void>;
   abstract visit(url: string): void | Promise<void>;
+  abstract scrollTo(id: number): void | Promise<void>;
 }

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -36,6 +36,7 @@ export class PlaywrightDriver extends BaseDriver {
     "HoverTool",
     "NavigateToUrlTool",
     "PressKeyTool",
+    "ScrollTool",
     "SelectTool",
     "TypeTool",
   ]);
@@ -105,6 +106,11 @@ export class PlaywrightDriver extends BaseDriver {
 
   async visit(url: string): Promise<void> {
     await this.page.goto(url);
+  }
+
+  async scrollTo(id: number): Promise<void> {
+    const element = await this.findElement(id);
+    await element.scrollIntoViewIfNeeded();
   }
 
   @Retry({

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -38,6 +38,7 @@ export class SeleniumDriver extends BaseDriver {
     "HoverTool",
     "NavigateToUrlTool",
     "PressKeyTool",
+    "ScrollTool",
     "SelectTool",
     "TypeTool",
   ]);
@@ -104,6 +105,11 @@ export class SeleniumDriver extends BaseDriver {
 
   async visit(url: string): Promise<void> {
     await this.driver.get(url);
+  }
+
+  async scrollTo(id: number): Promise<void> {
+    const element = await this.findElement(id);
+    await this.driver.executeScript("arguments[0].scrollIntoView();", element);
   }
 
   async screenshot(): Promise<string> {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -11,3 +11,4 @@ export { AssertionError } from "./errors/AssertionError.js";
 export { Model, ModelName, Provider } from "./Model.js";
 export { NavigateBackTool } from "./tools/NavigateBackTool.js";
 export { NavigateToUrlTool } from "./tools/NavigateToUrlTool.js";
+export { ScrollTool } from "./tools/ScrollTool.js";

--- a/packages/typescript/src/tools/ScrollTool.ts
+++ b/packages/typescript/src/tools/ScrollTool.ts
@@ -1,0 +1,25 @@
+import { BaseDriver } from "../drivers/BaseDriver.js";
+import { BaseTool } from "./BaseTool.js";
+import { field, FieldMetadata } from "./Field.js";
+
+export class ScrollTool extends BaseTool {
+  static description = "Scroll to an element.";
+  static fields: FieldMetadata[] = [
+    field({
+      name: "id",
+      type: "integer",
+      description: "Element identifier (ID)",
+    }),
+  ];
+
+  id: number;
+
+  constructor(args: { id: number }) {
+    super();
+    this.id = args.id;
+  }
+
+  async invoke(driver: BaseDriver): Promise<void> {
+    await driver.scrollTo(this.id);
+  }
+}


### PR DESCRIPTION
This PR adds a new tool that supports scrolling elements into view. Its main purpose is to solve complex UI where element contents are not loaded until scrolled to (e.g., map), so the user might need to explicitly scroll first:

```python
al.do("scroll to the map")  # this would actually load the map
al.do("click on 'zoom in' in map")
```

The tool is disabled by default and Android support is missing now.