### PR TITLE
feat(mcp)!: `start_driver/stop_driver` -> `start/stop`

### DIFF
--- a/packages/typescript/src/mcp/McpArtifactsStore.test.ts
+++ b/packages/typescript/src/mcp/McpArtifactsStore.test.ts
@@ -40,13 +40,13 @@ describe("McpArtifactsStore", () => {
       pushTeardown(() => {
         delete process.env.ALUMNIUM_MCP_ARTIFACTS_DIR;
       });
-      const driverId = "test-driver";
-      const artifactsStore = new McpArtifactsStore(driverId);
+      const id = "test-driver";
+      const artifactsStore = new McpArtifactsStore(id);
       const pixelB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
       const mockScreenshot = vi.fn(async () => pixelB64);
       McpState.registerDriver(
-        driverId,
+        id,
         { driver: { screenshot: mockScreenshot } } as any,
         {} as McpDriver,
         artifactsStore,
@@ -55,11 +55,11 @@ describe("McpArtifactsStore", () => {
         McpState.clear();
       });
       const screenshotProps: McpArtifactsStore.SaveScreenshotProps = {
-        driverId,
+        id,
         description:
           "Test screenshot! With special chars & long description that should be truncated",
       };
-      return { mockDir, driverId, mockScreenshot, pixelB64, screenshotProps };
+      return { mockDir, id, mockScreenshot, pixelB64, screenshotProps };
     });
 
     it("resolves path with step number and sanitized description prefix", async () => {

--- a/packages/typescript/src/mcp/McpArtifactsStore.ts
+++ b/packages/typescript/src/mcp/McpArtifactsStore.ts
@@ -7,18 +7,18 @@ const logger = getLogger(import.meta.url);
 
 export namespace McpArtifactsStore {
   export interface SaveScreenshotProps {
-    driverId: string;
+    id: string;
     description: string;
   }
 }
 
 export class McpArtifactsStore extends FileStore {
-  constructor(driverId: string) {
+  constructor(id: string) {
     super(
       FileStore.subResolve(
         process.env.ALUMNIUM_MCP_ARTIFACTS_DIR,
         "artifacts",
-        driverId,
+        id,
       ),
     );
   }
@@ -29,14 +29,14 @@ export class McpArtifactsStore extends FileStore {
   static async saveScreenshot(
     props: McpArtifactsStore.SaveScreenshotProps,
   ): Promise<string | null> {
-    const { driverId, description } = props;
+    const { id, description } = props;
     try {
-      const driverState = McpState.getDriverState(driverId);
+      const driverState = McpState.getDriverState(id);
 
       // TODO: It is a bad idea to manage step number here in the artifacts
       // store. A better place would be McpState and the `saveScreenshot` method
       // would only accept the step number as a prop.
-      const stepNum = McpState.incrementStepNum(driverId);
+      const stepNum = McpState.incrementStepNum(id);
 
       // Sanitize description for filename
       // Remove special characters and limit length
@@ -53,12 +53,12 @@ export class McpArtifactsStore extends FileStore {
         screenshotBytes,
       );
 
-      logger.debug(`Driver ${driverId}: Saved screenshot to ${filePath}`);
+      logger.debug(`Driver ${id}: Saved screenshot to ${filePath}`);
 
       return filePath;
     } catch (error) {
       // Log error but don't fail the operation
-      logger.warn(`Failed to save screenshot for driver ${driverId}: ${error}`);
+      logger.warn(`Failed to save screenshot for driver ${id}: ${error}`);
       return null;
     }
   }

--- a/packages/typescript/src/mcp/McpServer.ts
+++ b/packages/typescript/src/mcp/McpServer.ts
@@ -12,8 +12,8 @@ import { checkMcpTool } from "./tools/checkMcpTool.ts";
 import { doMcpTool } from "./tools/doMcpTool.ts";
 import { fetchAccessibilityTreeMcpTool } from "./tools/fetchAccessibilityTreeMcpTool.ts";
 import { getMcpTool } from "./tools/getMcpTool.ts";
-import { startDriverMcpTool } from "./tools/startDriverMcpTool.ts";
-import { stopDriverMcpTool } from "./tools/stopDriverMcpTool.ts";
+import { startMcpTool } from "./tools/startMcpTool.ts";
+import { stopMcpTool } from "./tools/stopMcpTool.ts";
 import { waitMcpTool } from "./tools/waitMcpTool.ts";
 
 const logger = getLogger(import.meta.url);
@@ -23,8 +23,8 @@ const MCP_TOOLS = [
   doMcpTool,
   fetchAccessibilityTreeMcpTool,
   getMcpTool,
-  startDriverMcpTool,
-  stopDriverMcpTool,
+  startMcpTool,
+  stopMcpTool,
   waitMcpTool,
 ];
 

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -9,7 +9,7 @@ import { LlmUsageStats } from "../llm/llmSchema.ts";
 import { getLogger } from "../utils/logger.ts";
 import { McpArtifactsStore } from "./McpArtifactsStore.ts";
 import type { McpDriver } from "./mcpDrivers.ts";
-import { startDriverMcpTool } from "./tools/startDriverMcpTool.ts";
+import { startMcpTool } from "./tools/startMcpTool.ts";
 
 const logger = getLogger(import.meta.url);
 
@@ -81,7 +81,7 @@ export abstract class McpState {
       logger.error(`Driver state for ${driverId} not found`);
       // NOTE: This error is required for the controlling agent calling MCP.
       throw new Error(
-        `Driver ${driverId} not found. Call ${startDriverMcpTool.name} first.`,
+        `Driver ${driverId} not found. Call ${startMcpTool.name} first.`,
       );
     }
     return driverState;

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -26,7 +26,7 @@ export namespace McpState {
 
 export abstract class McpState {
   // Global state for driver management
-  private static drivers: Record<string, McpState.Driver> = {}; // driver_id -> driver state
+  private static drivers: Record<string, McpState.Driver> = {}; // id -> driver state
 
   private static cleanupHooksRegistered = false;
   private static cleanupAllPromise: Promise<void> | null = null;
@@ -35,39 +35,39 @@ export abstract class McpState {
    * Register a new driver instance.
    */
   static registerDriver(
-    driverId: string,
+    id: string,
     al: Alumni,
     mcpDriver: McpDriver,
     artifactsStore: McpArtifactsStore,
   ): void {
     this.registerCleanupHooks();
 
-    this.drivers[driverId] = {
+    this.drivers[id] = {
       al,
       mcpDriver,
       artifactsStore: artifactsStore,
       stepCounter: 1,
     };
 
-    logger.debug(`Registered driver ${driverId}`);
+    logger.debug(`Registered driver ${id}`);
   }
 
   /**
    * Get driver's Alumni instance by driver ID.
    */
-  static getDriverAlumni(driverId: string): Alumni {
-    const driverState = this.getDriverState(driverId);
+  static getDriverAlumni(id: string): Alumni {
+    const driverState = this.getDriverState(id);
     return driverState.al;
   }
 
   /**
    * Increment driver step counter and return new step number.
    *
-   * @param driverId Driver ID.
+   * @param id Driver ID.
    * @returns New step number after increment.
    */
-  static incrementStepNum(driverId: string): number {
-    const driverState = this.getDriverState(driverId);
+  static incrementStepNum(id: string): number {
+    const driverState = this.getDriverState(id);
     const newStepCounter = driverState.stepCounter++;
     return newStepCounter;
   }
@@ -75,13 +75,13 @@ export abstract class McpState {
   /**
    * Get driver state by ID.
    */
-  static getDriverState(driverId: string): McpState.Driver {
-    const driverState = this.drivers[driverId];
+  static getDriverState(id: string): McpState.Driver {
+    const driverState = this.drivers[id];
     if (!driverState) {
-      logger.error(`Driver state for ${driverId} not found`);
+      logger.error(`Driver state for ${id} not found`);
       // NOTE: This error is required for the controlling agent calling MCP.
       throw new Error(
-        `Driver ${driverId} not found. Call ${startMcpTool.name} first.`,
+        `Driver ${id} not found. Call ${startMcpTool.name} first.`,
       );
     }
     return driverState;
@@ -90,18 +90,16 @@ export abstract class McpState {
   /**
    * Clean up driver and return artifacts directory and stats.
    */
-  static async cleanupDriver(
-    driverId: string,
-  ): Promise<[string, LlmUsageStats]> {
-    const driverState = this.getDriverState(driverId);
+  static async cleanupDriver(id: string): Promise<[string, LlmUsageStats]> {
+    const driverState = this.getDriverState(id);
 
-    logger.debug(`Cleaning up driver ${driverId}`);
+    logger.debug(`Cleaning up driver ${id}`);
 
     const { al, mcpDriver } = driverState;
     const stats = await al.getStats();
 
     if (mcpDriver instanceof PlaywrightDriver) {
-      logger.debug(`Driver ${driverId}: Stopping Playwright tracing`);
+      logger.debug(`Driver ${id}: Stopping Playwright tracing`);
 
       const tracePath =
         await driverState.artifactsStore.ensureFilePath("trace.zip");
@@ -113,27 +111,26 @@ export abstract class McpState {
       "token-stats.json",
       stats,
     );
-    logger.info(`Driver ${driverId}: Token stats saved to ${statsPath}`);
+    logger.info(`Driver ${id}: Token stats saved to ${statsPath}`);
 
     await al.quit();
 
-    delete this.drivers[driverId];
+    delete this.drivers[id];
 
-    logger.debug(`Driver ${driverId} cleanup complete`);
+    logger.debug(`Driver ${id} cleanup complete`);
 
     return [driverState.artifactsStore.dir, stats];
   }
 
   static async cleanupAllDrivers(): Promise<void> {
-    const driverIds = Object.keys(this.drivers);
+    const ids = Object.keys(this.drivers);
     await Promise.all(
-      driverIds.map(async (driverId) => {
-        logger.debug(`Exit hook: stopping driver ${driverId}`);
-        await this.cleanupDriver(driverId).catch((err) => {
-          logger.debug(
-            `Exit hook: error stopping driver ${driverId}: {error}`,
-            { error: err },
-          );
+      ids.map(async (id) => {
+        logger.debug(`Exit hook: stopping driver ${id}`);
+        await this.cleanupDriver(id).catch((err) => {
+          logger.debug(`Exit hook: error stopping driver ${id}: {error}`, {
+            error: err,
+          });
         });
       }),
     );

--- a/packages/typescript/src/mcp/tools/McpTool.ts
+++ b/packages/typescript/src/mcp/tools/McpTool.ts
@@ -36,7 +36,7 @@ export namespace McpTool {
 }
 
 export abstract class McpTool {
-  static DriverInput = z.object({ driver_id: z.string() });
+  static IdInput = z.object({ id: z.string() });
 
   static OutputContent = z.object({
     type: z.literal("text"),
@@ -51,11 +51,11 @@ export abstract class McpTool {
   ): McpTool.Definition<Name, Input> {
     // Instrument with input/output logging
     const execute = async (input: z.infer<Input>) => {
-      const parsedInput = McpTool.DriverInput.safeParse(input);
-      const driverId = parsedInput.data?.driver_id;
+      const parsedInput = McpTool.IdInput.safeParse(input);
+      const id = parsedInput.data?.id;
       const executeLogger = bindLogger(
         logger,
-        (message) => `${driverId || "global"}/${name}(): ${message}`,
+        (message) => `${id || "global"}/${name}(): ${message}`,
       );
 
       executeLogger.info("Executing");

--- a/packages/typescript/src/mcp/tools/checkMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/checkMcpTool.ts
@@ -11,7 +11,7 @@ export const checkMcpTool = McpTool.define("check", {
   description:
     "Verify a statement is true about the current page. Returns the result and explanation.",
 
-  inputSchema: McpTool.DriverInput.extend({
+  inputSchema: McpTool.IdInput.extend({
     statement: z
       .string()
       .describe("Statement to verify (e.g., 'page title contains Dashboard')"),
@@ -23,9 +23,9 @@ export const checkMcpTool = McpTool.define("check", {
   }),
 
   async execute(input, { logger }) {
-    const { driver_id: driverId, statement, vision } = input;
+    const { id, statement, vision } = input;
 
-    const al = McpState.getDriverAlumni(driverId);
+    const al = McpState.getDriverAlumni(id);
 
     let explanation = "";
     let result = "";
@@ -42,7 +42,7 @@ export const checkMcpTool = McpTool.define("check", {
     }
 
     await McpArtifactsStore.saveScreenshot({
-      driverId,
+      id,
       description: `check ${statement}`,
     });
 

--- a/packages/typescript/src/mcp/tools/doMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/doMcpTool.ts
@@ -66,7 +66,7 @@ export const doMcpTool = McpTool.define("do", {
     "Note that you don't need to scroll the page to interact with elements, Alumnium can locate and work with elements outside the viewport.",
 
   inputSchema: z.object({
-    driver_id: z.string().describe("Driver ID from start_driver"),
+    id: z.string().describe("Driver ID from start"),
 
     goal: z
       .string()
@@ -76,13 +76,13 @@ export const doMcpTool = McpTool.define("do", {
   }),
 
   async execute(input, { logger }) {
-    const { driver_id: driverId, goal } = input;
+    const { id, goal } = input;
 
-    const al = McpState.getDriverAlumni(driverId);
+    const al = McpState.getDriverAlumni(id);
     const { steps, explanation, changes } = await al.do(goal);
 
     logger.debug(`Completed with ${steps.length} steps`);
-    await McpArtifactsStore.saveScreenshot({ driverId, description: goal });
+    await McpArtifactsStore.saveScreenshot({ id, description: goal });
 
     // Build structured response
     const performedSteps = steps.map((step) => ({

--- a/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
@@ -14,13 +14,13 @@ export const fetchAccessibilityTreeMcpTool = McpTool.define(
       "Get structured representation of current page for debugging. Useful for understanding page structure or debugging.",
 
     inputSchema: z.object({
-      driver_id: z.string(),
+      id: z.string(),
     }),
 
     async execute(input) {
-      const { driver_id: driverId } = input;
+      const { id } = input;
 
-      const al = McpState.getDriverAlumni(driverId);
+      const al = McpState.getDriverAlumni(id);
       // Access the internal driver's accessibility tree
       // as if it's processed by Alumnium server
       const client = al.client;

--- a/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
@@ -29,9 +29,9 @@ export const fetchAccessibilityTreeMcpTool = McpTool.define(
         (await al.driver.getAccessibilityTree()).toStr(),
       );
 
-      const text = `Accessibility Tree:\n${tree.toXml(client.session.excludeAttributes)}`;
-
-      return [{ type: "text", text }];
+      return [
+        { type: "text", text: tree.toXml(client.session.excludeAttributes) },
+      ];
     },
   },
 );

--- a/packages/typescript/src/mcp/tools/getMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/getMcpTool.ts
@@ -11,7 +11,7 @@ export const getMcpTool = McpTool.define("get", {
     "Extract data from the page (e.g., 'user name', 'product prices', 'item count'). Returns the extracted data if it's available or explanation why it can't be extracted.",
 
   inputSchema: z.object({
-    driver_id: z.string(),
+    id: z.string(),
 
     data: z.string().describe("Description of data to extract"),
 
@@ -22,13 +22,13 @@ export const getMcpTool = McpTool.define("get", {
   }),
 
   async execute(input) {
-    const { driver_id: driverId, data, vision } = input;
+    const { id, data, vision } = input;
 
-    const al = McpState.getDriverAlumni(driverId);
+    const al = McpState.getDriverAlumni(id);
     const result = await al.get(data, { vision });
 
     await McpArtifactsStore.saveScreenshot({
-      driverId,
+      id,
       description: `get ${data}`,
     });
 

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -140,12 +140,12 @@ export const startMcpTool = McpTool.define("start", {
     // Generate driver ID from current directory and timestamp
     const cwdName = path.basename(process.cwd());
     const timestamp = Math.floor(Date.now() / 1000);
-    const driverId = `${cwdName}-${timestamp}`;
+    const id = `${cwdName}-${timestamp}`;
 
-    logger.info(`Starting driver ${driverId} for platform: ${platformName}`);
+    logger.info(`Starting driver ${id} for platform: ${platformName}`);
 
     // Create artifacts directories
-    const artifactsStore = new McpArtifactsStore(driverId);
+    const artifactsStore = new McpArtifactsStore(id);
 
     // Detect platform and create appropriate driver
     let driver: McpDriver;
@@ -204,18 +204,18 @@ export const startMcpTool = McpTool.define("start", {
     }
 
     // Register driver in global state
-    McpState.registerDriver(driverId, al, driver, artifactsStore);
+    McpState.registerDriver(id, al, driver, artifactsStore);
 
     return [
       {
         type: "text",
         text: JSON.stringify({
-          id: driverId,
+          id: id,
           driver: al.driver.constructor.name
             .replace(/Driver$/, "")
             .toLowerCase(),
-          platform_name: platformName,
           model: `${al.model.provider}/${al.model.name}`,
+          platform_name: platformName,
         }),
       },
     ];

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -23,9 +23,9 @@ import { McpTool } from "./McpTool.ts";
 /**
  * Start a new driver instance.
  */
-export const startDriverMcpTool = McpTool.define("start_driver", {
+export const startMcpTool = McpTool.define("start", {
   description:
-    "Initialize a browser driver for automated testing. Returns a driver_id for use in other calls.",
+    "Initialize a browser driver for automated testing. Returns an id for use in other calls.",
 
   inputSchema: z.object({
     capabilities: z
@@ -210,8 +210,10 @@ export const startDriverMcpTool = McpTool.define("start_driver", {
       {
         type: "text",
         text: JSON.stringify({
-          driver_id: driverId,
-          driver_type: al.driver.constructor.name,
+          id: driverId,
+          driver: al.driver.constructor.name
+            .replace(/Driver$/, "")
+            .toLowerCase(),
           platform_name: platformName,
           model: `${al.model.provider}/${al.model.name}`,
         }),

--- a/packages/typescript/src/mcp/tools/stopMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/stopMcpTool.ts
@@ -10,7 +10,7 @@ export const stopMcpTool = McpTool.define("stop", {
   description: "Close browser/app and cleanup driver resources.",
 
   inputSchema: z.object({
-    driver_id: z.string(),
+    id: z.string(),
 
     save_cache: z
       .boolean()
@@ -21,24 +21,24 @@ export const stopMcpTool = McpTool.define("stop", {
   }),
 
   async execute(input, { logger }) {
-    const driverId = String(input["driver_id"]);
+    const id = String(input.id);
     const saveCache = Boolean(input["save_cache"] || false);
 
     // Save cache if requested
     if (saveCache) {
-      const al = McpState.getDriverAlumni(driverId);
+      const al = McpState.getDriverAlumni(id);
       await al.cache.save();
       logger.info("Cache saved");
     }
 
     // Cleanup driver and get stats
-    const [artifactsDir, stats] = await McpState.cleanupDriver(driverId);
+    const [artifactsDir, stats] = await McpState.cleanupDriver(id);
 
     return [
       {
         type: "text",
         text: JSON.stringify({
-          id: driverId,
+          id: id,
           artifacts_dir: path.resolve(artifactsDir),
           token_usage: {
             total: stats["total"],

--- a/packages/typescript/src/mcp/tools/stopMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/stopMcpTool.ts
@@ -6,7 +6,7 @@ import { McpTool } from "./McpTool.ts";
 /**
  * Stop driver and cleanup.
  */
-export const stopDriverMcpTool = McpTool.define("stop_driver", {
+export const stopMcpTool = McpTool.define("stop", {
   description: "Close browser/app and cleanup driver resources.",
 
   inputSchema: z.object({
@@ -38,7 +38,7 @@ export const stopDriverMcpTool = McpTool.define("stop_driver", {
       {
         type: "text",
         text: JSON.stringify({
-          driver_id: driverId,
+          id: driverId,
           artifacts_dir: path.resolve(artifactsDir),
           token_usage: {
             total: stats["total"],

--- a/packages/typescript/src/mcp/tools/waitMcpTool.test.ts
+++ b/packages/typescript/src/mcp/tools/waitMcpTool.test.ts
@@ -36,7 +36,7 @@ describe("waitMcpTool", () => {
     expect(sleep).toHaveBeenCalledWith(30000);
   });
 
-  it("requires driver_id when waiting for condition", async () => {
+  it("requires id when waiting for condition", async () => {
     const result = await waitMcpTool.execute({
       for: "user is logged in",
       timeout: 10,
@@ -45,7 +45,7 @@ describe("waitMcpTool", () => {
       {
         type: "text",
         text: JSON.stringify({
-          error: "driver_id is required when waiting for a condition",
+          error: "id is required when waiting for a condition",
         }),
       },
     ]);
@@ -54,7 +54,7 @@ describe("waitMcpTool", () => {
   it("returns success when condition is met immediately", async () => {
     const check = mockCheck(async () => "The condition is satisfied");
     const result = await waitMcpTool.execute({
-      driver_id: "test-123",
+      id: "test-123",
       for: "user is logged in",
       timeout: 10,
     });
@@ -77,7 +77,7 @@ describe("waitMcpTool", () => {
       .mockRejectedValueOnce(new AssertionError("Not yet"))
       .mockRejectedValueOnce(new AssertionError("Still not"));
     const result = await waitMcpTool.execute({
-      driver_id: "test-123",
+      id: "test-123",
       for: "page loaded",
       timeout: 10,
     });
@@ -100,7 +100,7 @@ describe("waitMcpTool", () => {
       throw new AssertionError("Condition not satisfied");
     });
     const result = await waitMcpTool.execute({
-      driver_id: "test-123",
+      id: "test-123",
       for: "element visible",
       timeout: 0.001,
     });
@@ -125,7 +125,7 @@ describe("waitMcpTool", () => {
 
     await expect(
       waitMcpTool.execute({
-        driver_id: "test-123",
+        id: "test-123",
         for: "element visible",
         timeout: 1,
       }),
@@ -135,13 +135,17 @@ describe("waitMcpTool", () => {
   it("uses default timeout when timeout is omitted", async () => {
     const check = mockCheck(async () => "OK");
     const result = await waitMcpTool.execute({
-      driver_id: "test-123",
+      id: "test-123",
       for: "test condition",
     });
     expect(result).toEqual([
       {
         type: "text",
-        text: JSON.stringify({ status: "met", condition: "test condition", explanation: "OK" }),
+        text: JSON.stringify({
+          status: "met",
+          condition: "test condition",
+          explanation: "OK",
+        }),
       },
     ]);
     expect(check).toHaveBeenCalledTimes(1);

--- a/packages/typescript/src/mcp/tools/waitMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/waitMcpTool.ts
@@ -12,11 +12,9 @@ export const waitMcpTool = McpTool.define("wait", {
     "Wait for a specified duration or until a condition is met. Pass a number to wait that many seconds (1-30). Pass a string to wait for a natural language condition (e.g., 'My Account text', 'user is logged in', 'page shows success'). Uses AI-powered verification to check conditions.",
 
   inputSchema: z.object({
-    driver_id: z
+    id: z
       .string()
-      .describe(
-        "Driver ID from start_driver (required for condition-based waiting)",
-      )
+      .describe("Driver ID from start (required for condition-based waiting)")
       .optional(),
 
     for: z
@@ -35,7 +33,7 @@ export const waitMcpTool = McpTool.define("wait", {
   }),
 
   async execute(input, { logger }) {
-    const { for: waitFor, driver_id: driverId, timeout: inputTimeout } = input;
+    const { for: waitFor, id, timeout: inputTimeout } = input;
 
     // If it's a number, wait that many seconds
     if (typeof waitFor === "number") {
@@ -49,12 +47,12 @@ export const waitMcpTool = McpTool.define("wait", {
     }
 
     // Otherwise, treat as natural language condition
-    if (!driverId) {
+    if (!id) {
       return [
         {
           type: "text",
           text: JSON.stringify({
-            error: "driver_id is required when waiting for a condition",
+            error: "id is required when waiting for a condition",
           }),
         },
       ];
@@ -63,7 +61,7 @@ export const waitMcpTool = McpTool.define("wait", {
     const timeout = typeof inputTimeout === "number" ? inputTimeout : 10;
     const pollInterval = 1.0;
 
-    const al = McpState.getDriverAlumni(driverId);
+    const al = McpState.getDriverAlumni(id);
 
     const startTime = Date.now();
     let lastError: string | undefined;


### PR DESCRIPTION
Hides `driver` from MCP as an implementation detail:

1. The `start_driver` tool is now called `start`.
2. The `stop_driver` tool is now called `stop`.
3. The `driver_id` input is now called `id`.