### PR TITLE
test: skip dollar sign when getting amounts

### DIFF
--- a/packages/python/examples/pytest/bstackdemo_test.py
+++ b/packages/python/examples/pytest/bstackdemo_test.py
@@ -38,9 +38,9 @@ def test_checkout(al):
     al.do("click login button")  # Could be NOOP
 
     # Proceed through checkout
-    assert al.get("iPhone 12 Pro Max price") == 1099
-    assert al.get("iPhone 12 Mini price") == 699
-    assert al.get("total amount") == 1798
+    assert al.get("iPhone 12 Pro Max price (without money sign)") == 1099
+    assert al.get("iPhone 12 Mini price (without money sign)") == 699
+    assert al.get("total amount (without money sign)") == 1798
 
     fields = {
         "first name": "Al",

--- a/packages/python/examples/pytest/swag_labs_test.py
+++ b/packages/python/examples/pytest/swag_labs_test.py
@@ -81,10 +81,10 @@ def test_sorting(al):
     assert al.get("titles of products") == sorted(titles)
 
     al.do("sort products by lowest price")
-    assert al.get("prices of products") == sorted(prices)
+    assert al.get("prices of products (without money sign)") == sorted(prices)
 
     al.do("sort products by highest price")
-    assert al.get("prices of products") == sorted(prices, reverse=True)
+    assert al.get("prices of products (without money sign)") == sorted(prices, reverse=True)
 
 
 @mark.xfail(
@@ -109,9 +109,9 @@ def test_checkout(al):
     al.do("go to checkout")
     al.do("continue with first name - Al, last name - Um, ZIP - 95122")
 
-    assert al.get("item total without tax") == 37.98
-    assert al.get("tax amount") == 3.04
-    assert al.get("total amount with tax") == round(37.98 + 3.04, 2)
+    assert al.get("item total without tax (without money sign)") == 37.98
+    assert al.get("tax amount (without money sign)") == 3.04
+    assert al.get("total amount with tax (without money sign)") == round(37.98 + 3.04, 2)
     assert al.get("shipping information value") == "Free Pony Express Delivery!"
 
     al.do("finish checkout")


### PR DESCRIPTION
Fixes CI failures by making `get` instruction more concrete and telling Alumnium to ignore money signs ($).