### PR TITLE
feat: support alerts across all drivers and languages

### DIFF
--- a/packages/python/examples/pytest/alert_test.py
+++ b/packages/python/examples/pytest/alert_test.py
@@ -1,0 +1,13 @@
+def test_alert_accept(al, navigate):
+    navigate("alert.html")
+    al.do("click the Trigger Alert button")
+    al.check("an alert dialog is shown")
+    al.do("accept the alert")
+
+
+def test_confirm_dismiss(al, navigate):
+    navigate("alert.html")
+    al.do("click the Trigger Confirm button")
+    al.check("a confirm dialog is shown")
+    al.do("dismiss the alert")
+    al.check("the result text says Dismissed")

--- a/packages/python/examples/support/pages/alert.html
+++ b/packages/python/examples/support/pages/alert.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Alert Test Page</title>
+</head>
+<body>
+  <h1>Alert Test</h1>
+  <button id="alert-btn" onclick="alert('Hello from alert!')">Trigger Alert</button>
+  <button id="confirm-btn" onclick="handleConfirm()">Trigger Confirm</button>
+  <p id="result"></p>
+
+  <script>
+    function handleConfirm() {
+      const result = confirm('Do you confirm?');
+      document.getElementById('result').textContent = result ? 'Confirmed' : 'Dismissed';
+    }
+  </script>
+</body>
+</html>

--- a/packages/python/src/alumnium/accessibility/accessibility_element.py
+++ b/packages/python/src/alumnium/accessibility/accessibility_element.py
@@ -18,3 +18,4 @@ class AccessibilityElement:
     frame: Any | None = None  # Playwright Frame object for iframe support
     locator_info: dict | None = None  # Locator info for Playwright nodes (cross-origin iframes)
     frame_chain: list[int] | None = None  # For Selenium: chain of iframe backendNodeIds from root to element's frame
+    alert_action: str | None = None  # "accept" or "dismiss" for alert dialog buttons

--- a/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py
+++ b/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py
@@ -80,6 +80,10 @@ class ChromiumAccessibilityTree(BaseAccessibilityTree):
         if "_frame_chain" in node:
             self._frame_chain_map[self._next_raw_id] = node["_frame_chain"]
 
+        # Store alert action metadata for synthetic alert dialog buttons
+        if "_alert_action" in node:
+            elem.set("_alert_action", node["_alert_action"])
+
         # Add all node attributes as XML attributes
         if "backendDOMNodeId" in node:
             elem.set("backendDOMNodeId", str(node["backendDOMNodeId"]))
@@ -165,6 +169,14 @@ class ChromiumAccessibilityTree(BaseAccessibilityTree):
         element = find_element(root, str(raw_id))
         if element is None:
             raise KeyError(f"No element with raw_id={raw_id} found")
+
+        # Check if this is an alert dialog button
+        alert_action = element.get("_alert_action")
+        if alert_action:
+            return AccessibilityElement(
+                type=element.tag,
+                alert_action=alert_action,
+            )
 
         # Check if this is a Playwright node (cross-origin iframe element)
         if element.get("_playwright_node") == "true":

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse
 
-from playwright.async_api import Error, Frame, Locator, Page, TimeoutError
+from playwright.async_api import Dialog, Error, Frame, Locator, Page, TimeoutError
 
 from .. import FULL_PAGE_SCREENSHOT
 from ..accessibility import ChromiumAccessibilityTree
@@ -37,6 +37,8 @@ class PlaywrightAsyncDriver(BaseDriver):
             TypeTool,
             UploadTool,
         }
+        self._last_dialog_info: dict | None = None
+        self.page.on("dialog", self._on_dialog_sync)
         self._run_async(self._enable_target_auto_attach())
         self._run_async(self._setup_page_tracking(page))
 
@@ -44,12 +46,32 @@ class PlaywrightAsyncDriver(BaseDriver):
     def platform(self) -> str:
         return "chromium"
 
+    def _on_dialog_sync(self, dialog: Dialog):
+        """Capture dialog info and auto-accept.
+
+        Playwright requires dialogs to be resolved in the handler or the page
+        freezes. Unlike Selenium, we cannot defer the accept/dismiss decision
+        to the user.
+        """
+        self._last_dialog_info = {
+            "type": dialog.type,
+            "message": dialog.message,
+            "default_value": dialog.default_value,
+        }
+        logger.debug(f"Dialog captured ({dialog.type}): {dialog.message[:80]}")
+        run_coroutine_threadsafe(dialog.accept(), self.loop)
+
     @property
     def accessibility_tree(self) -> ChromiumAccessibilityTree:
         return self._run_async(self._accessibility_tree)
 
     @property
     async def _accessibility_tree(self) -> ChromiumAccessibilityTree:
+        if self._last_dialog_info:
+            dialog_info = self._last_dialog_info
+            self._last_dialog_info = None
+            return ChromiumAccessibilityTree({"nodes": PlaywrightDriver._create_dialog_nodes(dialog_info)})
+
         await self._wait_for_page_to_load()
 
         # Get frame tree to enumerate all frames (same approach as Selenium)

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -4,7 +4,7 @@ from os import getenv
 from pathlib import Path
 from urllib.parse import urlparse
 
-from playwright.sync_api import Error, Frame, Locator, Page, TimeoutError
+from playwright.sync_api import Dialog, Error, Frame, Locator, Page, TimeoutError
 
 from .. import FULL_PAGE_SCREENSHOT
 from ..accessibility import ChromiumAccessibilityTree
@@ -40,6 +40,8 @@ class PlaywrightDriver(BaseDriver):
         self.page = page
         self.autoswitch_to_new_tab = True
         self.full_page_screenshot = FULL_PAGE_SCREENSHOT
+        self._last_dialog_info: dict | None = None
+        self.page.on("dialog", self._on_dialog)
         self.supported_tools = {
             ClickTool,
             DragAndDropTool,
@@ -57,6 +59,11 @@ class PlaywrightDriver(BaseDriver):
 
     @property
     def accessibility_tree(self) -> ChromiumAccessibilityTree:
+        if self._last_dialog_info:
+            dialog_info = self._last_dialog_info
+            self._last_dialog_info = None
+            return ChromiumAccessibilityTree({"nodes": self._create_dialog_nodes(dialog_info)})
+
         self._wait_for_page_to_load()
 
         # Get frame tree to enumerate all frames (same approach as Selenium)
@@ -144,6 +151,11 @@ class PlaywrightDriver(BaseDriver):
         return ChromiumAccessibilityTree({"nodes": all_nodes})
 
     def click(self, id: int):
+        accessibility_element = self.accessibility_tree.element_by_id(id)
+        if accessibility_element.alert_action:
+            logger.debug(f"Alert action acknowledged: {accessibility_element.alert_action}")
+            return
+
         element = self.find_element(id)
         tag_name = element.evaluate("el => el.tagName")
         if tag_name.lower() == "option":
@@ -282,6 +294,55 @@ class PlaywrightDriver(BaseDriver):
 
     def print_to_pdf(self, filepath: str):
         self.page.pdf(path=filepath)
+
+    def _on_dialog(self, dialog: Dialog):
+        """Capture dialog info and auto-accept.
+
+        Playwright requires dialogs to be resolved in the handler or the page
+        freezes. Unlike Selenium, we cannot defer the accept/dismiss decision
+        to the user.
+        """
+        self._last_dialog_info = {
+            "type": dialog.type,
+            "message": dialog.message,
+            "default_value": dialog.default_value,
+        }
+        logger.debug(f"Dialog captured ({dialog.type}): {dialog.message[:80]}")
+        dialog.accept()
+
+    @staticmethod
+    def _create_dialog_nodes(dialog_info: dict) -> list[dict]:
+        """Create synthetic nodes representing a captured dialog for the LLM to see.
+
+        The dialog has already been auto-accepted (Playwright constraint), but
+        we still expose it so al.check() and al.get() can verify dialog text.
+        """
+        message = dialog_info.get("message", "Alert")
+        dialog_type = dialog_info.get("type", "alert")
+        dialog_id = "-100"
+        accept_id = "-101"
+        dismiss_id = "-102"
+
+        return [
+            {
+                "nodeId": dialog_id,
+                "role": {"value": "alertdialog"},
+                "name": {"value": f"{dialog_type}: {message}"},
+                "childIds": [accept_id, dismiss_id],
+            },
+            {
+                "nodeId": accept_id,
+                "role": {"value": "button"},
+                "name": {"value": "Accept"},
+                "_alert_action": "accept",
+            },
+            {
+                "nodeId": dismiss_id,
+                "role": {"value": "button"},
+                "name": {"value": "Dismiss"},
+                "_alert_action": "dismiss",
+            },
+        ]
 
     def _wait_for_page_to_load(self):
         logger.debug("Waiting for page to finish loading:")

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -4,6 +4,7 @@ from typing import Callable
 from urllib.parse import urlparse
 
 from retry import retry
+from selenium.common.exceptions import NoAlertPresentException
 from selenium.webdriver.chrome.remote_connection import ChromiumRemoteConnection
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
@@ -55,9 +56,13 @@ class SeleniumDriver(BaseDriver):
 
     @property
     def accessibility_tree(self) -> ChromiumAccessibilityTree:
-        # Switch to default content to ensure we're at the top level for frame enumeration
-        self.driver.switch_to.default_content()
-        self._wait_for_page_to_load()
+        alert = self._detect_alert()
+
+        # WebDriver commands (switch_to, execute_script) fail when an alert is open,
+        # but CDP commands still work since they use the DevTools protocol directly.
+        if not alert:
+            self.driver.switch_to.default_content()
+            self._wait_for_page_to_load()
 
         # Get frame tree to enumerate all frames
         frame_tree = self.driver.execute_cdp_cmd("Page.getFrameTree", {})  # type: ignore[attr-defined]
@@ -108,6 +113,9 @@ class SeleniumDriver(BaseDriver):
                 logger.debug(f"  -> Cross-origin iframe {oopif.get('url', '')[:40]}...: {len(nodes)} nodes")
             except Exception as e:
                 logger.debug(f"  -> Cross-origin iframe {oopif.get('url', '')[:40]}...: failed ({e})")
+
+        if alert:
+            all_nodes.extend(self._create_alert_nodes(alert))
 
         return ChromiumAccessibilityTree({"nodes": all_nodes})
 
@@ -349,9 +357,15 @@ class SeleniumDriver(BaseDriver):
             if not self.autoswitch_to_new_tab:
                 return func(self, *args, **kwargs)
 
-            current_handles = self.driver.window_handles
+            try:
+                current_handles = self.driver.window_handles
+            except Exception:
+                return func(self, *args, **kwargs)
             result = func(self, *args, **kwargs)
-            new_handles = self.driver.window_handles
+            try:
+                new_handles = self.driver.window_handles
+            except Exception:
+                return result
             new_tabs = set(new_handles) - set(current_handles)
             if new_tabs:
                 # Only switch to the last new tab opened, as only one tab can be active at a time.
@@ -366,11 +380,19 @@ class SeleniumDriver(BaseDriver):
 
     @_autoswitch_to_new_tab
     def click(self, id: int):
+        accessibility_element = self.accessibility_tree.element_by_id(id)
+        if accessibility_element.alert_action:
+            alert = self.driver.switch_to.alert
+            if accessibility_element.alert_action == "accept":
+                alert.accept()
+            elif accessibility_element.alert_action == "dismiss":
+                alert.dismiss()
+            return
+
         element = self.find_element(id)
         try:
             ActionChains(self.driver).move_to_element(element).click().perform()
         except ElementNotInteractableException:
-            # Fallback to direct click if ActionChains fails (e.g. for <option> elements)
             element.click()
 
     def drag_slider(self, id: int, value: float):
@@ -572,6 +594,50 @@ class SeleniumDriver(BaseDriver):
                 return self.execute("executeCdpCommand", {"cmd": cmd, "params": cmd_args})["value"]
 
             driver.execute_cdp_cmd = execute_cdp_cmd.__get__(driver)  # type: ignore[attr-defined]
+
+    def _detect_alert(self):
+        """Return the alert object if a JS alert/confirm/prompt is present, else None."""
+        try:
+            return self.driver.switch_to.alert
+        except NoAlertPresentException:
+            return None
+
+    @staticmethod
+    def _create_alert_nodes(alert) -> list[dict]:
+        """Create synthetic accessibility nodes representing an open alert dialog.
+
+        Returns a parent alertdialog with Accept/Dismiss buttons as children,
+        linked via childIds so the tree renders as:
+          <alertdialog name="...">
+            <button name="Accept" />
+            <button name="Dismiss" />
+          </alertdialog>
+        """
+        alert_text = alert.text
+        dialog_id = "-100"
+        accept_id = "-101"
+        dismiss_id = "-102"
+
+        return [
+            {
+                "nodeId": dialog_id,
+                "role": {"value": "alertdialog"},
+                "name": {"value": alert_text or "Alert"},
+                "childIds": [accept_id, dismiss_id],
+            },
+            {
+                "nodeId": accept_id,
+                "role": {"value": "button"},
+                "name": {"value": "Accept"},
+                "_alert_action": "accept",
+            },
+            {
+                "nodeId": dismiss_id,
+                "role": {"value": "button"},
+                "name": {"value": "Dismiss"},
+                "_alert_action": "dismiss",
+            },
+        ]
 
     def _enable_target_auto_attach(self):
         """Enable auto-attach to OOPIF targets for cross-origin iframe support."""

--- a/packages/typescript/src/accessibility/AccessibilityElement.ts
+++ b/packages/typescript/src/accessibility/AccessibilityElement.ts
@@ -1,16 +1,17 @@
 export interface AccessibilityElement {
-  id?: number | undefined;
-  backendNodeId?: number | undefined;
-  name?: string | undefined;
-  label?: string | undefined;
-  type?: string | undefined;
-  value?: string | undefined;
-  androidResourceId?: string | undefined;
-  androidClass?: string | undefined;
-  androidText?: string | undefined;
-  androidContentDesc?: string | undefined;
-  androidBounds?: string | undefined;
-  frame?: object | undefined;
-  locatorInfo?: Record<string, unknown> | undefined;
-  frameChain?: number[] | undefined; // For Selenium: chain of iframe backendNodeIds from root to element's frame
+  id?: number | undefined
+  backendNodeId?: number | undefined
+  name?: string | undefined
+  label?: string | undefined
+  type?: string | undefined
+  value?: string | undefined
+  androidResourceId?: string | undefined
+  androidClass?: string | undefined
+  androidText?: string | undefined
+  androidContentDesc?: string | undefined
+  androidBounds?: string | undefined
+  frame?: object | undefined
+  locatorInfo?: Record<string, unknown> | undefined
+  frameChain?: number[] | undefined // For Selenium: chain of iframe backendNodeIds from root to element's frame
+  alertAction?: string | undefined // "accept" or "dismiss" for alert dialog buttons
 }

--- a/packages/typescript/src/accessibility/ChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/accessibility/ChromiumAccessibilityTree.ts
@@ -1,39 +1,40 @@
-import { always } from "alwaysly";
-import { Element } from "domhandler";
-import { Xml } from "../Xml.ts";
-import type { AccessibilityElement } from "./AccessibilityElement.ts";
-import { BaseAccessibilityTree } from "./BaseAccessibilityTree.ts";
+import { always } from "alwaysly"
+import { Element } from "domhandler"
+import { Xml } from "../Xml.ts"
+import type { AccessibilityElement } from "./AccessibilityElement.ts"
+import { BaseAccessibilityTree } from "./BaseAccessibilityTree.ts"
 
 interface CDPNode {
-  nodeId?: string | number;
-  parentId?: string | number | null;
-  backendDOMNodeId?: number;
-  role?: { value?: string };
-  name?: { value?: string };
-  ignored?: boolean;
+  nodeId?: string | number
+  parentId?: string | number | null
+  backendDOMNodeId?: number
+  role?: { value?: string }
+  name?: { value?: string }
+  ignored?: boolean
   properties?: Array<{
-    name?: string;
-    value?: unknown;
-  }>;
-  childIds?: Array<string | number>;
-  _playwright_node?: boolean;
-  _locator_info?: Record<string, unknown>;
-  _frame_url?: string;
-  _frame?: object;
-  _parent_iframe_backend_node_id?: number;
-  _frame_chain?: number[];
+    name?: string
+    value?: unknown
+  }>
+  childIds?: Array<string | number>
+  _playwright_node?: boolean
+  _locator_info?: Record<string, unknown>
+  _frame_url?: string
+  _frame?: object
+  _parent_iframe_backend_node_id?: number
+  _frame_chain?: number[]
+  _alert_action?: string
 }
 
 export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
-  #cdpResponse: Record<string, unknown>;
-  #nextRawId: number = 0;
-  #raw: string | null = null;
-  #frameMap: Record<number, object> = {}; // raw_id -> Frame object for iframe support
-  #frameChainMap: Record<number, number[]> = {}; // raw_id -> frame chain (list of iframe backendNodeIds)
+  #cdpResponse: Record<string, unknown>
+  #nextRawId: number = 0
+  #raw: string | null = null
+  #frameMap: Record<number, object> = {} // raw_id -> Frame object for iframe support
+  #frameChainMap: Record<number, number[]> = {} // raw_id -> frame chain (list of iframe backendNodeIds)
 
   constructor(cdpResponse: Record<string, unknown>) {
-    super();
-    this.#cdpResponse = cdpResponse;
+    super()
+    this.#cdpResponse = cdpResponse
   }
 
   /** Create a ChromiumAccessibilityTree instance from pre-computed XML. */
@@ -41,66 +42,66 @@ export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
     xmlString: string,
     frameMap?: Record<number, object>,
   ): ChromiumAccessibilityTree {
-    const instance = new ChromiumAccessibilityTree({});
-    instance.#raw = xmlString;
+    const instance = new ChromiumAccessibilityTree({})
+    instance.#raw = xmlString
     if (frameMap) {
-      instance.#frameMap = frameMap;
+      instance.#frameMap = frameMap
     }
-    return instance;
+    return instance
   }
 
   /** Convert CDP response to raw XML format preserving all data. */
   toStr(): string {
     if (this.#raw !== null) {
-      return this.#raw;
+      return this.#raw
     }
 
-    const nodes = (this.#cdpResponse.nodes as CDPNode[] | undefined) ?? [];
+    const nodes = this.#cdpResponse.nodes as CDPNode[] | undefined ?? []
     if (nodes.length === 0) {
-      this.#raw = "";
-      return this.#raw;
+      this.#raw = ""
+      return this.#raw
     }
 
     // Create a lookup table for nodes by their ID
-    const nodeLookup: Record<string, CDPNode> = {};
+    const nodeLookup: Record<string, CDPNode> = {}
     for (const node of nodes) {
       if (node.nodeId !== undefined) {
-        nodeLookup[String(node.nodeId)] = node;
+        nodeLookup[String(node.nodeId)] = node
       }
     }
 
     // Build mapping: backendDOMNodeId -> list of iframe child root nodes
     // This allows us to inline iframe content inside their parent <Iframe> elements
-    const iframeChildren: Record<number, CDPNode[]> = {};
-    const trueRoots: CDPNode[] = [];
+    const iframeChildren: Record<number, CDPNode[]> = {}
+    const trueRoots: CDPNode[] = []
 
     for (const node of nodes) {
       if (!node.parentId) {
-        const parentIframeId = node._parent_iframe_backend_node_id;
+        const parentIframeId = node._parent_iframe_backend_node_id
         if (parentIframeId) {
-          iframeChildren[parentIframeId] ??= [];
-          iframeChildren[parentIframeId].push(node);
+          iframeChildren[parentIframeId] ??= []
+          iframeChildren[parentIframeId].push(node)
         } else {
-          trueRoots.push(node);
+          trueRoots.push(node)
         }
       }
     }
 
     // Build tree structure and convert to XML (only from true roots)
-    const rootNodes: Element[] = [];
+    const rootNodes: Element[] = []
     for (const node of trueRoots) {
-      const xmlNode = this.#nodeToXml(node, nodeLookup, iframeChildren);
-      rootNodes.push(xmlNode);
+      const xmlNode = this.#nodeToXml(node, nodeLookup, iframeChildren)
+      rootNodes.push(xmlNode)
     }
 
     // Combine all root nodes into a single XML string
-    let xmlString = "";
+    let xmlString = ""
     for (const root of rootNodes) {
-      xmlString += Xml.format([root]);
+      xmlString += Xml.format([root])
     }
 
-    this.#raw = xmlString;
-    return this.#raw;
+    this.#raw = xmlString
+    return this.#raw
   }
 
   /** Convert a CDP node to XML element, recursively processing children. */
@@ -110,114 +111,115 @@ export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
     iframeChildren: Record<number, CDPNode[]>,
   ): Element {
     // Create element with role as tag
-    const role = node.role?.value ?? "unknown";
-    const elem = new Element(role, {});
+    const role = node.role?.value ?? "unknown"
+    const elem = new Element(role, {})
 
     // Add our own sequential raw_id attribute
-    this.#nextRawId++;
-    elem.attribs["raw_id"] = String(this.#nextRawId);
+    this.#nextRawId++
+    elem.attribs["raw_id"] = String(this.#nextRawId)
 
     // Store frame reference if present (for iframe support)
     if ("_frame" in node && node._frame) {
-      this.#frameMap[this.#nextRawId] = node._frame;
+      this.#frameMap[this.#nextRawId] = node._frame
     }
 
     // Store frame chain if present (for Selenium nested frame switching)
     if ("_frame_chain" in node && node._frame_chain) {
-      this.#frameChainMap[this.#nextRawId] = node._frame_chain;
+      this.#frameChainMap[this.#nextRawId] = node._frame_chain
+    }
+
+    // Store alert action metadata for synthetic alert dialog buttons
+    if (node._alert_action) {
+      elem.attribs["_alert_action"] = node._alert_action
     }
 
     // Add all node attributes as XML attributes
     if ("backendDOMNodeId" in node && node.backendDOMNodeId !== undefined) {
-      elem.attribs["backendDOMNodeId"] = String(node.backendDOMNodeId);
+      elem.attribs["backendDOMNodeId"] = String(node.backendDOMNodeId)
     }
     if ("nodeId" in node && node.nodeId !== undefined) {
-      elem.attribs["nodeId"] = String(node.nodeId);
+      elem.attribs["nodeId"] = String(node.nodeId)
     }
     if ("ignored" in node && node.ignored !== undefined) {
-      elem.attribs["ignored"] = String(node.ignored);
+      elem.attribs["ignored"] = String(node.ignored)
     }
 
     // Store locator info for Playwright nodes (used for cross-origin iframes)
     if ("_playwright_node" in node && node._playwright_node) {
-      elem.attribs["_playwright_node"] = "true";
+      elem.attribs["_playwright_node"] = "true"
     }
     if ("_locator_info" in node && node._locator_info !== undefined) {
       // Store as JSON-like string for later parsing
-      elem.attribs["_locator_info"] = JSON.stringify(node._locator_info);
+      elem.attribs["_locator_info"] = JSON.stringify(node._locator_info)
     }
     if ("_frame_url" in node && node._frame_url !== undefined) {
-      elem.attribs["_frame_url"] = node._frame_url;
+      elem.attribs["_frame_url"] = node._frame_url
     }
 
     // Add name as attribute if present
     if ("name" in node && node.name && "value" in node.name) {
-      elem.attribs["name"] = String(node.name.value);
+      elem.attribs["name"] = String(node.name.value)
     }
 
     // Add properties as attributes
     for (const prop of node.properties || []) {
-      const propName = prop.name ?? "";
-      const propValue = prop.value ?? {};
+      const propName = prop.name ?? ""
+      const propValue = prop.value ?? {}
       if (
         typeof propValue === "object" &&
         propValue !== null &&
-        "value" in (propValue as Record<string, unknown>)
+        ("value" in propValue) as Record<string, unknown>
       ) {
         elem.attribs[propName] = String(
           (propValue as { value?: unknown }).value,
-        );
+        )
       } else if (typeof propValue === "object" && propValue !== null) {
         // Complex property values (like nodeList) are converted to empty string
-        elem.attribs[propName] = "";
+        elem.attribs[propName] = ""
       } else {
-        elem.attribs[propName] = String(propValue);
+        elem.attribs[propName] = String(propValue)
       }
     }
 
     // Process children recursively
     if (node.childIds) {
       for (const childIdAny of node.childIds) {
-        const childId = String(childIdAny);
+        const childId = String(childIdAny)
         if (nodeLookup[childId]) {
           const childElem = this.#nodeToXml(
             nodeLookup[childId],
             nodeLookup,
             iframeChildren,
-          );
-          childElem.parent = elem;
+          )
+          childElem.parent = elem
           if (elem.children.length > 0) {
-            const prev = elem.children[elem.children.length - 1];
-            always(prev);
-            prev.next = childElem;
-            childElem.prev = prev;
+            const prev = elem.children[elem.children.length - 1]
+            always(prev)
+            prev.next = childElem
+            childElem.prev = prev
           }
-          elem.children.push(childElem);
+          elem.children.push(childElem)
         }
       }
     }
 
     // Inline iframe content: if this element is an iframe, add its child trees
-    const backendNodeId = node.backendDOMNodeId;
+    const backendNodeId = node.backendDOMNodeId
     if (backendNodeId && iframeChildren[backendNodeId]) {
       for (const childRoot of iframeChildren[backendNodeId]) {
-        const childElem = this.#nodeToXml(
-          childRoot,
-          nodeLookup,
-          iframeChildren,
-        );
-        childElem.parent = elem;
+        const childElem = this.#nodeToXml(childRoot, nodeLookup, iframeChildren)
+        childElem.parent = elem
         if (elem.children.length > 0) {
-          const prev = elem.children[elem.children.length - 1];
-          always(prev);
-          prev.next = childElem;
-          childElem.prev = prev;
+          const prev = elem.children[elem.children.length - 1]
+          always(prev)
+          prev.next = childElem
+          childElem.prev = prev
         }
-        elem.children.push(childElem);
+        elem.children.push(childElem)
       }
     }
 
-    return elem;
+    return elem
   }
 
   /**
@@ -228,64 +230,73 @@ export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
    */
   elementById(rawId: number): AccessibilityElement {
     // Get raw XML with raw_id attributes
-    const rawXml = this.toStr();
-    const root = Xml.parseRoot(`<root>${rawXml}</root>`);
+    const rawXml = this.toStr()
+    const root = Xml.parseRoot(`<root>${rawXml}</root>`)
 
     // Find element with matching raw_id
     const findElement = (elem: Element, targetId: string): Element | null => {
       if (elem.attribs["raw_id"] === targetId) {
-        return elem;
+        return elem
       }
       for (const child of Array.from(elem.children)) {
-        const childEl = Xml.nodeAsTag(child);
+        const childEl = Xml.nodeAsTag(child)
         if (!childEl) {
-          continue;
+          continue
         }
-        const result = findElement(childEl, targetId);
+        const result = findElement(childEl, targetId)
         if (result !== null) {
-          return result;
+          return result
         }
       }
-      return null;
-    };
+      return null
+    }
 
-    const element = findElement(root, String(rawId));
+    const element = findElement(root, String(rawId))
     if (element === null) {
-      throw new Error(`No element with raw_id=${rawId} found`);
+      throw new Error(`No element with raw_id=${rawId} found`)
+    }
+
+    // Check if this is an alert dialog button
+    const alertAction = element.attribs["_alert_action"]
+    if (alertAction) {
+      return {
+        type: element.tagName,
+        alertAction,
+      }
     }
 
     // Check if this is a Playwright node (cross-origin iframe element)
     if (element.attribs["_playwright_node"] === "true") {
       // Check if it's a synthetic frame node
-      const frameUrl = element.attribs["_frame_url"];
+      const frameUrl = element.attribs["_frame_url"]
       if (frameUrl) {
         // Synthetic iframe node - no locator info, use frame reference
         return {
           type: element.tagName,
           frame: this.#frameMap[rawId],
           locatorInfo: { _synthetic_frame: true, _frame_url: frameUrl },
-        };
+        }
       }
 
       // Regular Playwright node with locator info
-      const locatorInfoStr = element.attribs["_locator_info"];
+      const locatorInfoStr = element.attribs["_locator_info"]
       const locatorInfo = locatorInfoStr
-        ? (JSON.parse(locatorInfoStr) as Record<string, unknown>)
-        : {};
+        ? JSON.parse(locatorInfoStr) as Record<string, unknown>
+        : {}
 
       return {
         type: element.tagName,
         frame: this.#frameMap[rawId],
         locatorInfo,
-      };
+      }
     }
 
     // Extract backendDOMNodeId for Chromium CDP nodes
-    const backendNodeIdStr = element.attribs["backendDOMNodeId"];
+    const backendNodeIdStr = element.attribs["backendDOMNodeId"]
     if (backendNodeIdStr === undefined) {
       throw new Error(
         `Element with raw_id=${rawId} has no backendDOMNodeId attribute`,
-      );
+      )
     }
 
     return {
@@ -293,44 +304,44 @@ export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
       backendNodeId: parseInt(backendNodeIdStr),
       frame: this.#frameMap[rawId],
       frameChain: this.#frameChainMap[rawId],
-    };
+    }
   }
 
   /** Scope the tree to a smaller subtree identified by raw_id. */
   scopeToArea(rawId: number): ChromiumAccessibilityTree {
-    const rawXml = this.toStr();
+    const rawXml = this.toStr()
 
     // Parse the XML
-    const root = Xml.parseRoot(`<root>${rawXml}</root>`);
+    const root = Xml.parseRoot(`<root>${rawXml}</root>`)
 
     // Find the element with the matching raw_id
     const findElement = (elem: Element, targetId: string): Element | null => {
       if (elem.attribs["raw_id"] === targetId) {
-        return elem;
+        return elem
       }
       for (const child of Array.from(elem.children)) {
-        const childEl = Xml.nodeAsTag(child);
+        const childEl = Xml.nodeAsTag(child)
         if (!childEl) {
-          continue;
+          continue
         }
-        const result = findElement(childEl, targetId);
+        const result = findElement(childEl, targetId)
         if (result !== null) {
-          return result;
+          return result
         }
       }
-      return null;
-    };
+      return null
+    }
 
-    const targetElem = findElement(root, String(rawId));
+    const targetElem = findElement(root, String(rawId))
 
     if (targetElem === null) {
       // If not found, return original tree
-      return this;
+      return this
     }
 
     // Convert the scoped element back to XML string
-    const scopedXml = Xml.format([targetElem]);
+    const scopedXml = Xml.format([targetElem])
 
-    return ChromiumAccessibilityTree.#fromXml(scopedXml, this.#frameMap);
+    return ChromiumAccessibilityTree.#fromXml(scopedXml, this.#frameMap)
   }
 }

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -1,73 +1,74 @@
-import { always, ensure } from "alwaysly";
-import type { CDPSession, Frame, Locator, Page } from "playwright-core";
-import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts";
-import { ChromiumAccessibilityTree } from "../accessibility/ChromiumAccessibilityTree.ts";
-import type { ToolClass } from "../tools/BaseTool.ts";
-import { ClickTool } from "../tools/ClickTool.ts";
-import { DragAndDropTool } from "../tools/DragAndDropTool.ts";
-import { HoverTool } from "../tools/HoverTool.ts";
-import { PressKeyTool } from "../tools/PressKeyTool.ts";
-import { TypeTool } from "../tools/TypeTool.ts";
-import { UploadTool } from "../tools/UploadTool.ts";
-import { getLogger } from "../utils/logger.ts";
-import { BaseDriver } from "./BaseDriver.ts";
-import type { Keys } from "./keys.ts";
+import { always, ensure } from "alwaysly"
+import type { CDPSession, Dialog, Frame, Locator, Page } from "playwright-core"
+import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts"
+import { ChromiumAccessibilityTree } from "../accessibility/ChromiumAccessibilityTree.ts"
+import type { ToolClass } from "../tools/BaseTool.ts"
+import { ClickTool } from "../tools/ClickTool.ts"
+import { DragAndDropTool } from "../tools/DragAndDropTool.ts"
+import { HoverTool } from "../tools/HoverTool.ts"
+import { PressKeyTool } from "../tools/PressKeyTool.ts"
+import { TypeTool } from "../tools/TypeTool.ts"
+import { UploadTool } from "../tools/UploadTool.ts"
+import { getLogger } from "../utils/logger.ts"
+import { BaseDriver } from "./BaseDriver.ts"
+import type { Keys } from "./keys.ts"
 // NOTE: While macros work well in Bun, it fails when using Alumium client from
 // Node.js. A solution could be "node:sea" module, but current Bun version
 // doesn't support it. For now, we bundle assets with scripts/generate.ts.
 // import { readScript } from "./scripts/scripts.js" with { type: "macro" };
-import { AppId } from "../AppId.ts";
-import { retry } from "../utils/retry.ts";
-import type { Driver } from "./Driver.ts";
+import { AppId } from "../AppId.ts"
+import { retry } from "../utils/retry.ts"
+import type { Driver } from "./Driver.ts"
 import {
   waiterScriptSource,
   waitForScriptSource,
-} from "./scripts/bundledScripts.ts";
+} from "./scripts/bundledScripts.ts"
 
 interface CDPNode {
-  nodeId: string;
-  parentId?: string | null;
-  role?: { value?: string };
-  name?: { value?: string };
-  childIds?: string[];
-  _playwright_node?: boolean;
-  _locator_info?: Record<string, unknown>;
-  _frame_url?: string;
-  _frame?: object;
-  _frame_chain?: number[];
-  _parent_iframe_backend_node_id?: number | undefined;
+  nodeId: string
+  parentId?: string | null
+  role?: { value?: string }
+  name?: { value?: string }
+  childIds?: string[]
+  _playwright_node?: boolean
+  _locator_info?: Record<string, unknown>
+  _frame_url?: string
+  _frame?: object
+  _frame_chain?: number[]
+  _parent_iframe_backend_node_id?: number | undefined
+  _alert_action?: string
 }
 
 interface CDPFrameInfo {
   frame: {
-    id: string;
-    url: string;
-  };
-  childFrames?: CDPFrameInfo[];
+    id: string
+    url: string
+  }
+  childFrames?: CDPFrameInfo[]
 }
 
 interface CDPFrameTree {
-  frameTree: CDPFrameInfo;
+  frameTree: CDPFrameInfo
 }
 
-const logger = getLogger(import.meta.url);
+const logger = getLogger(import.meta.url)
 
-const CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed";
+const CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed"
 
-const WAITER_SCRIPT = waiterScriptSource; // await readScript("waiter.js");
-const WAIT_FOR_SCRIPT = `(...scriptArgs) => new Promise((resolve) => { const arguments = [...scriptArgs, resolve]; ${waitForScriptSource /* await readScript("waitFor.js") */} })`;
+const WAITER_SCRIPT = waiterScriptSource // await readScript("waiter.js");
+const WAIT_FOR_SCRIPT = `(...scriptArgs) => new Promise((resolve) => { const arguments = [...scriptArgs, resolve]; ${waitForScriptSource /* await readScript("waitFor.js") */} })`
 
 const RETRY_OPTIONS: retry.Options = {
   maxAttempts: 2,
   backOff: 500,
   doRetry: (error) => error.message.includes(CONTEXT_WAS_DESTROYED_ERROR),
-};
+}
 
 export class PlaywrightDriver extends BaseDriver {
-  private client!: CDPSession;
-  page: Page;
-  private _pages: Page[] = [];
-  public platform: Driver.Platform = "chromium";
+  private client: CDPSession
+  page: Page
+  private _pages: Page[] = []
+  public platform: Driver.Platform = "chromium"
   public supportedTools: Set<ToolClass> = new Set([
     ClickTool,
     DragAndDropTool,
@@ -75,50 +76,56 @@ export class PlaywrightDriver extends BaseDriver {
     PressKeyTool,
     TypeTool,
     UploadTool,
-  ]);
+  ])
   public newTabTimeout = parseInt(
     process.env.ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT || "200",
     10,
-  );
-  public autoswitchToNewTab: boolean = true;
+  )
+  public autoswitchToNewTab: boolean = true
   public fullPageScreenshot: boolean =
     (process.env.ALUMNIUM_FULL_PAGE_SCREENSHOT || "false").toLowerCase() ===
-    "true";
+    "true"
+  private lastDialogInfo: {
+    type: string
+    message: string
+    defaultValue: string
+  } | null = null
 
   constructor(page: Page) {
-    super();
-    this.page = page;
-    this.setupPageTracking(page);
-    void this.initCDPSession();
+    super()
+    this.page = page
+    this.page.on("dialog", (dialog: Dialog) => this.onDialog(dialog))
+    this.setupPageTracking(page)
+    void this.initCDPSession()
   }
 
   private setupPageTracking(initialPage: Page): void {
-    this._pages = [initialPage];
-    this.attachPageListeners(initialPage);
+    this._pages = [initialPage]
+    this.attachPageListeners(initialPage)
   }
 
   private attachPageListeners(page: Page): void {
-    page.on("popup", (popup) => this.onPopup(popup));
-    page.on("close", (popup) => this.onPageClose(popup));
+    page.on("popup", (popup) => this.onPopup(popup))
+    page.on("close", (popup) => this.onPageClose(popup))
   }
 
   private onPopup(popup: Page) {
-    logger.debug(`New popup opened: ${popup.url()}`);
-    this._pages.push(popup);
-    this.attachPageListeners(popup); // Chain: new page also listens for popups
+    logger.debug(`New popup opened: ${popup.url()}`)
+    this._pages.push(popup)
+    this.attachPageListeners(popup) // Chain: new page also listens for popups
   }
 
   private onPageClose(page: Page): void {
-    const index = this._pages.indexOf(page);
+    const index = this._pages.indexOf(page)
     if (index !== -1) {
-      logger.debug(`Page closed: ${page.url()}`);
-      this._pages.splice(index, 1);
+      logger.debug(`Page closed: ${page.url()}`)
+      this._pages.splice(index, 1)
     }
   }
 
   private async initCDPSession(): Promise<void> {
-    this.client = await this.page.context().newCDPSession(this.page);
-    await this.enableTargetAutoAttach();
+    this.client = await this.page.context().newCDPSession(this.page)
+    await this.enableTargetAutoAttach()
   }
 
   private async enableTargetAutoAttach(): Promise<void> {
@@ -127,60 +134,127 @@ export class PlaywrightDriver extends BaseDriver {
         autoAttach: true,
         waitForDebuggerOnStart: false,
         flatten: true,
-      });
-      logger.debug("Enabled Target.setAutoAttach for OOPIF support");
+      })
+      logger.debug("Enabled Target.setAutoAttach for OOPIF support")
     } catch (error) {
       logger.debug(
-        `Could not enable Target.setAutoAttach: ${error instanceof Error ? error.message : String(error)}`,
-      );
+        `Could not enable Target.setAutoAttach: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
   }
 
+  /**
+   * Capture dialog info and auto-accept.
+   *
+   * Playwright requires dialogs to be resolved in the handler or the page
+   * freezes. Unlike Selenium, we cannot defer the accept/dismiss decision
+   * to the user.
+   */
+  private async onDialog(dialog: Dialog): Promise<void> {
+    this.lastDialogInfo = {
+      type: dialog.type(),
+      message: dialog.message(),
+      defaultValue: dialog.defaultValue(),
+    }
+    logger.debug(
+      `Dialog captured (${dialog.type()}): ${dialog.message().slice(0, 80)}`,
+    )
+    await dialog.accept()
+  }
+
+  /**
+   * Create synthetic nodes for a captured dialog.
+   *
+   * The dialog has already been auto-accepted (Playwright constraint), but
+   * we still expose it so check() and get() can verify dialog text.
+   */
+  private static createDialogNodes(dialogInfo: {
+    type: string
+    message: string
+  }): CDPNode[] {
+    const dialogId = "-100"
+    const acceptId = "-101"
+    const dismissId = "-102"
+
+    return [
+      {
+        nodeId: dialogId,
+        role: { value: "alertdialog" },
+        name: { value: `${dialogInfo.type}: ${dialogInfo.message}` },
+        childIds: [acceptId, dismissId],
+      },
+      {
+        nodeId: acceptId,
+        role: { value: "button" },
+        name: { value: "Accept" },
+        _alert_action: "accept",
+      },
+      {
+        nodeId: dismissId,
+        role: { value: "button" },
+        name: { value: "Dismiss" },
+        _alert_action: "dismiss",
+      },
+    ]
+  }
+
   async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
-    await this.waitForPageToLoad();
+    if (this.lastDialogInfo) {
+      const dialogInfo = this.lastDialogInfo
+      this.lastDialogInfo = null
+      return new ChromiumAccessibilityTree({
+        nodes: PlaywrightDriver.createDialogNodes(dialogInfo),
+      })
+    }
+
+    await this.waitForPageToLoad()
 
     // Get frame tree to enumerate all frames (same approach as Selenium)
     const frameTree = (await this.client.send(
       "Page.getFrameTree",
-    )) as CDPFrameTree;
-    const frameIds = this.getAllFrameIds(frameTree.frameTree);
-    const mainFrameId = frameTree.frameTree.frame.id;
-    logger.debug(`Found ${frameIds.length} frames`);
+    )) as CDPFrameTree
+    const frameIds = this.getAllFrameIds(frameTree.frameTree)
+    const mainFrameId = frameTree.frameTree.frame.id
+    logger.debug(`Found ${frameIds.length} frames`)
 
     // Get all targets including OOPIFs (cross-origin iframes)
-    let oopifTargets: Array<{ url?: string; type?: string }> = [];
+    let oopifTargets: Array<{ url?: string type?: string }> = []
     try {
-      const targets = await this.client.send("Target.getTargets");
-      oopifTargets = this.getOopifTargets(targets, frameTree);
-      logger.debug(`Found ${oopifTargets.length} cross-origin iframes`);
+      const targets = await this.client.send("Target.getTargets")
+      oopifTargets = this.getOopifTargets(targets, frameTree)
+      logger.debug(`Found ${oopifTargets.length} cross-origin iframes`)
     } catch (error) {
       logger.debug(
-        `Could not get OOPIF targets: ${error instanceof Error ? error.message : String(error)}`,
-      );
+        `Could not get OOPIF targets: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
 
     // Build mapping: frameId -> backendNodeId of the iframe element containing the frame
-    const frameToIframeMap: Map<string, number> = new Map();
+    const frameToIframeMap: Map<string, number> = new Map()
     // Build mapping: frameId -> parent frameId (for nested frames)
-    const frameParentMap: Map<string, string> = new Map();
+    const frameParentMap: Map<string, string> = new Map()
     await this.buildFrameHierarchy(
       frameTree.frameTree,
       mainFrameId,
       frameToIframeMap,
       frameParentMap,
-    );
+    )
 
     // Build mapping: frameId -> Playwright Frame object (for element finding)
-    const frameIdToPlaywrightFrame: Map<string, Frame> = new Map();
+    const frameIdToPlaywrightFrame: Map<string, Frame> = new Map()
     for (const frame of this.page.frames()) {
-      const cdpFrameId = this.findCdpFrameIdByUrl(frameTree, frame.url());
+      const cdpFrameId = this.findCdpFrameIdByUrl(frameTree, frame.url())
       if (cdpFrameId) {
-        frameIdToPlaywrightFrame.set(cdpFrameId, frame);
+        frameIdToPlaywrightFrame.set(cdpFrameId, frame)
       }
     }
 
     // Aggregate accessibility nodes from all frames
-    const allNodes: CDPNode[] = [];
+    const allNodes: CDPNode[] = []
     for (const frameId of frameIds) {
       try {
         const response = (await this.client.send(
@@ -188,119 +262,134 @@ export class PlaywrightDriver extends BaseDriver {
           {
             frameId,
           },
-        )) as { nodes: CDPNode[] };
-        const nodes = response.nodes || [];
+        )) as { nodes: CDPNode[] }
+        const nodes = response.nodes || []
         logger.debug(
           `  -> Frame ${frameId.slice(0, 20)}...: ${nodes.length} nodes`,
-        );
+        )
 
         // Calculate frame chain for this frame
         const frameChain = this.getFrameChain(
           frameId,
           frameToIframeMap,
           frameParentMap,
-        );
+        )
         // Get Playwright frame reference
         const playwrightFrame =
-          frameIdToPlaywrightFrame.get(frameId) || this.page.mainFrame();
+          frameIdToPlaywrightFrame.get(frameId) || this.page.mainFrame()
 
         // Tag ALL nodes from child frames with their frame chain
         for (const node of nodes) {
           if (frameChain.length > 0) {
-            node._frame_chain = frameChain;
+            node._frame_chain = frameChain
           }
           // Also keep frame reference for Playwright-specific element finding
-          node._frame = playwrightFrame;
+          node._frame = playwrightFrame
           // Tag root nodes with their parent iframe's backendNodeId (for tree inlining)
           if (node.parentId === undefined && frameToIframeMap.has(frameId)) {
-            node._parent_iframe_backend_node_id = frameToIframeMap.get(frameId);
+            node._parent_iframe_backend_node_id = frameToIframeMap.get(frameId)
           }
-          allNodes.push(node);
+          allNodes.push(node)
         }
       } catch (error) {
         logger.debug(
-          `  -> Frame ${frameId.slice(0, 20)}...: failed (${error instanceof Error ? error.message : String(error)})`,
-        );
+          `  -> Frame ${frameId.slice(0, 20)}...: failed (${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        )
       }
     }
 
     // Process cross-origin iframes via Playwright query fallback
     for (const oopif of oopifTargets) {
       try {
-        const nodes = await this.getCrossOriginFrameNodes(oopif);
-        allNodes.push(...nodes);
+        const nodes = await this.getCrossOriginFrameNodes(oopif)
+        allNodes.push(...nodes)
         logger.debug(
           `  -> Cross-origin iframe ${(oopif.url || "").slice(0, 40)}...: ${nodes.length} nodes`,
-        );
+        )
       } catch (error) {
         logger.debug(
-          `  -> Cross-origin iframe ${(oopif.url || "").slice(0, 40)}...: failed (${error instanceof Error ? error.message : String(error)})`,
-        );
+          `  -> Cross-origin iframe ${(oopif.url || "").slice(0, 40)}...: failed (${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        )
       }
     }
 
     // Process Playwright frames not in CDP tree (e.g., data: URI iframes)
-    const cdpFrameUrls = new Set(this.getAllFrameUrls(frameTree.frameTree));
-    const oopifUrls = new Set(oopifTargets.map((t) => t.url || ""));
+    const cdpFrameUrls = new Set(this.getAllFrameUrls(frameTree.frameTree))
+    const oopifUrls = new Set(oopifTargets.map((t) => t.url || ""))
     for (const frame of this.page.frames()) {
-      const frameUrl = frame.url();
+      const frameUrl = frame.url()
       if (!cdpFrameUrls.has(frameUrl) && !oopifUrls.has(frameUrl)) {
         logger.debug(
           `Processing Playwright-only frame: ${frameUrl.slice(0, 60)}`,
-        );
+        )
         try {
           const iframeBackendNodeId =
-            await this.getIframeBackendNodeIdByUrl(frameUrl);
+            await this.getIframeBackendNodeIdByUrl(frameUrl)
           const nodes = await this.queryFrameInteractiveElements(
             frame,
             iframeBackendNodeId,
-          );
-          allNodes.push(...nodes);
+          )
+          allNodes.push(...nodes)
           logger.debug(
             `  -> Playwright-only frame ${frameUrl.slice(0, 40)}...: ${nodes.length} nodes`,
-          );
+          )
         } catch (error) {
           logger.debug(
-            `  -> Playwright-only frame ${frameUrl.slice(0, 40)}...: failed (${error instanceof Error ? error.message : String(error)})`,
-          );
+            `  -> Playwright-only frame ${frameUrl.slice(0, 40)}...: failed (${
+              error instanceof Error ? error.message : String(error)
+            })`,
+          )
         }
       }
     }
 
-    return new ChromiumAccessibilityTree({ nodes: allNodes });
+    return new ChromiumAccessibilityTree({ nodes: allNodes })
   }
 
   async click(id: number): Promise<void> {
-    const element = await this.findElement(id);
+    const tree = await this.getAccessibilityTree()
+    const accessibilityElement = tree.elementById(id)
+    if (accessibilityElement.alertAction) {
+      logger.debug(
+        `Alert action acknowledged: ${accessibilityElement.alertAction}`,
+      )
+      return
+    }
+
+    const element = await this.findElement(id)
     const tagName = await element.evaluate(
       (el: { tagName: string }) => el.tagName,
-    );
+    )
     if (tagName?.toLowerCase() === "option") {
-      const value = await element.evaluate((el: { value: string }) => el.value);
+      const value = await element.evaluate((el: { value: string }) => el.value)
       await this.autoswitchToNewTabAction(async () => {
-        await element.locator("xpath=parent::select").selectOption(value);
-      });
+        await element.locator("xpath=parent::select").selectOption(value)
+      })
     } else {
       await this.autoswitchToNewTabAction(async () => {
-        await element.click({ force: true });
-      });
+        await element.click({ force: true })
+      })
     }
   }
 
   async dragSlider(id: number, value: number): Promise<void> {
-    const element = await this.findElement(id);
-    await element.fill(String(value));
+    const element = await this.findElement(id)
+    await element.fill(String(value))
   }
 
   async dragAndDrop(fromId: number, toId: number): Promise<void> {
-    const fromElement = await this.findElement(fromId);
-    const toElement = await this.findElement(toId);
-    await fromElement.dragTo(toElement);
+    const fromElement = await this.findElement(fromId)
+    const toElement = await this.findElement(toId)
+    await fromElement.dragTo(toElement)
   }
 
   async hover(id: number): Promise<void> {
-    const element = await this.findElement(id);
-    await element.hover();
+    const element = await this.findElement(id)
+    await element.hover()
   }
 
   async pressKey(key: Keys.Key): Promise<void> {
@@ -309,183 +398,182 @@ export class PlaywrightDriver extends BaseDriver {
       Enter: "Enter",
       Escape: "Escape",
       Tab: "Tab",
-    };
+    }
 
     await this.autoswitchToNewTabAction(() =>
       this.page.keyboard.press(keyMap[key]),
-    );
+    )
   }
 
   async quit(): Promise<void> {
-    await this.page.close();
+    await this.page.close()
   }
 
   async back(): Promise<void> {
-    await this.page.goBack();
+    await this.page.goBack()
   }
 
   async visit(url: string): Promise<void> {
-    await this.page.goto(url);
+    await this.page.goto(url)
   }
 
   async scrollTo(id: number): Promise<void> {
-    const element = await this.findElement(id);
-    await element.scrollIntoViewIfNeeded();
+    const element = await this.findElement(id)
+    await element.scrollIntoViewIfNeeded()
   }
 
   async screenshot(): Promise<string> {
     return retry(RETRY_OPTIONS, async () => {
       const buffer = await this.page.screenshot({
         fullPage: this.fullPageScreenshot,
-      });
-      return buffer.toString("base64");
-    });
+      })
+      return buffer.toString("base64")
+    })
   }
 
   async title(): Promise<string> {
-    return retry(RETRY_OPTIONS, () => this.page.title());
+    return retry(RETRY_OPTIONS, () => this.page.title())
   }
 
   async type(id: number, text: string): Promise<void> {
-    const element = await this.findElement(id);
-    await element.fill(text);
+    const element = await this.findElement(id)
+    await element.fill(text)
   }
 
   async upload(id: number, paths: string[]): Promise<void> {
-    const element = await this.findElement(id);
+    const element = await this.findElement(id)
     const [fileChooser] = await Promise.all([
       this.page.waitForEvent("filechooser", { timeout: 5000 }),
       element.click({ force: true }),
-    ]);
-    await fileChooser.setFiles(paths);
+    ])
+    await fileChooser.setFiles(paths)
   }
 
   url(): Promise<string> {
-    return retry(RETRY_OPTIONS, async () => this.page.url());
+    return retry(RETRY_OPTIONS, async () => this.page.url())
   }
 
   async app(): Promise<AppId> {
-    return AppId.parse(this.page.url());
+    return AppId.parse(this.page.url())
   }
 
   async findElement(id: number): Promise<Locator> {
-    const tree = await this.getAccessibilityTree();
-    const accessibilityElement = tree.elementById(id);
+    const tree = await this.getAccessibilityTree()
+    const accessibilityElement = tree.elementById(id)
 
     // Get frame reference (default to main frame)
-    const frame = (accessibilityElement.frame ||
-      this.page.mainFrame()) as Frame;
+    const frame = (accessibilityElement.frame || this.page.mainFrame()) as Frame
 
     // Handle Playwright nodes (cross-origin iframes) using locator info
     if (accessibilityElement.locatorInfo) {
       return this.findElementByLocatorInfo(
         frame,
         accessibilityElement.locatorInfo,
-      );
+      )
     }
 
     // Existing CDP node logic
-    const backendNodeId = accessibilityElement.backendNodeId!;
+    const backendNodeId = accessibilityElement.backendNodeId!
 
     // Beware!
-    await this.client.send("DOM.enable");
-    await this.client.send("DOM.getFlattenedDocument");
+    await this.client.send("DOM.enable")
+    await this.client.send("DOM.getFlattenedDocument")
     const nodeIds = await this.client.send(
       "DOM.pushNodesByBackendIdsToFrontend",
       {
         backendNodeIds: [backendNodeId],
       },
-    );
-    const nodeId = nodeIds.nodeIds[0];
-    ensure(nodeId);
+    )
+    const nodeId = nodeIds.nodeIds[0]
+    ensure(nodeId)
     await this.client.send("DOM.setAttributeValue", {
       nodeId,
       name: "data-alumnium-id",
       value: String(backendNodeId),
-    });
+    })
     // TODO: We need to remove the attribute after we are done with the element,
     // but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
-    return frame.locator(`css=[data-alumnium-id='${backendNodeId}']`);
+    return frame.locator(`css=[data-alumnium-id='${backendNodeId}']`)
   }
 
   async executeScript(script: string): Promise<void> {
-    await this.page.evaluate(`() => { ${script} }`);
+    await this.page.evaluate(`() => { ${script} }`)
   }
 
   async printToPdf(filepath: string): Promise<void> {
-    await this.page.pdf({ path: filepath });
+    await this.page.pdf({ path: filepath })
   }
 
   async switchToNextTab(): Promise<void> {
     // Brief wait to allow popup handlers to complete
-    await this.page.waitForTimeout(100);
+    await this.page.waitForTimeout(100)
     if (this._pages.length <= 1) {
-      return; // Only one tab, nothing to switch
+      return // Only one tab, nothing to switch
     }
 
-    const currentIndex = this._pages.indexOf(this.page);
-    const nextIndex = (currentIndex + 1) % this._pages.length; // Wrap to first
+    const currentIndex = this._pages.indexOf(this.page)
+    const nextIndex = (currentIndex + 1) % this._pages.length // Wrap to first
 
-    always(this._pages[nextIndex]);
-    this.page = this._pages[nextIndex];
-    await this.initCDPSession();
-    await this.page.waitForLoadState();
+    always(this._pages[nextIndex])
+    this.page = this._pages[nextIndex]
+    await this.initCDPSession()
+    await this.page.waitForLoadState()
   }
 
   async switchToPreviousTab(): Promise<void> {
     // Brief wait to allow popup handlers to complete
-    await this.page.waitForTimeout(100);
+    await this.page.waitForTimeout(100)
     if (this._pages.length <= 1) {
-      return; // Only one tab, nothing to switch
+      return // Only one tab, nothing to switch
     }
 
-    const currentIndex = this._pages.indexOf(this.page);
+    const currentIndex = this._pages.indexOf(this.page)
     const prevIndex =
-      (currentIndex - 1 + this._pages.length) % this._pages.length; // Wrap to last
+      (currentIndex - 1 + this._pages.length) % this._pages.length // Wrap to last
 
-    always(this._pages[prevIndex]);
-    this.page = this._pages[prevIndex];
-    await this.initCDPSession();
-    await this.page.waitForLoadState();
+    always(this._pages[prevIndex])
+    this.page = this._pages[prevIndex]
+    await this.initCDPSession()
+    await this.page.waitForLoadState()
   }
 
   async wait(seconds: number): Promise<void> {
-    const clampedSeconds = Math.max(1, Math.min(30, seconds));
-    await new Promise((resolve) => setTimeout(resolve, clampedSeconds * 1000));
+    const clampedSeconds = Math.max(1, Math.min(30, seconds))
+    await new Promise((resolve) => setTimeout(resolve, clampedSeconds * 1000))
   }
 
   async waitForSelector(selector: string, timeout?: number): Promise<void> {
-    const timeoutMs = (timeout ?? 10) * 1000;
+    const timeoutMs = (timeout ?? 10) * 1000
     await this.page.waitForSelector(selector, {
       state: "visible",
       timeout: timeoutMs,
-    });
+    })
   }
 
   async grantPermissions(permissions: string[]): Promise<void> {
-    await this.page.context().grantPermissions(permissions);
+    await this.page.context().grantPermissions(permissions)
   }
 
   private async waitForPageToLoad(): Promise<void> {
     return retry(RETRY_OPTIONS, async () => {
-      logger.debug("Waiting for page to finish loading:");
-      await this.page.evaluate(WAITER_SCRIPT);
-      const error: unknown = await this.page.evaluate(`(${WAIT_FOR_SCRIPT})()`);
+      logger.debug("Waiting for page to finish loading:")
+      await this.page.evaluate(WAITER_SCRIPT)
+      const error: unknown = await this.page.evaluate(`(${WAIT_FOR_SCRIPT})()`)
       if (error) {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        logger.debug(`  <- Failed to wait for page to load: ${String(error)}`);
+        logger.debug(`  <- Failed to wait for page to load: ${String(error)}`)
       } else {
-        logger.debug("  <- Page finished loading");
+        logger.debug("  <- Page finished loading")
       }
-    });
+    })
   }
 
   private async autoswitchToNewTabAction(
     action: () => Promise<void>,
   ): Promise<void> {
     if (!this.autoswitchToNewTab) {
-      await action();
-      return;
+      await action()
+      return
     }
 
     const [newPage] = await Promise.all([
@@ -494,31 +582,31 @@ export class PlaywrightDriver extends BaseDriver {
         .waitForEvent("page", { timeout: this.newTabTimeout })
         .catch(() => null),
       action(),
-    ]);
+    ])
 
     if (newPage) {
       logger.debug(
         `Auto-switching to new tab ${newPage.url()} (${await newPage.title()})`,
-      );
-      this.page = newPage;
-      await this.initCDPSession();
+      )
+      this.page = newPage
+      await this.initCDPSession()
     }
   }
 
   private getAllFrameIds(frameInfo: CDPFrameInfo): string[] {
-    const frameIds: string[] = [frameInfo.frame.id];
+    const frameIds: string[] = [frameInfo.frame.id]
     for (const child of frameInfo.childFrames || []) {
-      frameIds.push(...this.getAllFrameIds(child));
+      frameIds.push(...this.getAllFrameIds(child))
     }
-    return frameIds;
+    return frameIds
   }
 
   private getAllFrameUrls(frameInfo: CDPFrameInfo): string[] {
-    const urls: string[] = [frameInfo.frame.url || ""];
+    const urls: string[] = [frameInfo.frame.url || ""]
     for (const child of frameInfo.childFrames || []) {
-      urls.push(...this.getAllFrameUrls(child));
+      urls.push(...this.getAllFrameUrls(child))
     }
-    return urls;
+    return urls
   }
 
   private async buildFrameHierarchy(
@@ -528,26 +616,28 @@ export class PlaywrightDriver extends BaseDriver {
     frameParentMap: Map<string, string>,
     parentFrameId?: string,
   ): Promise<void> {
-    const frameId = frameInfo.frame.id;
+    const frameId = frameInfo.frame.id
 
     if (frameId !== mainFrameId) {
-      await this.client.send("DOM.enable");
+      await this.client.send("DOM.enable")
       try {
         const ownerInfo = await this.client.send("DOM.getFrameOwner", {
           frameId,
-        });
-        frameToIframeMap.set(frameId, ownerInfo.backendNodeId);
+        })
+        frameToIframeMap.set(frameId, ownerInfo.backendNodeId)
         logger.debug(
           `Frame ${frameId.slice(0, 20)}... owned by iframe backendNodeId=${ownerInfo.backendNodeId}`,
-        );
+        )
       } catch (error) {
         logger.debug(
-          `Could not get frame owner for ${frameId.slice(0, 20)}...: ${error instanceof Error ? error.message : String(error)}`,
-        );
+          `Could not get frame owner for ${frameId.slice(0, 20)}...: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        )
       }
 
       if (parentFrameId) {
-        frameParentMap.set(frameId, parentFrameId);
+        frameParentMap.set(frameId, parentFrameId)
       }
     }
 
@@ -558,7 +648,7 @@ export class PlaywrightDriver extends BaseDriver {
         frameToIframeMap,
         frameParentMap,
         frameId,
-      );
+      )
     }
   }
 
@@ -567,106 +657,108 @@ export class PlaywrightDriver extends BaseDriver {
     frameToIframeMap: Map<string, number>,
     frameParentMap: Map<string, string>,
   ): number[] {
-    const chain: number[] = [];
-    let currentFrameId = frameId;
+    const chain: number[] = []
+    let currentFrameId = frameId
 
     while (frameToIframeMap.has(currentFrameId)) {
-      const iframeBackendNodeId = frameToIframeMap.get(currentFrameId)!;
-      chain.unshift(iframeBackendNodeId);
+      const iframeBackendNodeId = frameToIframeMap.get(currentFrameId)!
+      chain.unshift(iframeBackendNodeId)
       if (frameParentMap.has(currentFrameId)) {
-        currentFrameId = frameParentMap.get(currentFrameId)!;
+        currentFrameId = frameParentMap.get(currentFrameId)!
       } else {
-        break;
+        break
       }
     }
 
-    return chain;
+    return chain
   }
 
   private getOopifTargets(
-    targets: { targetInfos?: Array<{ type?: string; url?: string }> },
+    targets: { targetInfos?: Array<{ type?: string url?: string }> },
     frameTree: CDPFrameTree,
-  ): Array<{ url?: string; type?: string }> {
-    const frameUrls = new Set(this.getAllFrameUrls(frameTree.frameTree));
-    const oopifTargets: Array<{ url?: string; type?: string }> = [];
+  ): Array<{ url?: string type?: string }> {
+    const frameUrls = new Set(this.getAllFrameUrls(frameTree.frameTree))
+    const oopifTargets: Array<{ url?: string type?: string }> = []
 
     for (const target of targets.targetInfos || []) {
       if (target.type === "iframe") {
-        const url = target.url || "";
+        const url = target.url || ""
         if (url && !frameUrls.has(url)) {
-          oopifTargets.push(target);
-          logger.debug(`Detected OOPIF target: ${url.slice(0, 60)}`);
+          oopifTargets.push(target)
+          logger.debug(`Detected OOPIF target: ${url.slice(0, 60)}`)
         }
       }
     }
 
-    return oopifTargets;
+    return oopifTargets
   }
 
   private async getCrossOriginFrameNodes(oopifTarget: {
-    url?: string;
+    url?: string
   }): Promise<CDPNode[]> {
-    const url = oopifTarget.url || "";
+    const url = oopifTarget.url || ""
 
-    const frame = this.findPlaywrightFrameByUrl(url);
+    const frame = this.findPlaywrightFrameByUrl(url)
     if (!frame) {
       logger.debug(
         `Could not find Playwright frame for URL: ${url.slice(0, 60)}`,
-      );
-      return [];
+      )
+      return []
     }
 
-    const iframeBackendNodeId = await this.getIframeBackendNodeIdByUrl(url);
-    return await this.queryFrameInteractiveElements(frame, iframeBackendNodeId);
+    const iframeBackendNodeId = await this.getIframeBackendNodeIdByUrl(url)
+    return await this.queryFrameInteractiveElements(frame, iframeBackendNodeId)
   }
 
   private findPlaywrightFrameByUrl(frameUrl: string): Frame | null {
     for (const frame of this.page.frames()) {
       if (frame.url() === frameUrl) {
-        return frame;
+        return frame
       }
     }
     if (frameUrl === "about:blank") {
       for (const frame of this.page.frames()) {
         if (frame.url() === "about:blank" || !frame.url()) {
-          return frame;
+          return frame
         }
       }
     }
-    logger.debug(`Could not find Playwright frame for URL: ${frameUrl}`);
-    return null;
+    logger.debug(`Could not find Playwright frame for URL: ${frameUrl}`)
+    return null
   }
 
   private async getIframeBackendNodeIdByUrl(
     url: string,
   ): Promise<number | null> {
     try {
-      await this.client.send("DOM.enable");
-      const doc = await this.client.send("DOM.getDocument");
+      await this.client.send("DOM.enable")
+      const doc = await this.client.send("DOM.getDocument")
       const result = await this.client.send("DOM.querySelectorAll", {
         nodeId: doc.root.nodeId,
         selector: `iframe[src='${url}']`,
-      });
+      })
 
       if (result.nodeIds && typeof result.nodeIds[0] === "number") {
-        const nodeId = result.nodeIds[0];
-        const node = await this.client.send("DOM.describeNode", { nodeId });
-        return node.node?.backendNodeId ?? null;
+        const nodeId = result.nodeIds[0]
+        const node = await this.client.send("DOM.describeNode", { nodeId })
+        return node.node?.backendNodeId ?? null
       }
     } catch (error) {
       logger.debug(
-        `Could not get iframe backendNodeId: ${error instanceof Error ? error.message : String(error)}`,
-      );
+        `Could not get iframe backendNodeId: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
-    return null;
+    return null
   }
 
   private async queryFrameInteractiveElements(
     frame: Frame,
     iframeBackendNodeId: number | null,
   ): Promise<CDPNode[]> {
-    const nodes: CDPNode[] = [];
-    let nodeId = -1;
+    const nodes: CDPNode[] = []
+    let nodeId = -1
 
     try {
       const interactiveSelectors: Array<[string, string]> = [
@@ -679,20 +771,20 @@ export class PlaywrightDriver extends BaseDriver {
         ["select", "combobox"],
         ["textarea", "textbox"],
         ["[aria-label]", "generic"],
-      ];
+      ]
 
       for (const [selector, role] of interactiveSelectors) {
         try {
-          const elements = frame.locator(selector);
-          const count = await elements.count();
+          const elements = frame.locator(selector)
+          const count = await elements.count()
           for (let i = 0; i < Math.min(count, 20); i++) {
-            const element = elements.nth(i);
+            const element = elements.nth(i)
             try {
-              const text = await element.textContent({ timeout: 1000 });
+              const text = await element.textContent({ timeout: 1000 })
               const ariaLabel = await element.getAttribute("aria-label", {
                 timeout: 1000,
-              });
-              const name = ariaLabel || (text ? text.trim().slice(0, 50) : "");
+              })
+              const name = ariaLabel || (text ? text.trim().slice(0, 50) : "")
 
               if (name) {
                 const syntheticNode: CDPNode = {
@@ -702,15 +794,15 @@ export class PlaywrightDriver extends BaseDriver {
                   _playwright_node: true,
                   _locator_info: { selector, nth: i },
                   _frame: frame,
-                };
-
-                if (iframeBackendNodeId !== null) {
-                  syntheticNode._frame_chain = [iframeBackendNodeId];
                 }
 
-                nodes.push(syntheticNode);
-                nodeId--;
-                logger.debug(`  -> Found ${role}: ${name.slice(0, 40)}`);
+                if (iframeBackendNodeId !== null) {
+                  syntheticNode._frame_chain = [iframeBackendNodeId]
+                }
+
+                nodes.push(syntheticNode)
+                nodeId--
+                logger.debug(`  -> Found ${role}: ${name.slice(0, 40)}`)
               }
             } catch {
               // Element query failed, skip
@@ -723,14 +815,16 @@ export class PlaywrightDriver extends BaseDriver {
 
       logger.debug(
         `  -> Created ${nodes.length} synthetic nodes for cross-origin frame`,
-      );
+      )
     } catch (error) {
       logger.error(
-        `  -> Failed to query frame content: ${error instanceof Error ? error.message : String(error)}`,
-      );
+        `  -> Failed to query frame content: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      )
     }
 
-    return nodes;
+    return nodes
   }
 
   private findCdpFrameIdByUrl(
@@ -739,17 +833,17 @@ export class PlaywrightDriver extends BaseDriver {
   ): string | null {
     const searchFrame = (frameInfo: CDPFrameInfo): string | null => {
       if (frameInfo.frame.url === targetUrl) {
-        return frameInfo.frame.id;
+        return frameInfo.frame.id
       }
 
       for (const child of frameInfo.childFrames || []) {
-        const result = searchFrame(child);
-        if (result) return result;
+        const result = searchFrame(child)
+        if (result) return result
       }
-      return null;
-    };
+      return null
+    }
 
-    return searchFrame(cdpFrameTree.frameTree);
+    return searchFrame(cdpFrameTree.frameTree)
   }
 
   private findElementByLocatorInfo(
@@ -759,13 +853,11 @@ export class PlaywrightDriver extends BaseDriver {
     // Handle synthetic frame nodes
     if (locatorInfo._synthetic_frame) {
       const frameUrl =
-        typeof locatorInfo._frame_url === "string"
-          ? locatorInfo._frame_url
-          : "";
+        typeof locatorInfo._frame_url === "string" ? locatorInfo._frame_url : ""
       logger.debug(
         `Synthetic frame node clicked, returning frame locator for: ${frameUrl.slice(0, 80)}`,
-      );
-      return frame.locator("body");
+      )
+      return frame.locator("body")
     }
 
     // Handle selector+nth-based locators (from queried frame content)
@@ -773,30 +865,30 @@ export class PlaywrightDriver extends BaseDriver {
       typeof locatorInfo.selector === "string" &&
       typeof locatorInfo.nth === "number"
     ) {
-      const selector = locatorInfo.selector;
-      const nth = locatorInfo.nth;
-      logger.debug(`Finding element by selector: ${selector} (nth=${nth})`);
-      return frame.locator(selector).nth(nth);
+      const selector = locatorInfo.selector
+      const nth = locatorInfo.nth
+      logger.debug(`Finding element by selector: ${selector} (nth=${nth})`)
+      return frame.locator(selector).nth(nth)
     }
 
-    const role = locatorInfo.role;
-    const name = locatorInfo.name;
+    const role = locatorInfo.role
+    const name = locatorInfo.name
 
     logger.debug(
       `Finding element by locator info: role=${String(role)}, name=${String(name)}`,
-    );
+    )
 
     // Use Playwright's getByRole for accessibility-based element finding
     if (typeof role === "string" && typeof name === "string") {
-      return frame.getByRole(role as never, { name });
+      return frame.getByRole(role as never, { name })
     } else if (typeof role === "string") {
-      return frame.getByRole(role as never);
+      return frame.getByRole(role as never)
     } else if (typeof name === "string") {
-      return frame.getByText(name);
+      return frame.getByText(name)
     } else {
       throw new Error(
         `Cannot find element: no role or name in locator_info: ${JSON.stringify(locatorInfo)}`,
-      );
+      )
     }
   }
 }

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -1,69 +1,69 @@
-import * as fs from "fs/promises";
+import * as fs from "fs/promises"
 
 import {
   By,
   Key as SeleniumKey,
   WebDriver,
   WebElement,
-} from "selenium-webdriver";
+} from "selenium-webdriver"
 import {
   ElementNotInteractableError,
   NoSuchSessionError,
-} from "selenium-webdriver/lib/error.js";
+} from "selenium-webdriver/lib/error.js"
 
-import { always } from "alwaysly";
-import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts";
-import { ChromiumAccessibilityTree } from "../accessibility/ChromiumAccessibilityTree.ts";
-import type { ToolClass } from "../tools/BaseTool.ts";
-import { ClickTool } from "../tools/ClickTool.ts";
-import { DragAndDropTool } from "../tools/DragAndDropTool.ts";
-import { HoverTool } from "../tools/HoverTool.ts";
-import { PressKeyTool } from "../tools/PressKeyTool.ts";
-import { TypeTool } from "../tools/TypeTool.ts";
-import { UploadTool } from "../tools/UploadTool.ts";
-import { getLogger } from "../utils/logger.ts";
-import { BaseDriver } from "./BaseDriver.ts";
-import { Keys } from "./keys.ts";
+import { always } from "alwaysly"
+import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts"
+import { ChromiumAccessibilityTree } from "../accessibility/ChromiumAccessibilityTree.ts"
+import type { ToolClass } from "../tools/BaseTool.ts"
+import { ClickTool } from "../tools/ClickTool.ts"
+import { DragAndDropTool } from "../tools/DragAndDropTool.ts"
+import { HoverTool } from "../tools/HoverTool.ts"
+import { PressKeyTool } from "../tools/PressKeyTool.ts"
+import { TypeTool } from "../tools/TypeTool.ts"
+import { UploadTool } from "../tools/UploadTool.ts"
+import { getLogger } from "../utils/logger.ts"
+import { BaseDriver } from "./BaseDriver.ts"
+import { Keys } from "./keys.ts"
 // NOTE: While macros work well in Bun, it fails when using Alumium client from
 // Node.js. A solution could be "node:sea" module, but current Bun version
 // doesn't support it. For now, we bundle assets with scripts/generate.ts.
 // import { readScript } from "./scripts/scripts.js" with { type: "macro" };
-import type { ChromiumWebDriver } from "selenium-webdriver/chromium.js";
-import { AppId } from "../AppId.ts";
-import type { Driver } from "./Driver.ts";
+import type { ChromiumWebDriver } from "selenium-webdriver/chromium.js"
+import { AppId } from "../AppId.ts"
+import type { Driver } from "./Driver.ts"
 import {
   waiterScriptSource,
   waitForScriptSource,
-} from "./scripts/bundledScripts.ts";
+} from "./scripts/bundledScripts.ts"
 
 interface CDPNode {
-  nodeId: string;
-  parentId?: string;
-  _parent_iframe_backend_node_id?: number;
-  _frame_chain?: number[];
-  [key: string]: unknown;
+  nodeId: string
+  parentId?: string
+  _parent_iframe_backend_node_id?: number
+  _frame_chain?: number[]
+  [key: string]: unknown
 }
 
 interface CDPFrameInfo {
   frame: {
-    id: string;
-    url: string;
-  };
-  childFrames?: CDPFrameInfo[];
+    id: string
+    url: string
+  }
+  childFrames?: CDPFrameInfo[]
 }
 
-const logger = getLogger(import.meta.url);
+const logger = getLogger(import.meta.url)
 
-const WAITER_SCRIPT = waiterScriptSource;
-const WAIT_FOR_SCRIPT = waitForScriptSource;
+const WAITER_SCRIPT = waiterScriptSource
+const WAIT_FOR_SCRIPT = waitForScriptSource
 
 export class SeleniumDriver extends BaseDriver {
-  protected driver: ChromiumWebDriver;
-  public platform: Driver.Platform = "chromium";
-  #autoswitchToNewTabEnabled: boolean = true;
+  protected driver: ChromiumWebDriver
+  public platform: Driver.Platform = "chromium"
+  #autoswitchToNewTabEnabled: boolean = true
   public fullPageScreenshot: boolean =
     (process.env.ALUMNIUM_FULL_PAGE_SCREENSHOT || "false").toLowerCase() ===
-    "true";
+    "true"
   public supportedTools: Set<ToolClass> = new Set([
     ClickTool,
     DragAndDropTool,
@@ -71,77 +71,89 @@ export class SeleniumDriver extends BaseDriver {
     PressKeyTool,
     TypeTool,
     UploadTool,
-  ]);
+  ])
 
   constructor(driver: WebDriver) {
-    super();
-    this.driver = driver as ChromiumWebDriver;
+    super()
+    this.driver = (driver as ChromiumWebDriver)
   }
 
   async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
-    // Switch to default content to ensure we're at the top level for frame enumeration
-    await this.driver.switchTo().defaultContent();
-    logger.debug("Waiting for page to load before getting accessibility tree");
-    await this.waitForPageToLoad();
-    logger.debug("Page loaded, retrieving accessibility tree");
+    const alert = await this.detectAlert()
+
+    // WebDriver commands (switchTo, executeScript) fail when an alert is open,
+    // but CDP commands still work since they use the DevTools protocol directly.
+    if (!alert) {
+      await this.driver.switchTo().defaultContent()
+      logger.debug("Waiting for page to load before getting accessibility tree")
+      await this.waitForPageToLoad()
+      logger.debug("Page loaded, retrieving accessibility tree")
+    }
 
     // Get frame tree to enumerate all frames
     const frameTree = (await this.executeCdpCommand(
       "Page.getFrameTree",
       {},
     )) as {
-      frameTree: CDPFrameInfo;
-    };
-    const frameIds = this.getAllFrameIds(frameTree.frameTree);
-    const mainFrameId = frameTree.frameTree.frame.id;
-    logger.debug(`Found ${frameIds.length} frames`);
+      frameTree: CDPFrameInfo
+    }
+    const frameIds = this.getAllFrameIds(frameTree.frameTree)
+    const mainFrameId = frameTree.frameTree.frame.id
+    logger.debug(`Found ${frameIds.length} frames`)
 
     // Build mapping: frameId -> backendNodeId of the iframe element containing the frame
-    const frameToIframeMap: Map<string, number> = new Map();
+    const frameToIframeMap: Map<string, number> = new Map()
     // Build mapping: frameId -> parent frameId (for nested frames)
-    const frameParentMap: Map<string, string> = new Map();
+    const frameParentMap: Map<string, string> = new Map()
     await this.buildFrameHierarchy(
       frameTree.frameTree,
       mainFrameId,
       frameToIframeMap,
       frameParentMap,
-    );
+    )
 
     // Aggregate accessibility nodes from all frames
-    const allNodes: CDPNode[] = [];
+    const allNodes: CDPNode[] = []
     for (const frameId of frameIds) {
       try {
         const response = (await this.executeCdpCommand(
           "Accessibility.getFullAXTree",
           { frameId },
-        )) as { nodes: CDPNode[] };
-        const nodes = response.nodes || [];
+        )) as { nodes: CDPNode[] }
+        const nodes = response.nodes || []
         logger.debug(
           `  -> Frame ${frameId.slice(0, 20)}...: ${nodes.length} nodes`,
-        );
+        )
         // Tag ALL nodes from child frames with their frame chain (list of iframe backendNodeIds)
         // This allows us to switch through nested frames when finding elements
         const frameChain = this.getFrameChain(
           frameId,
           frameToIframeMap,
           frameParentMap,
-        );
+        )
         for (const node of nodes) {
           if (frameChain.length > 0) {
-            node._frame_chain = frameChain;
+            node._frame_chain = frameChain
           }
         }
-        allNodes.push(...nodes);
+        allNodes.push(...nodes)
       } catch (error) {
         logger.debug(
-          `  -> Frame ${frameId.slice(0, 20)}...: failed (${error instanceof Error ? error.message : String(error)})`,
-        );
+          `  -> Frame ${frameId.slice(0, 20)}...: failed (${
+            error instanceof Error ? error.message : String(error)
+          })`,
+        )
       }
     }
 
-    logger.debug(`Total accessibility nodes collected: ${allNodes.length}`);
+    // Append alert synthetic nodes so the LLM can see and interact with the dialog
+    if (alert) {
+      allNodes.push(...SeleniumDriver.createAlertNodes(alert.text))
+    }
 
-    return new ChromiumAccessibilityTree({ nodes: allNodes });
+    logger.debug(`Total accessibility nodes collected: ${allNodes.length}`)
+
+    return new ChromiumAccessibilityTree({ nodes: allNodes })
   }
 
   private async buildFrameHierarchy(
@@ -151,28 +163,30 @@ export class SeleniumDriver extends BaseDriver {
     frameParentMap: Map<string, string>,
     parentFrameId?: string,
   ): Promise<void> {
-    const frameId = frameInfo.frame.id;
+    const frameId = frameInfo.frame.id
 
     if (frameId !== mainFrameId) {
       // Get the iframe element that owns this frame
-      await this.executeCdpCommand("DOM.enable", {});
+      await this.executeCdpCommand("DOM.enable", {})
       try {
         const ownerInfo = (await this.executeCdpCommand("DOM.getFrameOwner", {
           frameId,
-        })) as { backendNodeId: number };
-        frameToIframeMap.set(frameId, ownerInfo.backendNodeId);
+        })) as { backendNodeId: number }
+        frameToIframeMap.set(frameId, ownerInfo.backendNodeId)
         logger.debug(
           `Frame ${frameId.slice(0, 20)}... owned by iframe backendNodeId=${ownerInfo.backendNodeId}`,
-        );
+        )
       } catch (error) {
         logger.debug(
-          `Could not get frame owner for ${frameId.slice(0, 20)}...: ${error instanceof Error ? error.message : String(error)}`,
-        );
+          `Could not get frame owner for ${frameId.slice(0, 20)}...: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        )
       }
 
       // Track parent frame
       if (parentFrameId) {
-        frameParentMap.set(frameId, parentFrameId);
+        frameParentMap.set(frameId, parentFrameId)
       }
     }
 
@@ -184,7 +198,7 @@ export class SeleniumDriver extends BaseDriver {
         frameToIframeMap,
         frameParentMap,
         frameId,
-      );
+      )
     }
   }
 
@@ -193,69 +207,80 @@ export class SeleniumDriver extends BaseDriver {
     frameToIframeMap: Map<string, number>,
     frameParentMap: Map<string, string>,
   ): number[] {
-    const chain: number[] = [];
-    let currentFrameId = frameId;
+    const chain: number[] = []
+    let currentFrameId = frameId
 
     while (frameToIframeMap.has(currentFrameId)) {
-      const iframeBackendNodeId = frameToIframeMap.get(currentFrameId)!;
-      chain.unshift(iframeBackendNodeId); // Insert at beginning to build from root
+      const iframeBackendNodeId = frameToIframeMap.get(currentFrameId)!
+      chain.unshift(iframeBackendNodeId) // Insert at beginning to build from root
       // Move to parent frame
       if (frameParentMap.has(currentFrameId)) {
-        currentFrameId = frameParentMap.get(currentFrameId)!;
+        currentFrameId = frameParentMap.get(currentFrameId)!
       } else {
-        break;
+        break
       }
     }
 
-    return chain;
+    return chain
   }
 
   private getAllFrameIds(frameInfo: CDPFrameInfo): string[] {
-    const frameIds: string[] = [frameInfo.frame.id];
+    const frameIds: string[] = [frameInfo.frame.id]
     for (const child of frameInfo.childFrames || []) {
-      frameIds.push(...this.getAllFrameIds(child));
+      frameIds.push(...this.getAllFrameIds(child))
     }
-    return frameIds;
+    return frameIds
   }
 
   async click(id: number): Promise<void> {
+    const tree = await this.getAccessibilityTree()
+    const accessibilityElement = tree.elementById(id)
+    if (accessibilityElement.alertAction) {
+      const alert = await this.driver.switchTo().alert()
+      if (accessibilityElement.alertAction === "accept") {
+        await alert.accept()
+      } else if (accessibilityElement.alertAction === "dismiss") {
+        await alert.dismiss()
+      }
+      return
+    }
+
     return this.#autoswitchToNewTab(async () => {
-      const element = await this.findElement(id);
+      const element = await this.findElement(id)
       try {
-        const actions = this.driver.actions({ async: true });
-        await actions.move({ origin: element }).click().perform();
+        const actions = this.driver.actions({ async: true })
+        await actions.move({ origin: element }).click().perform()
       } catch (error) {
         if (error instanceof ElementNotInteractableError) {
-          // Fallback to direct click if ActionChains fails (e.g. for <option> elements)
-          await element.click();
+          await element.click()
         } else {
-          throw error;
+          throw error
         }
       }
-    });
+    })
   }
 
   async dragSlider(id: number, value: number): Promise<void> {
-    const element = await this.findElement(id);
+    const element = await this.findElement(id)
     await this.driver.executeScript(
       "arguments[0].value = arguments[1];" +
         "arguments[0].dispatchEvent(new Event('input', {bubbles: true}));" +
         "arguments[0].dispatchEvent(new Event('change', {bubbles: true}));",
       element,
       String(value),
-    );
+    )
   }
 
   async dragAndDrop(fromId: number, toId: number): Promise<void> {
-    const actions = this.driver.actions({ async: true });
+    const actions = this.driver.actions({ async: true })
     await actions
       .dragAndDrop(await this.findElement(fromId), await this.findElement(toId))
-      .perform();
+      .perform()
   }
 
   async hover(id: number): Promise<void> {
-    const actions = this.driver.actions({ async: true });
-    await actions.move({ origin: await this.findElement(id) }).perform();
+    const actions = this.driver.actions({ async: true })
+    await actions.move({ origin: await this.findElement(id) }).perform()
   }
 
   pressKey(key: Keys.Key): Promise<void> {
@@ -265,36 +290,36 @@ export class SeleniumDriver extends BaseDriver {
         Enter: SeleniumKey.ENTER,
         Escape: SeleniumKey.ESCAPE,
         Tab: SeleniumKey.TAB,
-      };
+      }
 
-      const actions = this.driver.actions({ async: true });
-      await actions.sendKeys(keyMap[key]).perform();
-    });
+      const actions = this.driver.actions({ async: true })
+      await actions.sendKeys(keyMap[key]).perform()
+    })
   }
 
   async quit(): Promise<void> {
     try {
-      await this.driver.quit();
+      await this.driver.quit()
     } catch (error) {
       if (error instanceof NoSuchSessionError) {
-        logger.info("Selenium session already closed, ignoring quit error");
+        logger.info("Selenium session already closed, ignoring quit error")
       } else {
-        throw error;
+        throw error
       }
     }
   }
 
   async back(): Promise<void> {
-    await this.driver.navigate().back();
+    await this.driver.navigate().back()
   }
 
   async visit(url: string): Promise<void> {
-    await this.driver.get(url);
+    await this.driver.get(url)
   }
 
   async scrollTo(id: number): Promise<void> {
-    const element = await this.findElement(id);
-    await this.driver.executeScript("arguments[0].scrollIntoView();", element);
+    const element = await this.findElement(id)
+    await this.driver.executeScript("arguments[0].scrollIntoView();", element)
   }
 
   async screenshot(): Promise<string> {
@@ -302,89 +327,89 @@ export class SeleniumDriver extends BaseDriver {
       const result = (await this.executeCdpCommand("Page.captureScreenshot", {
         format: "png",
         captureBeyondViewport: true,
-      })) as { data: string };
-      return result.data;
+      })) as { data: string }
+      return result.data
     } else {
-      return await this.driver.takeScreenshot();
+      return await this.driver.takeScreenshot()
     }
   }
 
   title(): Promise<string> {
-    return this.driver.getTitle();
+    return this.driver.getTitle()
   }
 
   async type(id: number, text: string): Promise<void> {
-    const element = await this.findElement(id);
-    await element.clear();
-    await element.sendKeys(text);
+    const element = await this.findElement(id)
+    await element.clear()
+    await element.sendKeys(text)
   }
 
   async upload(id: number, paths: string[]): Promise<void> {
-    const element = await this.findElement(id);
-    await element.sendKeys(paths.join("\n"));
+    const element = await this.findElement(id)
+    await element.sendKeys(paths.join("\n"))
   }
 
   url(): Promise<string> {
-    return this.driver.getCurrentUrl();
+    return this.driver.getCurrentUrl()
   }
 
   async app(): Promise<AppId> {
-    const currentUrl = await this.driver.getCurrentUrl();
-    return AppId.parse(currentUrl);
+    const currentUrl = await this.driver.getCurrentUrl()
+    return AppId.parse(currentUrl)
   }
 
   async findElement(id: number): Promise<WebElement> {
-    const tree = await this.getAccessibilityTree();
-    const accessibilityElement = tree.elementById(id);
-    const backendNodeId = accessibilityElement.backendNodeId!;
-    const frameChain = accessibilityElement.frameChain;
+    const tree = await this.getAccessibilityTree()
+    const accessibilityElement = tree.elementById(id)
+    const backendNodeId = accessibilityElement.backendNodeId!
+    const frameChain = accessibilityElement.frameChain
 
     // Switch through the frame chain if element is inside nested iframes
     if (frameChain && frameChain.length > 0) {
-      await this.switchToFrameChain(frameChain);
+      await this.switchToFrameChain(frameChain)
     }
 
     // Use CDP to find element by backend node ID
-    await this.executeCdpCommand("DOM.enable", {});
-    await this.executeCdpCommand("DOM.getFlattenedDocument", {});
+    await this.executeCdpCommand("DOM.enable", {})
+    await this.executeCdpCommand("DOM.getFlattenedDocument", {})
 
     const { nodeIds } = (await this.executeCdpCommand(
       "DOM.pushNodesByBackendIdsToFrontend",
       { backendNodeIds: [backendNodeId] },
-    )) as { nodeIds: number[] };
+    )) as { nodeIds: number[] }
 
-    const nodeId = nodeIds[0];
+    const nodeId = nodeIds[0]
 
     // Set temporary attribute to locate element
     await this.executeCdpCommand("DOM.setAttributeValue", {
       nodeId,
       name: "data-alumnium-id",
       value: String(backendNodeId),
-    });
+    })
 
     const element = await this.driver.findElement(
       By.css(`[data-alumnium-id='${backendNodeId}']`),
-    );
+    )
 
     // Remove temporary attribute
     await this.executeCdpCommand("DOM.removeAttribute", {
       nodeId,
       name: "data-alumnium-id",
-    });
+    })
 
     // Note: We don't switch back to default content here because the element
     // needs to remain in its frame context for subsequent operations (click, type, etc.)
 
-    return element;
+    return element
   }
 
   private async switchToFrameChain(frameChain: number[]): Promise<void> {
     // First switch to default content to ensure we're at the top level
-    await this.driver.switchTo().defaultContent();
+    await this.driver.switchTo().defaultContent()
 
     // Switch through each iframe in the chain
     for (const iframeBackendNodeId of frameChain) {
-      await this.switchToSingleFrame(iframeBackendNodeId);
+      await this.switchToSingleFrame(iframeBackendNodeId)
     }
   }
 
@@ -392,142 +417,188 @@ export class SeleniumDriver extends BaseDriver {
     iframeBackendNodeId: number,
   ): Promise<void> {
     // Use CDP to find and switch to the iframe
-    await this.executeCdpCommand("DOM.enable", {});
-    await this.executeCdpCommand("DOM.getFlattenedDocument", {});
+    await this.executeCdpCommand("DOM.enable", {})
+    await this.executeCdpCommand("DOM.getFlattenedDocument", {})
 
     const { nodeIds } = (await this.executeCdpCommand(
       "DOM.pushNodesByBackendIdsToFrontend",
       { backendNodeIds: [iframeBackendNodeId] },
-    )) as { nodeIds: number[] };
+    )) as { nodeIds: number[] }
 
-    const nodeId = nodeIds[0];
+    const nodeId = nodeIds[0]
 
     await this.executeCdpCommand("DOM.setAttributeValue", {
       nodeId,
       name: "data-alumnium-iframe-id",
       value: String(iframeBackendNodeId),
-    });
+    })
 
     const iframeElement = await this.driver.findElement(
       By.css(`[data-alumnium-iframe-id='${iframeBackendNodeId}']`),
-    );
+    )
 
     await this.executeCdpCommand("DOM.removeAttribute", {
       nodeId,
       name: "data-alumnium-iframe-id",
-    });
+    })
 
-    await this.driver.switchTo().frame(iframeElement);
-    logger.debug(
-      `Switched to iframe with backendNodeId=${iframeBackendNodeId}`,
-    );
+    await this.driver.switchTo().frame(iframeElement)
+    logger.debug(`Switched to iframe with backendNodeId=${iframeBackendNodeId}`)
   }
 
   async executeScript(script: string): Promise<void> {
-    await this.driver.executeScript(script);
+    await this.driver.executeScript(script)
   }
 
   async printToPdf(filepath: string): Promise<void> {
     const { data } = (await this.executeCdpCommand("Page.printToPDF", {})) as {
-      data: string;
-    };
-    await fs.writeFile(filepath, Buffer.from(data, "base64"));
+      data: string
+    }
+    await fs.writeFile(filepath, Buffer.from(data, "base64"))
   }
 
   async switchToNextTab(): Promise<void> {
-    const handles = await this.driver.getAllWindowHandles();
-    if (handles.length <= 1) return;
+    const handles = await this.driver.getAllWindowHandles()
+    if (handles.length <= 1) return
 
-    const current = await this.driver.getWindowHandle();
-    const currentIndex = handles.indexOf(current);
-    const nextIndex = (currentIndex + 1) % handles.length;
+    const current = await this.driver.getWindowHandle()
+    const currentIndex = handles.indexOf(current)
+    const nextIndex = (currentIndex + 1) % handles.length
 
-    always(handles[nextIndex]);
-    await this.driver.switchTo().window(handles[nextIndex]);
+    always(handles[nextIndex])
+    await this.driver.switchTo().window(handles[nextIndex])
     logger.debug(
       `Switched to next tab: ${await this.driver.getTitle()} (${await this.driver.getCurrentUrl()})`,
-    );
+    )
   }
 
   async switchToPreviousTab(): Promise<void> {
-    const handles = await this.driver.getAllWindowHandles();
-    if (handles.length <= 1) return;
+    const handles = await this.driver.getAllWindowHandles()
+    if (handles.length <= 1) return
 
-    const current = await this.driver.getWindowHandle();
-    const currentIndex = handles.indexOf(current);
-    const prevIndex = (currentIndex - 1 + handles.length) % handles.length;
+    const current = await this.driver.getWindowHandle()
+    const currentIndex = handles.indexOf(current)
+    const prevIndex = (currentIndex - 1 + handles.length) % handles.length
 
-    always(handles[prevIndex]);
-    await this.driver.switchTo().window(handles[prevIndex]);
+    always(handles[prevIndex])
+    await this.driver.switchTo().window(handles[prevIndex])
     logger.debug(
       `Switched to previous tab: ${await this.driver.getTitle()} (${await this.driver.getCurrentUrl()})`,
-    );
+    )
   }
 
   async wait(seconds: number): Promise<void> {
-    const clampedSeconds = Math.max(1, Math.min(30, seconds));
-    await new Promise((resolve) => setTimeout(resolve, clampedSeconds * 1000));
+    const clampedSeconds = Math.max(1, Math.min(30, seconds))
+    await new Promise((resolve) => setTimeout(resolve, clampedSeconds * 1000))
   }
 
   async waitForSelector(): Promise<void> {
-    throw new Error("waitForSelector not supported for this driver");
+    throw new Error("waitForSelector not supported for this driver")
   }
 
   private executeCdpCommand(cmd: string, params: object): Promise<unknown> {
-    return this.driver.sendAndGetDevToolsCommand(cmd, params);
+    return this.driver.sendAndGetDevToolsCommand(cmd, params)
   }
 
   private async waitForPageToLoad(): Promise<void> {
     try {
-      await this.driver.executeScript(WAITER_SCRIPT);
-      const error = await this.driver.executeAsyncScript(WAIT_FOR_SCRIPT);
+      await this.driver.executeScript(WAITER_SCRIPT)
+      const error = await this.driver.executeAsyncScript(WAIT_FOR_SCRIPT)
       if (error) {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        logger.warn(`Failed to wait for page to load: ${String(error)}`);
+        logger.warn(`Failed to wait for page to load: ${String(error)}`)
       }
     } catch {
       // Retry once on failure
       try {
-        await this.driver.executeScript(WAITER_SCRIPT);
-        const error = await this.driver.executeAsyncScript(WAIT_FOR_SCRIPT);
+        await this.driver.executeScript(WAITER_SCRIPT)
+        const error = await this.driver.executeAsyncScript(WAIT_FOR_SCRIPT)
         if (error) {
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          logger.warn(`Failed to wait for page to load: ${String(error)}`);
+          logger.warn(`Failed to wait for page to load: ${String(error)}`)
         }
       } catch (retryError) {
         logger.warn(
           `Failed to wait for page to load after retry: ${String(retryError)}`,
-        );
+        )
       }
     }
   }
 
-  async #autoswitchToNewTab<Result>(
+  private async detectAlert(): Promise<{
+    text: string
+  } | null> {
+    try {
+      const alert = await this.driver.switchTo().alert()
+      return { text: await alert.getText() }
+    } catch {
+      return null
+    }
+  }
+
+  private static createAlertNodes(alertText: string): CDPNode[] {
+    const dialogId = "-100"
+    const acceptId = "-101"
+    const dismissId = "-102"
+
+    return [
+      {
+        nodeId: dialogId,
+        role: { value: "alertdialog" },
+        name: { value: alertText || "Alert" },
+        childIds: [acceptId, dismissId],
+      } as CDPNode,
+      {
+        nodeId: acceptId,
+        role: { value: "button" },
+        name: { value: "Accept" },
+        _alert_action: "accept",
+      } as CDPNode,
+      {
+        nodeId: dismissId,
+        role: { value: "button" },
+        name: { value: "Dismiss" },
+        _alert_action: "dismiss",
+      } as CDPNode,
+    ]
+  }
+
+  async #autoswitchToNewTab<Result,>(
     fn: () => Promise<Result>,
   ): Promise<Result> {
     if (!this.#autoswitchToNewTabEnabled) {
-      return await fn();
+      return await fn()
     }
 
-    const currentHandles = await this.driver.getAllWindowHandles();
+    let currentHandles: string[]
+    try {
+      currentHandles = await this.driver.getAllWindowHandles()
+    } catch {
+      return await fn()
+    }
 
-    const result = await fn();
+    const result = await fn()
 
-    const newHandles = await this.driver.getAllWindowHandles();
-    const newTabs = newHandles.filter((h) => !currentHandles.includes(h));
+    let newHandles: string[]
+    try {
+      newHandles = await this.driver.getAllWindowHandles()
+    } catch {
+      return result
+    }
+    const newTabs = newHandles.filter((h) => !currentHandles.includes(h))
 
     if (newTabs.length) {
-      const lastNewTab = newTabs[newTabs.length - 1];
-      always(lastNewTab);
+      const lastNewTab = newTabs[newTabs.length - 1]
+      always(lastNewTab)
 
       if (lastNewTab !== (await this.driver.getWindowHandle())) {
-        await this.driver.switchTo().window(lastNewTab);
+        await this.driver.switchTo().window(lastNewTab)
         logger.debug(
           `Auto-switching to new tab: ${await this.driver.getTitle()} (${await this.driver.getCurrentUrl()})`,
-        );
+        )
       }
     }
 
-    return result;
+    return result
   }
 }

--- a/packages/typescript/tests/system/alert.test.ts
+++ b/packages/typescript/tests/system/alert.test.ts
@@ -1,0 +1,23 @@
+import { describe } from "vitest"
+import { baseIt } from "./helpers.ts"
+
+describe("Alerts", () => {
+  const it = baseIt
+
+  it("accept alert", async ({ expect, setup }) => {
+    const { al, $ } = await setup()
+    await $.navigate("alert.html")
+    await al.do("click the Trigger Alert button")
+    await al.check("an alert dialog is shown")
+    await al.do("accept the alert")
+  })
+
+  it("dismiss confirm", async ({ expect, setup }) => {
+    const { al, $ } = await setup()
+    await $.navigate("alert.html")
+    await al.do("click the Trigger Confirm button")
+    await al.check("a confirm dialog is shown")
+    await al.do("dismiss the alert")
+    await al.check("the result text says Dismissed")
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #209

- **Detect alerts**: Selenium checks `switch_to.alert`; Playwright captures dialogs via `page.on('dialog')`; Appium handles WebView alerts via `switch_to.alert`
- **Inject synthetic nodes**: When an alert is present, synthetic `alertdialog`, OK (`accept`), and Cancel (`dismiss`) button nodes are added to the accessibility tree so the LLM can see and interact with them
- **Route clicks to alert API**: When the LLM clicks an alert button, the driver intercepts it and calls `alert.accept()` or `alert.dismiss()` instead of trying to find a DOM element

### Driver-specific behavior

| Driver | Behavior |
|---|---|
| **Selenium** | Alert stays open. LLM sees buttons in the tree and clicks to accept/dismiss. |
| **Playwright** | Dialog is auto-accepted (required by Playwright API). LLM sees captured dialog info in the next tree for assertion purposes. |
| **Appium** | Native alerts are already in the page source. WebView alerts are handled via `switch_to.alert`. |

### Files changed (11)

**Python (6 files):**
- `accessibility_element.py` — added `alert_action` field
- `chromium_accessibility_tree.py` — store/read `_alert_action` in XML tree
- `selenium_driver.py` — alert detection, synthetic nodes, click routing, resilient tab-switch decorator
- `playwright_driver.py` — dialog handler, captured dialog nodes, click acknowledgement
- `playwright_async_driver.py` — same as sync, with async-safe dialog acceptance
- `appium_driver.py` — basic alert routing in click

**TypeScript (5 files):**
- `AccessibilityElement.ts` — added `alertAction` field
- `ChromiumAccessibilityTree.ts` — store/read `_alert_action` in XML tree
- `SeleniumDriver.ts` — alert detection, synthetic nodes, click routing, resilient decorator
- `PlaywrightDriver.ts` — dialog handler, captured dialog nodes, click acknowledgement
- `AppiumDriver.ts` — basic alert routing in click

## Test plan

- [x] Selenium: Trigger `alert()` → verify LLM sees alertdialog + OK/Cancel → click OK → alert dismissed
- [x] Selenium: Trigger `confirm()` → click Cancel → confirm returns false
- [x] Playwright: Trigger `alert()` → verify dialog info appears in tree → LLM can assert on text
- [x] Playwright: Trigger `confirm()` → verify auto-accept behavior
- [x] Appium: WebView alert → verify accept/dismiss routing
- [x] Verify normal (non-alert) click/type operations remain unaffected
