### PR TITLE
test: add uiatumator2 scope_to_area edge case test

### DIFF
--- a/packages/python/tests/accessibility/test_uiautomator2_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_uiautomator2_accessibility_tree.py
@@ -24,3 +24,10 @@ def test_element_by_id(simple_tree: UIAutomator2AccessibilityTree):
     assert element.id == 9
     assert element.androidresourceid == "org.wikipedia.alpha:id/fragment_container"
     assert element.type == "android.widget.FrameLayout"
+
+
+def test_scope_to_area_returns_original_if_not_found(simple_tree: UIAutomator2AccessibilityTree):
+    # Try to scope to a non-existent element
+    result = simple_tree.scope_to_area(99999)
+    # Should return the original tree when element not found
+    assert result.to_str() == simple_tree.to_str()


### PR DESCRIPTION
Hi! @p0deje 

This PR adds a test for the scope_to_area() method in UIAutomator2AccessibilityTree to cover the edge case when the target element is not found.

**What was added:**

test_scope_to_area_returns_original_if_not_found() - verifies that when scope_to_area() is called with a non-existent raw_id, it returns the original tree unchanged.

**Why:**
Following the same pattern as https://github.com/alumnium-hq/alumnium/pull/308 (ChromiumAccessibilityTree), this ensures consistent test coverage across all accessibility tree implementations. The method behavior was previously untested for this edge case.