### PR TITLE
refactor(typescript): fix code quality issues

### DIFF
--- a/packages/typescript/src/Model.ts
+++ b/packages/typescript/src/Model.ts
@@ -31,7 +31,6 @@ export class ModelName {
   };
 }
 
-// TODO: Make class abstract and use plain object instead.
 export class Model {
   static PROVIDERS = [
     "azure_foundry",

--- a/packages/typescript/src/server/LlmFactory.ts
+++ b/packages/typescript/src/server/LlmFactory.ts
@@ -70,6 +70,8 @@ export class LlmFactory {
         return LlmFactory.createOpenAiLlm(model, cache);
       case "xai":
         return LlmFactory.createXAiLlm(model, cache);
+      default:
+        throw new Error(`Unknown provider: ${model.provider}`);
     }
   }
 

--- a/packages/typescript/src/server/serverApp.ts
+++ b/packages/typescript/src/server/serverApp.ts
@@ -27,7 +27,6 @@ export const serverApp = new Elysia({ prefix: "/v1" })
 
     return ctx.status(500, {
       message: ctx.error.toString(),
-      // TODO: Figure out how to pass the stack
       stack: "stack" in ctx.error ? ctx.error.stack : undefined,
     });
   })

--- a/packages/typescript/src/utils/logFormat.ts
+++ b/packages/typescript/src/utils/logFormat.ts
@@ -49,8 +49,6 @@ ${value}`,
     : [];
 
   const content = `${message}${lines.length ? "\n" : ""}${lines.join("\n")}`;
-  console.log(content);
-
   logger[method](content, payload);
 }
 


### PR DESCRIPTION
# Summary

This PR addresses several code quality issues in the TypeScript codebase:

- **Add missing default case in [LlmFactory.createLlm](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/server/LlmFactory.ts:39:2-75:3)** - The switch statement previously had no default case, which could silently return `undefined` if an unknown provider was passed. Now throws a clear error: `Unknown provider: ${model.provider}`

- **Remove redundant `console.log` in [logFormat.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/utils/logFormat.ts:0:0-0:0)** - The [logBlocks](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/utils/logFormat.ts:26:0-52:1) function had `console.log(content)` followed by `logger[method](content, payload)`. Removed the direct `console.log` call as the logger already handles output consistently

- **Remove outdated TODO in [serverApp.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/server/serverApp.ts:0:0-0:0)** - Comment said "TODO: Figure out how to pass the stack" but stack is already being passed on the next line - TODO is no longer relevant

- **Remove outdated TODO in [Model.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/Model.ts:0:0-0:0)** - Comment said "TODO: Make class abstract and use plain object instead" but the [Model](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/Model.ts:33:0-133:1) class is actively instantiated in multiple places (ResponseCache.test.ts, SessionManager.ts, etc.) - TODO is outdated

All changes are minimal and focused on code quality improvements.