### PR TITLE
refactor(typescript): use logger instead of console.debug in AppiumDr…

### DIFF
--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -11,6 +11,9 @@ import { PressKeyTool } from "../tools/PressKeyTool.ts";
 import { TypeTool } from "../tools/TypeTool.ts";
 import { BaseDriver } from "./BaseDriver.ts";
 import type { Keys } from "./keys.ts";
+import { getLogger } from "../utils/logger.ts";
+
+const logger = getLogger(import.meta.url);
 
 export class AppiumDriver extends BaseDriver {
   private driver: Browser;
@@ -177,7 +180,7 @@ export class AppiumDriver extends BaseDriver {
         predicate += ` AND ${propsStr}`;
       }
 
-      console.debug(`Finding element by predicate: ${predicate}`);
+      logger.debug(`Finding element by predicate: ${predicate}`);
       return this.driver.$(`-ios predicate string:${predicate}`).getElement();
     } else {
       // Use XPath for UIAutomator2
@@ -195,7 +198,7 @@ export class AppiumDriver extends BaseDriver {
         xpath += `[${conditions.join(" and ")}]`;
       }
 
-      console.debug(`Finding element by xpath: ${xpath}`);
+      logger.debug(`Finding element by xpath: ${xpath}`);
       return this.driver.$(xpath).getElement();
     }
   }


### PR DESCRIPTION
@p0deje 

## Summary
Replaces direct `console.debug` calls with the project's `logger` utility in [**AppiumDriver.ts**] file for consistency with other drivers.

## Changes Made
- Added import: `import { getLogger } from "../utils/logger.ts";`
- Added logger initialization: `const logger = getLogger(import.meta.url);`
- Replaced `console.debug` with `logger.debug`.

## Why This Change?
The codebase consistently uses the `getLogger` utility across all other drivers:
- [PlaywrightDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/PlaywrightDriver.ts:0:0-0:0) uses `logger.debug`
- [SeleniumDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/SeleniumDriver.ts:0:0-0:0) uses `logger.debug`