### PR TITLE
feat: custom tool to execute javascript

### DIFF
--- a/packages/python/examples/pytest/execute_javascript_test.py
+++ b/packages/python/examples/pytest/execute_javascript_test.py
@@ -1,0 +1,13 @@
+from pytest import mark
+
+from alumnium import Alumni, Model, Provider
+from alumnium.tools import ExecuteJavascriptTool
+
+
+@mark.xfail(Model.current.provider == Provider.DEEPSEEK, reason="No vision support yet")
+def test_execute_javascript_to_scroll(al, driver, navigate):
+    al = Alumni(driver, extra_tools=[ExecuteJavascriptTool])
+    navigate("https://the-internet.herokuapp.com/large")
+    al.check("'Powered by Elemental Selenium' is not present", vision=True)
+    al.do("execute javascript 'window.scrollTo(0, document.body.scrollHeight)'")
+    al.check("'Powered by Elemental Selenium' is present", vision=True)

--- a/packages/python/examples/pytest/waiting_test.py
+++ b/packages/python/examples/pytest/waiting_test.py
@@ -5,7 +5,7 @@ from pytest import mark
 
 @mark.xfail(
     getenv("ALUMNIUM_DRIVER", "selenium") == "appium-ios",
-    reason="Synchrnoization is not implemented in Appium yet",
+    reason="Synchronization is not implemented in Appium yet",
 )
 def test_waiting_for_loading_content(al, navigate):
     navigate("https://the-internet.herokuapp.com/dynamic_content")
@@ -14,7 +14,7 @@ def test_waiting_for_loading_content(al, navigate):
 
 @mark.xfail(
     getenv("ALUMNIUM_DRIVER", "selenium") == "appium-ios",
-    reason="Synchrnoization is not implemented in Appium yet",
+    reason="Synchronization is not implemented in Appium yet",
 )
 def test_waiting_for_requests_and_form_updates(al, navigate):
     navigate("https://the-internet.herokuapp.com/forgot_password")

--- a/packages/python/src/alumnium/drivers/appium_driver.py
+++ b/packages/python/src/alumnium/drivers/appium_driver.py
@@ -180,6 +180,10 @@ class AppiumDriver(BaseDriver):
 
             return self.driver.find_element(By.XPATH, xpath)
 
+    def execute_script(self, script: str):
+        self._ensure_webview_context()
+        self.driver.execute_script(script)
+
     def _ensure_native_app_context(self):
         if not self.autoswitch_contexts:
             return

--- a/packages/python/src/alumnium/drivers/base_driver.py
+++ b/packages/python/src/alumnium/drivers/base_driver.py
@@ -65,3 +65,7 @@ class BaseDriver(ABC):
     @abstractmethod
     def find_element(self, id: int) -> Element:
         pass
+
+    @abstractmethod
+    def execute_script(self, script: str):
+        pass

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -140,6 +140,9 @@ class PlaywrightDriver(BaseDriver):
         # but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
         return self.page.locator(f"css=[data-alumnium-id='{backend_node_id}']")
 
+    def execute_script(self, script: str):
+        self.page.evaluate(f"() => {{ {script} }}")
+
     def wait_for_page_to_load(self):
         logger.debug("Waiting for page to finish loading:")
         try:

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -172,6 +172,9 @@ class SeleniumDriver(BaseDriver):
         )
         return element
 
+    def execute_script(self, script: str):
+        self.driver.execute_script(script)
+
     # Remote Chromium instances support CDP commands, but the Python bindings don't expose them.
     # https://github.com/SeleniumHQ/selenium/issues/14799
     def _patch_driver(self, driver: WebDriver):

--- a/packages/python/src/alumnium/tools/__init__.py
+++ b/packages/python/src/alumnium/tools/__init__.py
@@ -1,6 +1,7 @@
 from .base_tool import BaseTool
 from .click_tool import ClickTool
 from .drag_and_drop_tool import DragAndDropTool
+from .execute_javascript_tool import ExecuteJavascriptTool
 from .hover_tool import HoverTool
 from .navigate_back_tool import NavigateBackTool
 from .navigate_to_url_tool import NavigateToUrlTool

--- a/packages/python/src/alumnium/tools/base_tool.py
+++ b/packages/python/src/alumnium/tools/base_tool.py
@@ -1,15 +1,21 @@
+from abc import ABC, abstractmethod
+
 from pydantic import BaseModel
 
 from alumnium.drivers.base_driver import BaseDriver
 
 
-class BaseTool(BaseModel):
+class BaseTool(ABC, BaseModel):
     @classmethod
     def execute_tool_call(
         cls,
         tool_call: dict,
-        tools: list["BaseTool"],
+        tools: dict[str, type["BaseTool"]],
         driver: BaseDriver,
     ):
         tool = tools[tool_call["name"]](**tool_call["args"])
         tool.invoke(driver)
+
+    @abstractmethod
+    def invoke(self, driver: BaseDriver):
+        pass

--- a/packages/python/src/alumnium/tools/execute_javascript_tool.py
+++ b/packages/python/src/alumnium/tools/execute_javascript_tool.py
@@ -1,0 +1,14 @@
+from pydantic import Field
+
+from alumnium.drivers.base_driver import BaseDriver
+
+from .base_tool import BaseTool
+
+
+class ExecuteJavascriptTool(BaseTool):
+    """Execute a JavaScript snippet in the browser context."""
+
+    script: str = Field(description="JavaScript code to execute")
+
+    def invoke(self, driver: BaseDriver):
+        driver.execute_script(self.script)

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -229,6 +229,11 @@ export class AppiumDriver extends BaseDriver {
     }
   }
 
+  async executeScript(script: string): Promise<void> {
+    await this.ensureWebviewContext();
+    await this.driver.execute(script);
+  }
+
   // eslint-disable-next-line @typescript-eslint/require-await, @typescript-eslint/no-unused-vars
   async hover(_id: number): Promise<void> {
     // Hover is not typically supported in mobile contexts

--- a/packages/typescript/src/drivers/BaseDriver.ts
+++ b/packages/typescript/src/drivers/BaseDriver.ts
@@ -19,4 +19,5 @@ export abstract class BaseDriver {
   abstract hover(id: number): void | Promise<void>;
   abstract visit(url: string): void | Promise<void>;
   abstract scrollTo(id: number): void | Promise<void>;
+  abstract executeScript(script: string): void | Promise<void>;
 }

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -190,6 +190,10 @@ export class PlaywrightDriver extends BaseDriver {
     return this.page.locator(`css=[data-alumnium-id='${backendNodeId}']`);
   }
 
+  async executeScript(script: string): Promise<void> {
+    await this.page.evaluate(`() => { ${script} }`);
+  }
+
   @Retry({
     maxAttempts: 2,
     backOff: 500,

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -234,6 +234,10 @@ export class SeleniumDriver extends BaseDriver {
     return element;
   }
 
+  async executeScript(script: string): Promise<void> {
+    await this.driver.executeScript(script);
+  }
+
   private async executeCdpCommand(
     cmd: string,
     params: object

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -9,6 +9,7 @@ export { PlaywrightDriver } from "./drivers/PlaywrightDriver.js";
 export { SeleniumDriver } from "./drivers/SeleniumDriver.js";
 export { AssertionError } from "./errors/AssertionError.js";
 export { Model, ModelName, Provider } from "./Model.js";
+export { ExecuteJavascriptTool } from "./tools/ExecuteJavascriptTool.js";
 export { NavigateBackTool } from "./tools/NavigateBackTool.js";
 export { NavigateToUrlTool } from "./tools/NavigateToUrlTool.js";
 export { ScrollTool } from "./tools/ScrollTool.js";

--- a/packages/typescript/src/tools/ExecuteJavascriptTool.ts
+++ b/packages/typescript/src/tools/ExecuteJavascriptTool.ts
@@ -1,0 +1,25 @@
+import { BaseDriver } from "../drivers/BaseDriver.js";
+import { BaseTool } from "./BaseTool.js";
+import { field, FieldMetadata } from "./Field.js";
+
+export class ExecuteJavascriptTool extends BaseTool {
+  static description = "Execute a JavaScript snippet in the browser context.";
+  static fields: FieldMetadata[] = [
+    field({
+      name: "script",
+      type: "string",
+      description: "JavaScript code to execute",
+    }),
+  ];
+
+  script: string;
+
+  constructor(args: { script: string }) {
+    super();
+    this.script = args.script;
+  }
+
+  async invoke(driver: BaseDriver): Promise<void> {
+    await driver.executeScript(this.script);
+  }
+}


### PR DESCRIPTION
This PR adds a new tool that supports executing arbitrary JavaScript on the page. Its main purpose is to let generic-purpose agents like Claude Code to workaround current limitations. For example, if there is a sticky header that obscures an element, Claude Code can suggest scrolling to the top:

```python
al.do("execute javascript 'window.scrollTo(0, 0);'")
```

The tool is disabled by default.