### PR TITLE
fix: trim whitespace in file upload paths

### DIFF
--- a/packages/python/src/alumnium/tools/upload_tool.py
+++ b/packages/python/src/alumnium/tools/upload_tool.py
@@ -26,7 +26,7 @@ class UploadTool(BaseTool):
         # It also often surrounds paths with quotes.
         normalized = []
         for path in paths:
-            normalized_path = sub(r"\\+/", "/", path).strip('"').strip("'")
+            normalized_path = sub(r"\\+/", "/", path).strip('"').strip("'").strip()
             normalized.append(normalized_path)
 
         return normalized

--- a/packages/typescript/src/tools/UploadTool.ts
+++ b/packages/typescript/src/tools/UploadTool.ts
@@ -39,7 +39,10 @@ export class UploadTool extends BaseTool {
     // Planner often attempts to "escape" file paths by adding backslashes.
     // It also often surrounds paths with quotes.
     return paths.map((path) => {
-      return path.replace(/\\+\//g, "/").replace(/^["']|["']$/g, "");
+      return path
+        .replace(/\\+\//g, "/")
+        .replace(/^["']|["']$/g, "")
+        .trim();
     });
   }
 }


### PR DESCRIPTION
Sometimes LLM responds with leading spaces, e.g. `[" /Users/p0deje/..."]`.