### PR TITLE
test: add XCUITestAccessibilityTree scope_to_area edge case test

### DIFF
--- a/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
@@ -24,6 +24,7 @@ def test_element_by_id(simple_tree: XCUITestAccessibilityTree):
     assert element.name == "Continue"
     assert element.type == "XCUIElementTypeButton"
 
+
 def test_scope_to_area_returns_original_if_not_found(simple_tree: XCUITestAccessibilityTree):
     # Try to scope to a non-existent element
     result = simple_tree.scope_to_area(99999)

--- a/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
@@ -23,3 +23,9 @@ def test_element_by_id(simple_tree: XCUITestAccessibilityTree):
     assert element.id == 74
     assert element.name == "Continue"
     assert element.type == "XCUIElementTypeButton"
+
+def test_scope_to_area_returns_original_if_not_found(simple_tree: XCUITestAccessibilityTree):
+    # Try to scope to a non-existent element
+    result = simple_tree.scope_to_area(99999)
+    # Should return the original tree when element not found
+    assert result.to_str() == simple_tree.to_str()


### PR DESCRIPTION
Hi!  @p0deje 

This PR adds a test for the [scope_to_area()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py:206:4-239:58) method in [XCUITestAccessibilityTree](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/accessibility/xcuitest_accessibility_tree.py:6:0-99:52) to cover the edge case when the target element is not found.

**What was added:**
- [test_scope_to_area_returns_original_if_not_found()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/tests/accessibility/test_chromium_accessibility_tree.py:23:0-28:52) - verifies that when [scope_to_area()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py:206:4-239:58) is called with a non-existent `raw_id`, it returns the original tree unchanged.

**Why:**
Following the same pattern as #308 (ChromiumAccessibilityTree), this ensures consistent test coverage across all accessibility tree implementations. The method behavior was previously untested for this edge case.

