### PR TITLE
feat(mcp)!: simplify `alumnium:options` capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set Up Dev Env
         uses: ./.github/actions/setup

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -2,7 +2,7 @@
  * Driver factory functions for different platforms.
  */
 
-import type { Browser, BrowserContext, Page } from "playwright-core";
+import type { BrowserContext, Page } from "playwright-core";
 import { chromium } from "playwright-core";
 import { Builder, type WebDriver } from "selenium-webdriver";
 import { Options } from "selenium-webdriver/chrome.js";
@@ -19,20 +19,21 @@ const logger = getLogger(import.meta.url);
 export type McpDriver = Page | WebDriver | WebdriverIoBrowser;
 
 export namespace McpDriver {
-  export type PlaywrightCookie = Parameters<
-    BrowserContext["addCookies"]
-  >[0][number];
+  type PlaywrightCookie = Parameters<BrowserContext["addCookies"]>[0][number];
 
-  export type PlaywrightHeaders = (Parameters<
-    Browser["newContext"]
-  >[0] & {})["extraHTTPHeaders"] & {};
+  export type Cookies = PlaywrightCookie[];
+  export type Headers = Record<string, string>;
 
   export interface Capabilities {
-    headers?: PlaywrightHeaders | undefined;
-    cookies?: PlaywrightCookie[] | undefined;
-    permissions?: string[] | undefined;
     "appium:settings"?: Record<string, unknown> | undefined;
     [key: string]: unknown;
+  }
+
+  export interface DriverOptions {
+    cookies?: Cookies;
+    headers?: Headers;
+    headless?: boolean;
+    permissions?: string[];
   }
 
   export interface SeleniumCdpConnection {
@@ -46,13 +47,14 @@ export function createChromeDriver(
   capabilities: McpDriver.Capabilities,
   serverUrl: string | null | undefined,
   artifactsStore: FileStore,
+  driverOptions: McpDriver.DriverOptions = {},
 ): Promise<McpDriver> {
   const driverType = (process.env.ALUMNIUM_DRIVER || "selenium").toLowerCase();
   logger.info(`Creating Chrome driver using ${driverType}`);
   if (driverType === "playwright") {
-    return createPlaywrightDriver(capabilities, artifactsStore);
+    return createPlaywrightDriver(capabilities, artifactsStore, driverOptions);
   } else {
-    return createSeleniumDriver(capabilities, serverUrl);
+    return createSeleniumDriver(capabilities, serverUrl, driverOptions);
   }
 }
 
@@ -60,18 +62,21 @@ export function createChromeDriver(
  * Create Playwright driver from capabilities.
  */
 export async function createPlaywrightDriver(
-  capabilities: McpDriver.Capabilities,
+  _capabilities: McpDriver.Capabilities,
   artifactsStore: FileStore,
+  driverOptions: McpDriver.DriverOptions = {},
 ): Promise<Page> {
-  const headless =
-    (process.env.ALUMNIUM_PLAYWRIGHT_HEADLESS || "true").toLowerCase() ===
-    "true";
-  logger.info(`Creating Playwright driver (headless=${headless})`);
+  const {
+    cookies,
+    headless = false,
+    headers = {},
+    permissions,
+  } = driverOptions;
 
+  logger.info(`Creating Playwright driver (headless=${headless})`);
   const browser = await chromium.launch({ headless });
 
-  const headers = capabilities["headers"] || {};
-  if (Object.keys(headers).length) {
+  if (headers) {
     logger.debug("Setting extra HTTP headers: {headers}", { headers });
   }
 
@@ -86,8 +91,6 @@ export async function createPlaywrightDriver(
     snapshots: true,
     sources: true,
   });
-
-  const { cookies, permissions } = capabilities;
 
   if (cookies) {
     logger.debug("Adding cookies: {cookies}", { cookies });
@@ -114,22 +117,29 @@ export async function createPlaywrightDriver(
 export async function createSeleniumDriver(
   capabilities: McpDriver.Capabilities,
   serverUrl: string | null | undefined,
+  driverOptions: McpDriver.DriverOptions = {},
 ): Promise<WebDriver> {
   logger.info(`Creating Selenium driver (serverUrl=${serverUrl || "local"})`);
 
-  const { headers, cookies, ...seleniumCapabilities } = capabilities;
+  const { cookies, headers = {}, headless = false } = driverOptions;
 
-  const options = new Options();
+  const chromeOptions = new Options();
+
+  if (headless) {
+    chromeOptions.addArguments("--headless=new");
+  }
 
   // Apply all capabilities to options
-  for (const [key, value] of Object.entries(seleniumCapabilities)) {
+  for (const [key, value] of Object.entries(capabilities)) {
     if (key !== "platformName") {
-      options.set(key, value);
+      chromeOptions.set(key, value);
     }
   }
 
   // Use remote driver if serverUrl provided, otherwise local Chrome
-  const builder = new Builder().forBrowser("chrome").setChromeOptions(options);
+  const builder = new Builder()
+    .forBrowser("chrome")
+    .setChromeOptions(chromeOptions);
   if (serverUrl) {
     builder.usingServer(serverUrl);
   }
@@ -137,20 +147,19 @@ export async function createSeleniumDriver(
   const cdp: McpDriver.SeleniumCdpConnection =
     await driver.createCDPConnection("page");
 
-  const cdpPromises: Promise<unknown>[] = [];
-
-  if (headers || cookies) {
-    cdpPromises.push(cdp.send("Network.enable", {}));
+  if (Object.keys(headers).length || cookies?.length) {
+    await cdp.send("Network.enable", {});
   }
 
-  if (headers) {
+  const cdpPromises: Promise<unknown>[] = [];
+  if (Object.keys(headers).length) {
     logger.debug("Setting extra HTTP headers: {headerNames}", {
       headerNames: Object.keys(headers),
     });
     cdpPromises.push(cdp.send("Network.setExtraHTTPHeaders", { headers }));
   }
 
-  if (cookies) {
+  if (cookies?.length) {
     logger.debug(`Adding ${cookies.length} cookie(s)`);
     cdpPromises.push(cdp.send("Network.setCookies", { cookies }));
   }

--- a/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startDriverMcpTool.ts
@@ -31,7 +31,7 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
     capabilities: z
       .string()
       .describe(
-        `JSON string or path to a JSON file with Selenium/Appium/Playwright capabilities. Must include 'platformName' (e.g., 'chrome', 'iOS', 'Android'). Example JSON string: '{"platformName": "iOS", "appium:deviceName": "iPhone 16", "appium:platformVersion": "18.0"}'. Example file path: '/path/to/capabilities.json'. You can optionally set extra HTTP headers. Example: '{"headers": {"Authorization": "Bearer token"}}'. You can optionally set cookies. Example: '{"cookies": [{"name": "session", "value": "abc123", "domain": ".example.com"}]}'.`,
+        `JSON string or path to a JSON file with Selenium/Appium/Playwright capabilities. Must include 'platformName' (e.g., 'chrome', 'ios', 'android'). Example JSON string: '{"platformName": "ios", "appium:deviceName": "iPhone 16", "appium:platformVersion": "18.0"}'. Example file path: '/path/to/capabilities.json'. Alumnium-specific options go in 'alumnium:options': 'headless' (boolean, default false) — run browser headless, supported for Selenium and Playwright; 'headers' (object) — extra HTTP headers for every request, supported for Selenium and Playwright, e.g. {"Authorization": "Bearer token"}; 'cookies' (array) — cookies to set, supported for Selenium and Playwright, e.g. [{"name": "session", "value": "abc123", "domain": ".example.com"}]; 'permissions' (string[]) — browser permissions to grant, Playwright only, e.g. ["geolocation"]; 'planner' (boolean) — enable/disable planner agent; 'changeAnalysis' (boolean, default true) — enable change analysis; 'excludeAttributes' (string[]) — accessibility attributes to exclude from the tree; 'newTabTimeout' (number, default 200) — ms to wait for new tab detection, Playwright only; 'autoswitchToNewTab' (boolean, default true) — auto-switch to newly opened tabs; 'fullPageScreenshot' (boolean, default false) — capture full-page screenshots. Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "headers": {"Authorization": "Bearer token"}, "newTabTimeout": 500}}'.`,
       ),
 
     server_url: z
@@ -50,12 +50,9 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
       try {
         rawCapabilities = fs.readFileSync(filePath, "utf-8");
       } catch (error) {
-        logger.error(
-          `Failed to read capabilities file '${filePath}': ${error}`,
-        );
-        throw new Error(
-          `Failed to read capabilities file '${filePath}': ${error}`,
-        );
+        const message = `Failed to read capabilities file '${filePath}': ${error}`;
+        logger.error(message);
+        throw new Error(message);
       }
     } else {
       rawCapabilities = input.capabilities;
@@ -66,8 +63,9 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
     try {
       capabilities = JSON.parse(rawCapabilities);
     } catch (error) {
-      logger.error(`Invalid JSON in capabilities parameter: ${error}`);
-      throw new Error(`Invalid JSON in capabilities parameter: ${error}`);
+      const message = `Invalid JSON in capabilities parameter: ${error}`;
+      logger.error(message);
+      throw new Error(message);
     }
 
     // Extract and validate platformName
@@ -75,11 +73,13 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
       typeof capabilities.platformName !== "string" ||
       !capabilities.platformName
     ) {
-      logger.error("Capabilities must include 'platformName' field");
-      throw new Error("Capabilities must include 'platformName' field");
+      const message = "Capabilities must include 'platformName' field";
+      logger.error(message);
+      throw new Error(message);
     }
-
     const platformName = capabilities.platformName.toLowerCase();
+    capabilities.platformName = platformName;
+
     const serverUrl =
       typeof input["server_url"] === "string" ? input["server_url"] : null;
 
@@ -89,10 +89,7 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
         | Record<string, unknown>
         | undefined) || {};
     delete capabilities["alumnium:options"];
-    const driverSettings =
-      (alumniumOptions["driverSettings"] as
-        | Record<string, unknown>
-        | undefined) || {};
+
     const planner =
       typeof alumniumOptions["planner"] === "boolean"
         ? alumniumOptions["planner"]
@@ -108,6 +105,37 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
           (value): value is string => typeof value === "string",
         )
       : undefined;
+
+    const driverOptions: McpDriver.DriverOptions = {
+      ...(alumniumOptions["headers"] !== undefined && {
+        headers: alumniumOptions["headers"] as McpDriver.Headers,
+      }),
+      ...(alumniumOptions["cookies"] !== undefined && {
+        cookies: alumniumOptions["cookies"] as McpDriver.Cookies,
+      }),
+      ...(Array.isArray(alumniumOptions["permissions"]) && {
+        permissions: alumniumOptions["permissions"] as string[],
+      }),
+      ...(typeof alumniumOptions["headless"] === "boolean" && {
+        headless: alumniumOptions["headless"],
+      }),
+    };
+
+    const alumniumOptionsNonDriverKeys = new Set([
+      "changeAnalysis",
+      "cookies",
+      "excludeAttributes",
+      "headers",
+      "headless",
+      "permissions",
+      "planner",
+    ]);
+    const driverSettings: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(alumniumOptions)) {
+      if (!alumniumOptionsNonDriverKeys.has(key)) {
+        driverSettings[key] = value;
+      }
+    }
 
     // Generate driver ID from current directory and timestamp
     const cwdName = path.basename(process.cwd());
@@ -126,6 +154,7 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
         capabilities,
         serverUrl,
         artifactsStore,
+        driverOptions,
       );
     } else if (platformName === "ios") {
       driver = await createIosDriver(capabilities, serverUrl);
@@ -161,9 +190,13 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
       });
       for (const [key, value] of Object.entries(driverSettings)) {
         if (key in al.driver) {
-          // @ts-expect-error
-          al.driver[key] = value;
-          logger.debug(`Set driver option ${key}={value}`, { value });
+          try {
+            // @ts-expect-error
+            al.driver[key] = value;
+            logger.debug(`Set driver option ${key}={value}`, { value });
+          } catch (error) {
+            logger.warn(`Failed to set driver option ${key}: ${error}`);
+          }
         } else {
           logger.warn(`Unknown driver option: ${key}`);
         }

--- a/packages/typescript/src/mcp/tools/waitMcpTool.test.ts
+++ b/packages/typescript/src/mcp/tools/waitMcpTool.test.ts
@@ -14,19 +14,25 @@ vi.mock("../../utils/timers.ts", async () => {
 describe("waitMcpTool", () => {
   it("waits for given number of seconds", async () => {
     const result = await waitMcpTool.execute({ for: 1, timeout: 10 });
-    expect(result).toEqual([{ type: "text", text: "Waited 1 seconds" }]);
+    expect(result).toEqual([
+      { type: "text", text: JSON.stringify({ waited_seconds: 1 }) },
+    ]);
     expect(sleep).toHaveBeenCalledWith(1000);
   });
 
   it("clamps number waits to minimum", async () => {
     const result = await waitMcpTool.execute({ for: 0, timeout: 10 });
-    expect(result).toEqual([{ type: "text", text: "Waited 1 seconds" }]);
+    expect(result).toEqual([
+      { type: "text", text: JSON.stringify({ waited_seconds: 1 }) },
+    ]);
     expect(sleep).toHaveBeenCalledWith(1000);
   });
 
   it("clamps number waits to maximum", async () => {
     const result = await waitMcpTool.execute({ for: 100, timeout: 10 });
-    expect(result).toEqual([{ type: "text", text: "Waited 30 seconds" }]);
+    expect(result).toEqual([
+      { type: "text", text: JSON.stringify({ waited_seconds: 30 }) },
+    ]);
     expect(sleep).toHaveBeenCalledWith(30000);
   });
 
@@ -38,7 +44,9 @@ describe("waitMcpTool", () => {
     expect(result).toEqual([
       {
         type: "text",
-        text: "driver_id is required when waiting for a condition",
+        text: JSON.stringify({
+          error: "driver_id is required when waiting for a condition",
+        }),
       },
     ]);
   });
@@ -53,7 +61,11 @@ describe("waitMcpTool", () => {
     expect(result).toEqual([
       {
         type: "text",
-        text: "Condition met: user is logged in\nThe condition is satisfied",
+        text: JSON.stringify({
+          status: "met",
+          condition: "user is logged in",
+          explanation: "The condition is satisfied",
+        }),
       },
     ]);
     expect(check).toHaveBeenCalledTimes(1);
@@ -72,7 +84,11 @@ describe("waitMcpTool", () => {
     expect(result).toEqual([
       {
         type: "text",
-        text: "Condition met: page loaded\nThe condition is now satisfied",
+        text: JSON.stringify({
+          status: "met",
+          condition: "page loaded",
+          explanation: "The condition is now satisfied",
+        }),
       },
     ]);
     expect(check).toHaveBeenCalledTimes(3);
@@ -91,9 +107,12 @@ describe("waitMcpTool", () => {
     expect(result).toEqual([
       {
         type: "text",
-        text: expect.stringContaining(
-          "Timeout after 0.001s waiting for: element visible",
-        ),
+        text: JSON.stringify({
+          status: "timeout",
+          condition: "element visible",
+          timeout_seconds: 0.001,
+          last_error: "AssertionError: Condition not satisfied",
+        }),
       },
     ]);
     expect(check).toHaveBeenCalledWith("element visible");
@@ -120,7 +139,10 @@ describe("waitMcpTool", () => {
       for: "test condition",
     });
     expect(result).toEqual([
-      { type: "text", text: "Condition met: test condition\nOK" },
+      {
+        type: "text",
+        text: JSON.stringify({ status: "met", condition: "test condition", explanation: "OK" }),
+      },
     ]);
     expect(check).toHaveBeenCalledTimes(1);
     expect(check).toHaveBeenCalledWith("test condition");


### PR DESCRIPTION
- Flattens `driverSettings` previously nested under `alumnium:options`
- Moves `headers`, `cookies`, and `permissions` into `alumnium:options` keeping support for both Selenium and Playwright
- Adds `headless` option to `alumnium:options`, supported for both Selenium (`--headless=new`) and Playwright
- Lowercase `platformName` automatically so users don't need to match exact casing
- Update `start_driver` tool description to document all supported `alumnium:options` fields
- Wrap driver setting assignment in try/catch so unknown or invalid options log a warning instead of failing
