### PR TITLE
feat: force click elements

### DIFF
--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -14,8 +14,8 @@ from .clients.native_client import NativeClient
 from .clients.typecasting import Data
 from .drivers import Element
 from .drivers.appium_driver import AppiumDriver
+from .drivers.playwright_async_driver import PlaywrightAsyncDriver
 from .drivers.playwright_driver import PlaywrightDriver
-from .drivers.playwright_driver_async import PlaywrightDriverAsync
 from .drivers.selenium_driver import SeleniumDriver
 from .server.logutils import get_logger
 from .server.models import Model
@@ -42,7 +42,7 @@ class Alumni:
             isinstance(driver, tuple) and isinstance(driver[0], PageAsync) and isinstance(driver[1], AbstractEventLoop)
         ):
             # Asynchronous Playwright driver requires a shared event loop
-            self.driver = PlaywrightDriverAsync(driver[0], driver[1])
+            self.driver = PlaywrightAsyncDriver(driver[0], driver[1])
         elif isinstance(driver, WebDriver):
             self.driver = SeleniumDriver(driver)
         else:

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -61,7 +61,7 @@ class PlaywrightDriver(BaseDriver):
             element.locator("xpath=.//parent::select").select_option(option)
         else:
             with self._autoswitch_to_new_tab():
-                element.click()
+                element.click(force=True)
 
     def drag_and_drop(self, from_id: int, to_id: int):
         from_element = self.find_element(from_id)

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -73,7 +73,7 @@ export class PlaywrightDriver extends BaseDriver {
       return;
     }
 
-    await this.autoswitchToNewTab(() => element.click());
+    await this.autoswitchToNewTab(() => element.click({ force: true }));
   }
 
   async dragAndDrop(fromId: number, toId: number): Promise<void> {


### PR DESCRIPTION
Since Alumnium operates over an accessibility tree, whatever is present there is known to be visible and actionable. In these cases, we can short-circuit and force-click an element (https://playwright.dev/docs/input#forcing-the-click). This also ensures that a complex UI where elements overlay each other (e.g. image and a link are indistinguishable and overlap each other) can still receive clicks. One example of such a scenario is an Airbnb search results page where the `link` is made bigger than the internal images:
<img width="1840" height="1119" alt="Screenshot 2026-01-05 at 11 12 50" src="https://github.com/user-attachments/assets/612ade20-161d-4f78-93b4-2702d040d683" />
