### PR TITLE
feat: add custom Chat instance support to Alumni

### DIFF
--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -1,6 +1,7 @@
 from asyncio import AbstractEventLoop
 
 from appium.webdriver.webdriver import WebDriver as Appium
+from langchain_core.language_models import BaseChatModel
 from playwright.async_api import Page as PageAsync
 from playwright.sync_api import Page
 from retry import retry
@@ -29,10 +30,12 @@ class Alumni:
         self,
         driver: Page | WebDriver | tuple[PageAsync, AbstractEventLoop],
         model: Model | None = None,
+        llm: BaseChatModel | None = None,
         extra_tools: list[type[BaseTool]] | None = None,
         url: str | None = None,
     ):
         self.model = model or Model.current
+        self.llm = llm
 
         if isinstance(driver, Appium):
             self.driver = AppiumDriver(driver)
@@ -59,7 +62,7 @@ class Alumni:
             self.client = HttpClient(url, self.model, self.driver.platform, self.tools)
         else:
             logger.info("Using native client")
-            self.client = NativeClient(self.model, self.driver.platform, self.tools)
+            self.client = NativeClient(self.model, self.driver.platform, self.tools, llm=self.llm)
 
         self.cache = Cache(self.client)
 

--- a/packages/python/src/alumnium/clients/native_client.py
+++ b/packages/python/src/alumnium/clients/native_client.py
@@ -1,3 +1,5 @@
+from langchain_core.language_models import BaseChatModel
+
 from ..server.logutils import get_logger
 from ..server.models import Model
 from ..server.session_manager import SessionManager
@@ -9,7 +11,9 @@ logger = get_logger(__name__)
 
 
 class NativeClient:
-    def __init__(self, model: Model, platform: str, tools: dict[str, type[BaseTool]]):
+    def __init__(
+        self, model: Model, platform: str, tools: dict[str, type[BaseTool]], llm: BaseChatModel | None = None
+    ):
         self.session_manager = SessionManager()
         self.model = model
         self.tools = tools
@@ -17,7 +21,11 @@ class NativeClient:
         # Convert tools to schemas for API
         tool_schemas = convert_tools_to_schemas(tools)
         self.session_id = self.session_manager.create_session(
-            provider=self.model.provider.value, name=self.model.name, tools=tool_schemas, platform=platform
+            provider=self.model.provider.value,
+            name=self.model.name,
+            tools=tool_schemas,
+            platform=platform,
+            llm=llm,
         )
 
         self.session = self.session_manager.get_session(self.session_id)

--- a/packages/python/src/alumnium/server/session.py
+++ b/packages/python/src/alumnium/server/session.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from langchain_core.language_models import BaseChatModel
+
 from .accessibility import (
     BaseServerAccessibilityTree,
     ServerChromiumAccessibilityTree,
@@ -28,13 +30,17 @@ class Session:
         model: Model,
         platform: str,
         tools: dict[str, Any],
+        llm: BaseChatModel | None = None,
     ):
         self.session_id = session_id
         self.model = model
         self.platform = platform
 
         self.cache = CacheFactory.create_cache()
-        self.llm = LLMFactory.create_llm(model=model)
+        if llm is not None:
+            self.llm = llm
+        else:
+            self.llm = LLMFactory.create_llm(model=model)
         self.llm.cache = self.cache
 
         self.actor_agent = ActorAgent(self.llm, tools)

--- a/packages/python/src/alumnium/server/session_manager.py
+++ b/packages/python/src/alumnium/server/session_manager.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Any, Dict, List, Optional
 
+from langchain_core.language_models import BaseChatModel
+
 from .logutils import get_logger
 from .models import Model
 from .schema_to_tool_converter import convert_schemas_to_tools
@@ -15,13 +17,21 @@ class SessionManager:
     def __init__(self):
         self.sessions: dict[str, Session] = {}
 
-    def create_session(self, provider: str, name: str, platform: str, tools: List[Dict[str, Any]]) -> str:
+    def create_session(
+        self,
+        provider: str,
+        name: str,
+        platform: str,
+        tools: List[Dict[str, Any]],
+        llm: BaseChatModel | None = None,
+    ) -> str:
         """Create a new session and return its ID.
         Args:
             provider: The model provider name
             name: The model name (optional)
             platform: The platform type (chromium, xcuitest, uiautomator2)
             tools: List of LangChain tool schemas
+            llm: Optional custom LangChain Chat model instance
         Returns:
             Session ID string
         """
@@ -33,7 +43,9 @@ class SessionManager:
         # Convert tool schemas to tool classes
         tool_classes = convert_schemas_to_tools(tools)
 
-        self.sessions[session_id] = Session(session_id=session_id, model=model, platform=platform, tools=tool_classes)
+        self.sessions[session_id] = Session(
+            session_id=session_id, model=model, platform=platform, tools=tool_classes, llm=llm
+        )
         logger.info(f"Created new session: {session_id}")
         return session_id
 


### PR DESCRIPTION
Add support for passing custom LangChain Chat* instances to Alumni class, allowing users to configure their own LLM with specific settings (e.g., custom clients, async clients, temperature).

Changes:
- Alumni: Add optional llm parameter to constructor
- NativeClient: Accept and forward custom LLM to SessionManager
- SessionManager: Accept and forward custom LLM to Session
- Session: Use custom LLM if provided, otherwise create via LLMFactory

Example usage:
```python
llm = ChatOpenAI(
    model=DEPLOYMENT_NAME,
    client=client_resource,
    async_client=async_client_resource,
    temperature=0.2,
)
al = Alumni(driver=driver, llm=llm)
```

Fixes #210