### PR TITLE
feat(playwright): configurable new tab timeout

### DIFF
--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 from contextlib import contextmanager
+from os import getenv
 from pathlib import Path
 
 from playwright.sync_api import Error, Locator, Page, TimeoutError
@@ -19,7 +20,7 @@ logger = get_logger(__name__)
 
 
 class PlaywrightDriver(BaseDriver):
-    NEW_TAB_TIMEOUT = 200
+    NEW_TAB_TIMEOUT = int(getenv("ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT", "200"))
     NOT_SELECTABLE_ERROR = "Element is not a <select> element"
     CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed"
 

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -40,7 +40,10 @@ export class PlaywrightDriver extends BaseDriver {
     "SelectTool",
     "TypeTool",
   ]);
-  public newTabTimeout = 200;
+  public newTabTimeout = parseInt(
+    process.env.ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT || "200",
+    10
+  );
 
   constructor(page: Page) {
     super();


### PR DESCRIPTION
200ms seems to be fine for lightweight websites, but fails often for more complex ones. Make it configurable via the environment variable `ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT` until we find a better solution that doesn't rely on fixed timeouts.

*sigh* I wish Playwright tabs manipulation were as easy as Selenium window handling.
