### PR TITLE
feat(mcp): return all response as JSON

### DIFF
--- a/packages/typescript/scripts/build.ts
+++ b/packages/typescript/scripts/build.ts
@@ -336,6 +336,8 @@ async function main() {
         console.log(`🟢 ${target} (${cwdRelPath(binPath)})`);
       }),
     );
+
+    await cleanUpDir(STANDALONE_EMBEDDED_ASSETS_DIR);
   }
 
   //#endregion

--- a/packages/typescript/src/mcp/tools/checkMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/checkMcpTool.ts
@@ -31,14 +31,14 @@ export const checkMcpTool = McpTool.define("check", {
     let result = "";
     try {
       explanation = await al.check(statement, { vision });
-      result = "passed";
-      logger.debug(`Passed with ${explanation}`);
+      result = "success";
+      logger.debug(`Success with ${explanation}`);
     } catch (error) {
       if (!(error instanceof AssertionError)) throw error;
 
       explanation = String(error);
-      result = "failed";
-      logger.error(`Failed with ${explanation}`);
+      result = "failure";
+      logger.error(`Failure with ${explanation}`);
     }
 
     await McpArtifactsStore.saveScreenshot({
@@ -46,6 +46,6 @@ export const checkMcpTool = McpTool.define("check", {
       description: `check ${statement}`,
     });
 
-    return [{ type: "text", text: `Check ${result}! ${explanation}` }];
+    return [{ type: "text", text: JSON.stringify({ result, explanation }) }];
   },
 });

--- a/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
@@ -50,8 +50,12 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
       try {
         rawCapabilities = fs.readFileSync(filePath, "utf-8");
       } catch (error) {
-        logger.error(`Failed to read capabilities file '${filePath}': ${error}`);
-        throw new Error(`Failed to read capabilities file '${filePath}': ${error}`);
+        logger.error(
+          `Failed to read capabilities file '${filePath}': ${error}`,
+        );
+        throw new Error(
+          `Failed to read capabilities file '${filePath}': ${error}`,
+        );
       }
     } else {
       rawCapabilities = input.capabilities;

--- a/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
@@ -102,20 +102,16 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
 
     // Detect platform and create appropriate driver
     let driver: McpDriver;
-    let platformLabel: string;
     if (["chrome", "chromium"].includes(platformName)) {
       driver = await createChromeDriver(
         capabilities,
         serverUrl,
         artifactsStore,
       );
-      platformLabel = "Chrome";
     } else if (platformName === "ios") {
       driver = await createIosDriver(capabilities, serverUrl);
-      platformLabel = "iOS";
     } else if (platformName === "android") {
       driver = await createAndroidDriver(capabilities, serverUrl);
-      platformLabel = "Android";
     } else {
       logger.error(`Unsupported platformName: ${platformName}`);
       throw new Error(
@@ -161,7 +157,12 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
     return [
       {
         type: "text",
-        text: `${platformLabel} driver started successfully (driver_id: ${driverId})\nModel: ${al.model.provider}/${al.model.name}`,
+        text: JSON.stringify({
+          driver_id: driverId,
+          driver_type: al.driver.constructor.name,
+          platform_name: platformName,
+          model: `${al.model.provider}/${al.model.name}`,
+        }),
       },
     ];
   },

--- a/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import z from "zod";
 import { Alumni } from "../../client/Alumni.ts";
@@ -30,7 +31,7 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
     capabilities: z
       .string()
       .describe(
-        `JSON string with Selenium/Appium/Playwright capabilities. Must include 'platformName' (e.g., 'chrome', 'iOS', 'Android'). Example: '{"platformName": "iOS", "appium:deviceName": "iPhone 16", "appium:platformVersion": "18.0"}'. You can optionally set extra HTTP headers. Example: '{"headers": {"Authorization": "Bearer token"}}'. You can optionally set cookies. Example: '{"cookies": [{"name": "session", "value": "abc123", "domain": ".example.com"}]}'.`,
+        `JSON string or path to a JSON file with Selenium/Appium/Playwright capabilities. Must include 'platformName' (e.g., 'chrome', 'iOS', 'Android'). Example JSON string: '{"platformName": "iOS", "appium:deviceName": "iPhone 16", "appium:platformVersion": "18.0"}'. Example file path: '/path/to/capabilities.json'. You can optionally set extra HTTP headers. Example: '{"headers": {"Authorization": "Bearer token"}}'. You can optionally set cookies. Example: '{"cookies": [{"name": "session", "value": "abc123", "domain": ".example.com"}]}'.`,
       ),
 
     server_url: z
@@ -42,10 +43,24 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
   }),
 
   async execute(input, { logger }) {
+    // Resolve capabilities: file path or inline JSON string
+    let rawCapabilities: string;
+    const filePath = path.resolve(input.capabilities);
+    if (fs.existsSync(filePath)) {
+      try {
+        rawCapabilities = fs.readFileSync(filePath, "utf-8");
+      } catch (error) {
+        logger.error(`Failed to read capabilities file '${filePath}': ${error}`);
+        throw new Error(`Failed to read capabilities file '${filePath}': ${error}`);
+      }
+    } else {
+      rawCapabilities = input.capabilities;
+    }
+
     // Parse capabilities JSON
     let capabilities: Record<string, unknown>;
     try {
-      capabilities = JSON.parse(input.capabilities);
+      capabilities = JSON.parse(rawCapabilities);
     } catch (error) {
       logger.error(`Invalid JSON in capabilities parameter: ${error}`);
       throw new Error(`Invalid JSON in capabilities parameter: ${error}`);

--- a/packages/typescript/src/mcp/tools/stopDriverMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/stopDriverMcpTool.ts
@@ -34,9 +34,18 @@ export const stopDriverMcpTool = McpTool.define("stop_driver", {
     // Cleanup driver and get stats
     const [artifactsDir, stats] = await McpState.cleanupDriver(driverId);
 
-    // Format stats message with detailed cache breakdown
-    const message = `Driver ${driverId} closed.\nArtifacts saved to: ${path.resolve(artifactsDir)}\nToken usage statistics:\n- Total: ${stats["total"]["total_tokens"]} tokens (${stats["total"]["input_tokens"]} input, ${stats["total"]["output_tokens"]} output)\n- Cached: ${stats["cache"]["total_tokens"]} tokens (${stats["cache"]["input_tokens"]} input, ${stats["cache"]["output_tokens"]} output)`;
-
-    return [{ type: "text", text: message }];
+    return [
+      {
+        type: "text",
+        text: JSON.stringify({
+          driver_id: driverId,
+          artifacts_dir: path.resolve(artifactsDir),
+          token_usage: {
+            total: stats["total"],
+            cached: stats["cache"],
+          },
+        }),
+      },
+    ];
   },
 });

--- a/packages/typescript/src/mcp/tools/waitMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/waitMcpTool.ts
@@ -43,7 +43,9 @@ export const waitMcpTool = McpTool.define("wait", {
       logger.info(`Waiting for ${seconds} seconds`);
 
       await sleep(seconds * 1000);
-      return [{ type: "text", text: `Waited ${seconds} seconds` }];
+      return [
+        { type: "text", text: JSON.stringify({ waited_seconds: seconds }) },
+      ];
     }
 
     // Otherwise, treat as natural language condition
@@ -51,7 +53,9 @@ export const waitMcpTool = McpTool.define("wait", {
       return [
         {
           type: "text",
-          text: "driver_id is required when waiting for a condition",
+          text: JSON.stringify({
+            error: "driver_id is required when waiting for a condition",
+          }),
         },
       ];
     }
@@ -71,7 +75,14 @@ export const waitMcpTool = McpTool.define("wait", {
         const explanation = await al.check(waitFor);
         logger.info(`Condition met after ${attempts} attempt(s)`);
         return [
-          { type: "text", text: `Condition met: ${waitFor}\n${explanation}` },
+          {
+            type: "text",
+            text: JSON.stringify({
+              status: "met",
+              condition: waitFor,
+              explanation,
+            }),
+          },
         ];
       } catch (error) {
         if (
@@ -91,7 +102,12 @@ export const waitMcpTool = McpTool.define("wait", {
     return [
       {
         type: "text",
-        text: `Timeout after ${timeout}s waiting for: ${waitFor}\nLast check: ${lastError}`,
+        text: JSON.stringify({
+          status: "timeout",
+          condition: waitFor,
+          timeout_seconds: timeout,
+          last_error: lastError,
+        }),
       },
     ];
   },


### PR DESCRIPTION
This PR ensures that all MCP tool responses are JSON. This allows processing the responses via `jq` in Claude Code `PostToolUses` hooks (e.g., to extract `artifacts_store`) after the driver is stopped and automatically generate report based on the artifacts. 

In addition to that, the `capabilities` input in `start_driver` can be read directly from a file rather than constructed by an agent.