### PR TITLE
test: add test for scope_to_area edge case

### DIFF
--- a/packages/python/tests/accessibility/test_chromium_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_chromium_accessibility_tree.py
@@ -20,9 +20,10 @@ def test_element_by_id(chromium_tree: ChromiumAccessibilityTree):
     assert chromium_tree.element_by_id(2).backend_node_id == 6
     assert chromium_tree.element_by_id(3).backend_node_id == 5
 
+
 def test_scope_to_area_returns_original_if_not_found(chromium_tree: ChromiumAccessibilityTree):
     # Try to scope to a non-existent element
     result = chromium_tree.scope_to_area(99999)
-    
+
     # Should return the original tree when element not found
     assert result.to_str() == chromium_tree.to_str()

--- a/packages/python/tests/accessibility/test_chromium_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_chromium_accessibility_tree.py
@@ -19,3 +19,10 @@ def test_element_by_id(chromium_tree: ChromiumAccessibilityTree):
     assert chromium_tree.element_by_id(1).backend_node_id == 7
     assert chromium_tree.element_by_id(2).backend_node_id == 6
     assert chromium_tree.element_by_id(3).backend_node_id == 5
+
+def test_scope_to_area_returns_original_if_not_found(chromium_tree: ChromiumAccessibilityTree):
+    # Try to scope to a non-existent element
+    result = chromium_tree.scope_to_area(99999)
+    
+    # Should return the original tree when element not found
+    assert result.to_str() == chromium_tree.to_str()


### PR DESCRIPTION
## Summary
Adds test coverage for [ChromiumAccessibilityTree.scope_to_area()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py:206:4-239:58) method when the target element is not found.

**What was added:**
- [test_scope_to_area_returns_original_if_not_found()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/tests/accessibility/test_chromium_accessibility_tree.py:22:0-27:52) - verifies that when [scope_to_area()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py:206:4-239:58) is called with a non-existent `raw_id`, it returns the original tree unchanged rather than raising an error or returning an empty tree.

## Type of Change
- Test Coverage 
