### PR TITLE
fix: follow open url instructions

### DIFF
--- a/packages/python/src/alumnium/server/agents/planner_prompts/anthropic/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/anthropic/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/agents/planner_prompts/deepseek/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/deepseek/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/agents/planner_prompts/google/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/google/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/agents/planner_prompts/meta/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/meta/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/mistralai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/mistralai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/agents/planner_prompts/ollama/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/ollama/system.md
@@ -4,4 +4,4 @@ Do not include element id in the step.
 Include element tag name in the step.
 Include element text content if it's present.
 Wrap step arguments except tag name in quotes.
-Each step can start with one of the following: click, drag and drop, hover, press key, select, type.
+Each step can start with one of the following: {tools}.

--- a/packages/python/src/alumnium/server/agents/planner_prompts/openai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/openai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/agents/planner_prompts/xai/system.md
+++ b/packages/python/src/alumnium/server/agents/planner_prompts/xai/system.md
@@ -9,7 +9,7 @@ Your goal is to determine a series of actions that will accomplish the task desc
 
 When formulating your actions:
 
-1. Use only the following action types: click, drag and drop, hover, press key, select, scroll, type, navigate back, navigate to URL.
+1. Use only the following action types: {tools}.
 2. Include the element's tag name in each action.
 3. If text content is present for an element, include it in quotes.
 4. Do not include element IDs in the actions.
@@ -30,3 +30,5 @@ Outline the actions needed to achieve the following goal: perform foobar
 Output:
 Explanation: In order to foobar, I am going to click button with "Foobar" label - it clearly corresponds with the goal.
 Actions: ['click button "Foobar"']
+
+{extra_examples}

--- a/packages/python/src/alumnium/server/session.py
+++ b/packages/python/src/alumnium/server/session.py
@@ -38,7 +38,7 @@ class Session:
         self.llm.cache = self.cache
 
         self.actor_agent = ActorAgent(self.llm, tools)
-        self.planner_agent = PlannerAgent(self.llm)
+        self.planner_agent = PlannerAgent(self.llm, list(tools.keys()))
         self.retriever_agent = RetrieverAgent(self.llm)
         self.area_agent = AreaAgent(self.llm)
         self.locator_agent = LocatorAgent(self.llm)


### PR DESCRIPTION
Right now, the planner is not correctly instructed for the variety of tools that the actor supports. Notably, when Alumni is started with an extra NavigateToUrlTool, it is not being selected because the planner prefers to look at the accessibility tree links instead of opening the URL directly, which doesn't even need the tree at all. It often results in incorrect tool selection, so Alumnium cannot open the URL.

Until #109 is solved and we have a single actor and planner, it makes sense to propagate the exact tool names and specific tool examples to the planner system prompt.
