### PR TITLE
fix(mcp): preserve caller args in goog:chromeOptions for Selenium driver

### DIFF
--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -134,11 +134,36 @@ export async function createSeleniumDriver(
     chromeOptions.addArguments("--headless=new");
   }
 
-  // Apply all capabilities to options
+  // Apply all capabilities to options.
+  //
+  // `goog:chromeOptions` is special-cased: setting it via `chromeOptions.set(...)`
+  // would replace the entire dict at that capability key, losing the built-in
+  // args/excludeSwitches set above and de-syncing the internal `options_` cache
+  // that `addArguments`/`addExtensions`/`setBinaryPath` mutate. Translate caller-
+  // supplied `args`/`extensions`/`binary` to the proper helpers so they merge
+  // cleanly with built-in state and actually reach the spawned browser.
   for (const [key, value] of Object.entries(capabilities)) {
-    if (key !== "platformName") {
-      chromeOptions.set(key, value);
+    if (key === "platformName") {
+      continue;
     }
+    if (key === "goog:chromeOptions" && value && typeof value === "object") {
+      const chromeOpts = value as {
+        args?: string[];
+        extensions?: (string | Buffer)[];
+        binary?: string;
+      };
+      if (chromeOpts.args?.length) {
+        chromeOptions.addArguments(...chromeOpts.args);
+      }
+      if (chromeOpts.extensions?.length) {
+        chromeOptions.addExtensions(...chromeOpts.extensions);
+      }
+      if (chromeOpts.binary) {
+        chromeOptions.setBinaryPath(chromeOpts.binary);
+      }
+      continue;
+    }
+    chromeOptions.set(key, value);
   }
 
   // Use remote driver if serverUrl provided, otherwise local Chrome


### PR DESCRIPTION
## Summary

`createSeleniumDriver` in `packages/typescript/src/mcp/mcpDrivers.ts` (lines ~137-142 on main) applies caller capabilities to `chrome.Options` via a generic `chromeOptions.set(key, value)` loop. For `goog:chromeOptions`, that replaces the entire capability dict at the key — which both clobbers the built-in args set above and de-syncs the internal `options_` reference that `addArguments`/`addExtensions`/`setBinaryPath` mutate. Caller-supplied `args` end up either lost or landing while quietly dropping alumnium's own defaults (`--disable-logging`, `--log-level=3`, `excludeSwitches: enable-logging`, optional `--headless=new`).

## Repro

Pass capabilities through the MCP `start_driver` tool:

```json
{
  "goog:chromeOptions": {
    "args": ["--window-position=-2000,0", "--no-default-browser-check"]
  }
}
```

Expected: spawned Chrome's argv contains `--window-position=-2000,0`.
Actual (before patch, on the equivalent Python code path that was structurally identical): `ps aux | grep [c]hrome` shows the Alumnium-spawned Chrome running with only `--enable-automation` and friends — no caller args land. Verified empirically against the Python MCP package which carried the same anti-pattern.

## Fix

Special-case `goog:chromeOptions` in the capability loop: translate caller `args` → `chromeOptions.addArguments(...)`, `extensions` → `chromeOptions.addExtensions(...)`, `binary` → `chromeOptions.setBinaryPath(...)`. These mutate `Options.options_` in place (the same object the constructor binds to the capability key), so they merge with built-in state instead of overwriting it.

No behavior change for capabilities that don't include `goog:chromeOptions`.

## Notes

- The Python tree shipped with the same anti-pattern. It was removed from `main` in the tsify migration (`753fcd9`), so this PR fixes only the TypeScript port. The PyPI 0.18.0 release is still affected; let me know if a back-port to `feat/telemetry` would be wanted.
- I did not run the TS test suite locally (Bun + dependency install would have exceeded the time budget for this drive-by); CI here will exercise it. The fix is mechanical and the existing capability-loop semantics are preserved for every key other than `goog:chromeOptions`.

## Test plan

- [ ] Existing unit/system tests still pass (CI)
- [ ] Manual: caller-supplied `goog:chromeOptions.args` land in spawned Chrome's argv (`ps aux`)
- [ ] Manual: built-in `--disable-logging`, `--log-level=3`, `excludeSwitches: enable-logging` still applied alongside caller args
- [ ] Manual: `headless=true` driverOption still produces `--headless=new` even when caller passes `goog:chromeOptions`