### PR TITLE
fix(python): add missing -> None return type hints in alumni.py

### DIFF
--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -78,7 +78,7 @@ class Alumni:
 
         self.cache = Cache(self.client)
 
-    def quit(self):
+    def quit(self) -> None:
         self.client.quit()
         self.driver.quit()
 
@@ -219,7 +219,7 @@ class Alumni:
             client=self.client,
         )
 
-    def learn(self, goal: str, actions: list[str]):
+    def learn(self, goal: str, actions: list[str]) -> None:
         """
         Adds a new learning example on what steps should be take to achieve the goal.
 
@@ -229,7 +229,7 @@ class Alumni:
         """
         self.client.add_example(goal, actions)
 
-    def clear_learn_examples(self):
+    def clear_learn_examples(self) -> None:
         """
         Clears the learn examples.
         """


### PR DESCRIPTION
## Problem

Three methods in `alumni.py` are missing `-> None` return type annotations, inconsistent with the rest of the class where all other methods have explicit return type hints:

- `quit(self):`
- - `learn(self, goal: str, actions: list[str]):`
- - `clear_learn_examples(self):`
## Fix

Add `-> None` return type annotations to these three methods to match the style used by `do()`, `check()`, `get()`, `find()`, `area()`, and `stats()`.