### PR TITLE
Accept string booleans for vision and save_cache params

### DIFF
--- a/packages/python/src/alumnium/mcp/handlers.py
+++ b/packages/python/src/alumnium/mcp/handlers.py
@@ -160,6 +160,8 @@ async def handle_check(args: dict[str, Any]) -> list[dict]:
     driver_id = args["driver_id"]
     statement = args["statement"]
     vision = args.get("vision", False)
+    if isinstance(vision, str):
+        vision = vision.lower() == "true"
 
     logger.info(f"Driver {driver_id}: Executing check('{statement}', vision={vision})")
 
@@ -183,6 +185,8 @@ async def handle_get(args: dict[str, Any]) -> list[dict]:
     driver_id = args["driver_id"]
     data = args["data"]
     vision = args.get("vision", False)
+    if isinstance(vision, str):
+        vision = vision.lower() == "true"
 
     logger.info(f"Driver {driver_id}: Executing get('{data}', vision={vision})")
 
@@ -218,6 +222,8 @@ async def handle_stop_driver(args: dict[str, Any]) -> list[dict]:
     """Stop driver and cleanup."""
     driver_id = args["driver_id"]
     save_cache = args.get("save_cache", False)
+    if isinstance(save_cache, str):
+        save_cache = save_cache.lower() == "true"
 
     logger.info(f"Driver {driver_id}: Stopping driver (save_cache={save_cache})")
 

--- a/packages/python/src/alumnium/mcp/tools.py
+++ b/packages/python/src/alumnium/mcp/tools.py
@@ -95,7 +95,7 @@ def get_tool_definitions() -> list[Tool]:
                 "properties": {
                     "driver_id": {"type": "string"},
                     "save_cache": {
-                        "type": "boolean",
+                        "oneOf": [{"type": "boolean"}, {"type": "string"}],
                         "description": (
                             "Save the Alumnium cache before stopping. "
                             "This persists executed interactions for future use."
@@ -148,7 +148,7 @@ def get_tool_definitions() -> list[Tool]:
                         "description": "Statement to verify (e.g., 'page title contains Dashboard')",
                     },
                     "vision": {
-                        "type": "boolean",
+                        "oneOf": [{"type": "boolean"}, {"type": "string"}],
                         "description": "Use screenshot for verification",
                         "default": False,
                     },
@@ -171,7 +171,7 @@ def get_tool_definitions() -> list[Tool]:
                         "description": "Description of data to extract",
                     },
                     "vision": {
-                        "type": "boolean",
+                        "oneOf": [{"type": "boolean"}, {"type": "string"}],
                         "description": "Use screenshot for extraction",
                         "default": False,
                     },


### PR DESCRIPTION
## Summary

LLM agents calling the MCP server sometimes serialize boolean parameters as strings ("true" instead of true). The MCP client validates arguments against the tool schema before forwarding the call, so a strict "type": "boolean" causes a validation error and the call never reaches the handler — silently breaking vision-based checks and cache saving. 

tools.py broadens the schema for vision (check, get) and save_cache (stop_driver) to oneOf: [boolean, string], removing the client-side rejection. handlers.py adds coercion so string "true"/"false" is converted to the correct boolean before use.

## Motivation

From several runs, I can see LLMs consistently serialize boolean parameters as strings in tool calls. Broadening the schema to accept both types makes Alumnium robust to this, without changing any expected behavior for callers that already pass correct booleans.


## Type of Change
Mark the relevant options.

- [x] Bug fix  
- [ ] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

## Code or UI Demos (if applicable)
Add screenshots, logs, terminal output, or code snippets that help reviewers understand the change.
Useful especially for UI changes or error fixes.

## Checklist
Please verify the following before submitting:

- [x] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [x] I have added or updated relevant documentation
- [x] I have written or updated necessary tests
- [ ] I have tested the changes locally
- [ ] The changes follow the project's coding style and structure
- [ ] I have not included any sensitive or credential-related information
- [ ] I have ensured these changes maintain or improve accessibility (for UI changes)
- [ ] I have considered security implications of these changes

## Additional Notes
Anything else the reviewer should be aware of?
For example: limitations, discussions to follow up on, or next steps.
