### PR TITLE
Distinguish NOOP from FALSE in check() MCP response

### DIFF
--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -163,6 +163,8 @@ class Alumni:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
+        if value is None:
+            raise AssertionError(f"NOOP: {explanation}")
         assert value, explanation
         return explanation
 

--- a/packages/python/src/alumnium/area.py
+++ b/packages/python/src/alumnium/area.py
@@ -86,6 +86,8 @@ class Area:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
+        if value is None:
+            raise AssertionError(f"NOOP: {explanation}")
         assert value, explanation
         return explanation
 

--- a/packages/python/src/alumnium/mcp/handlers.py
+++ b/packages/python/src/alumnium/mcp/handlers.py
@@ -170,8 +170,13 @@ async def handle_check(args: dict[str, Any]) -> list[dict]:
         logger.debug(f"Driver {driver_id}: check() passed: {explanation}")
     except AssertionError as e:
         explanation = str(e)
-        result = "failed"
-        logger.debug(f"Driver {driver_id}: check() failed: {explanation}")
+        if explanation.startswith("NOOP:"):
+            result = "inconclusive"
+            explanation = explanation[5:].strip()
+            logger.debug(f"Driver {driver_id}: check() inconclusive (NOOP): {explanation}")
+        else:
+            result = "failed"
+            logger.debug(f"Driver {driver_id}: check() failed: {explanation}")
 
     screenshots.save_screenshot(driver_id, f"check {statement}", al)
 


### PR DESCRIPTION
## Summary
When the retriever LLM can't determine if a statement is true or false from the accessibility tree, it returns NOOP (indeterminate). Previously, `check()` treated NOOP identically to a definitive false. Both raised the same `AssertionError`. The MCP handler returned `"Check failed!"` for both cases, giving the executor agent no way to distinguish "definitely false" from "can't tell


## Motivation
Why is this change being made?
Above design has caused silent false positives: the executor would retry, fail to verify the original statement, then reformulate it into something softer that the ARIA tree could confirm and the step would pass even though the original condition was never verified.

## Related Issue(s)
If this PR fixes or is related to an open issue, link it here.
Example: Closes #123

Closes #

## Type of Change
Mark the relevant options.

- [ ] Bug fix  
- [ ] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

## Code or UI Demos (if applicable)
Add screenshots, logs, terminal output, or code snippets that help reviewers understand the change.
Useful especially for UI changes or error fixes.

## Checklist
Please verify the following before submitting:

- [ ] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated relevant documentation
- [ ] I have written or updated necessary tests
- [ ] I have tested the changes locally
- [ ] The changes follow the project's coding style and structure
- [ ] I have not included any sensitive or credential-related information
- [ ] I have ensured these changes maintain or improve accessibility (for UI changes)
- [ ] I have considered security implications of these changes

## Additional Notes
Anything else the reviewer should be aware of?
For example: limitations, discussions to follow up on, or next steps.
