### PR TITLE
feat(mcp): auto-install playwright browser

### DIFF
--- a/packages/typescript/scripts/build.ts
+++ b/packages/typescript/scripts/build.ts
@@ -11,6 +11,7 @@ import { stringify as tomlStringify } from "smol-toml";
 import { z } from "zod";
 import { ALUMNIUM_VERSION } from "../src/package.ts";
 import {
+  PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
   PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
   SELENIUM_ATOM_ASSET_PREFIX,
   SELENIUM_MANAGER_ASSET_NAMES,
@@ -343,8 +344,7 @@ async function main() {
       }),
     );
 
-    await cleanUpDir(STANDALONE_EMBEDDED_ASSETS_DIR);
-    await fs.rmdir(STANDALONE_EMBEDDED_ASSETS_DIR);
+    await fs.rm(TMP_DIR, { recursive: true, force: true });
   }
 
   //#endregion
@@ -821,15 +821,58 @@ function getNpmOs(os: OS) {
 async function prepareStandaloneEmbeddedAssets() {
   await cleanUpDir(STANDALONE_EMBEDDED_ASSETS_DIR);
 
-  const assets = await getStandaloneEmbeddedAssets();
+  const [assets, oopDownloadPath] = await Promise.all([
+    getStandaloneEmbeddedAssets(),
+    buildPlaywrightOopDownloadBundle(),
+  ]);
+
+  const allAssets: StandaloneEmbeddedAsset[] = [
+    ...assets,
+    {
+      name: PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
+      sourcePath: oopDownloadPath,
+    },
+  ];
 
   return Promise.all(
-    assets.map(async ({ name, sourcePath }) => {
+    allAssets.map(async ({ name, sourcePath }) => {
       const stagedPath = path.join(STANDALONE_EMBEDDED_ASSETS_DIR, name);
       await fs.copyFile(sourcePath, stagedPath);
       return stagedPath;
     }),
   );
+}
+
+async function buildPlaywrightOopDownloadBundle(): Promise<string> {
+  const playwrightCorePkgDir = path.resolve(
+    PKG_DIR,
+    "node_modules/playwright-core",
+  );
+  const entrypoint = path.join(
+    playwrightCorePkgDir,
+    "lib/server/registry/oopDownloadBrowserMain.js",
+  );
+  const outDir = path.resolve(TMP_DIR, "playwright-oop-download");
+  await cleanUpDir(outDir);
+
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir: outDir,
+    target: "node",
+    format: "cjs",
+    packages: "bundle",
+    naming: "[name].cjs",
+    minify: false,
+  });
+
+  if (!result.success) {
+    throw new AggregateError(
+      result.logs.map((log) => new Error(log.message)),
+      "Failed to bundle playwright oopDownloadBrowserMain.js",
+    );
+  }
+
+  return path.join(outDir, "oopDownloadBrowserMain.cjs");
 }
 
 async function getStandaloneEmbeddedAssets(): Promise<

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -5,6 +5,7 @@
 import type { BrowserContext, Page } from "playwright-core";
 import { chromium } from "playwright-core";
 import { Builder, type WebDriver } from "selenium-webdriver";
+import { ensurePlaywrightChromiumInstalled } from "../standalone/installPlaywrightBrowsers.ts";
 import { Options } from "selenium-webdriver/chrome.js";
 import {
   remote as remoteWebdriverio,
@@ -85,6 +86,7 @@ export async function createPlaywrightDriver(
     logger.debug("Setting extra HTTP headers: {headers}", { headers });
   }
 
+  await ensurePlaywrightChromiumInstalled();
   const videosDir = await artifactsStore.ensureDir("videos");
 
   let context: BrowserContext;

--- a/packages/typescript/src/standalone/embeddedAssetNames.ts
+++ b/packages/typescript/src/standalone/embeddedAssetNames.ts
@@ -3,6 +3,9 @@ export const SELENIUM_ATOM_ASSET_PREFIX = "selenium-atom-";
 export const PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME =
   "playwright-core-package.json";
 
+export const PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME =
+  "playwright-core-oopDownloadBrowserMain.cjs";
+
 export const SELENIUM_MANAGER_ASSET_NAMES = {
   linux: "selenium-manager-linux",
   macos: "selenium-manager-macos",

--- a/packages/typescript/src/standalone/installPlaywrightBrowsers.ts
+++ b/packages/typescript/src/standalone/installPlaywrightBrowsers.ts
@@ -1,0 +1,171 @@
+// Auto-installs Playwright browsers (Chromium + FFmpeg) on first use.
+//
+// In dev mode `installBrowsersForNpmInstall` works as-is because all
+// node_modules are on disk. In the compiled Bun single-file binary it needs
+// extra wiring: playwright-core downloads browsers by forking itself via
+// child_process.fork to run oopDownloadBrowserMain.js. That script lives
+// inside $bunfs and its relative imports (manualPromise, network, zipBundle,
+// fileUtils) aren't available on disk. To fix this we:
+//
+//   1. Pre-bundle oopDownloadBrowserMain.js at Alumnium build time into a
+//      self-contained CJS file with all imports inlined (scripts/build.ts).
+//   2. Embed the bundle as an asset and extract it to a temp dir at runtime
+//      (setupEmbeddedDependencies.ts).
+//   3. Monkey-patch child_process.fork to redirect calls targeting
+//      oopDownloadBrowserMain.js to the extracted bundle.
+//   4. Set BUN_BE_BUN=1 on the fork so process.execPath (the alumnium binary)
+//      behaves as the Bun CLI and can execute the script.
+//
+// The patch is applied only while installBrowsersForNpmInstall is running and
+// removed immediately after, leaving fork unmodified for all other callers.
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { Logger } from "../telemetry/Logger.ts";
+import { isSingleFileExecutable } from "../bundle.ts";
+
+const logger = Logger.get(import.meta.url);
+
+let installPromise: Promise<void> | undefined;
+
+// Memoize the promise so concurrent `start` tool calls don't race each other
+// into parallel downloads. The promise is cleared on failure so the next call
+// can retry.
+export function ensurePlaywrightChromiumInstalled(): Promise<void> {
+  installPromise ??= installChromiumIfNeeded().catch((err) => {
+    installPromise = undefined;
+    throw err;
+  });
+  return installPromise;
+}
+
+async function installChromiumIfNeeded() {
+  // String literal dynamic import so Bun bundles playwright-core's registry
+  // at build time from alumnium's own node_modules. A variable import()
+  // is not bundled and fails at runtime in the binary with "Module not found".
+  //
+  // playwright-core/lib/server/registry/index is the same module that backs
+  // `npx playwright install`. It reads browser revision info from
+  // playwright-core's own package.json, which in the single-file binary is
+  // redirected to the embedded copy via the _resolveFilename hook in
+  // setupEmbeddedDependencies.ts, so the downloaded browser always matches
+  // the bundled runtime exactly.
+  //
+  // The import is lazy (inside this function, not at module top level) so the
+  // _resolveFilename hook is already installed before the registry module loads.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { registry, installBrowsersForNpmInstall } = (await import(
+    // @ts-expect-error — internal path, no type declarations
+    "playwright-core/lib/server/registry/index"
+  )) as any;
+
+  const chromiumExecutable = registry.findExecutable("chromium");
+  const chromiumHeadlessShellExecutable = registry.findExecutable(
+    "chromium-headless-shell",
+  );
+  const ffmpegExecutable = registry.findExecutable("ffmpeg");
+
+  const [chromiumInstalled, chromiumHeadlessShellInstalled, ffmpegInstalled] = [
+    isExeInstalled(chromiumExecutable),
+    isExeInstalled(chromiumHeadlessShellExecutable),
+    isExeInstalled(ffmpegExecutable),
+  ];
+
+  // Skip install only if every executable is already present on disk.
+  // All three must exist — otherwise we run the full install so that e.g.
+  // ffmpeg is not skipped when chromium is already there.
+  if (chromiumInstalled && chromiumHeadlessShellInstalled && ffmpegInstalled) {
+    logger.debug("Playwright browsers already installed");
+    return;
+  }
+
+  logger.info("Playwright chromium not found, installing...");
+
+  let restoreFork: (() => void) | undefined;
+  if (isSingleFileExecutable()) {
+    // Dynamic import keeps the `bun`-dependent module out of the vitest
+    // environment, which runs under Node and has no `bun` package.
+    const { setupEmbeddedDependencies, getExtractedPlaywrightOopDownloadPath } =
+      await import("./setupEmbeddedDependencies.ts");
+    await setupEmbeddedDependencies();
+    const oopDownloadPath = getExtractedPlaywrightOopDownloadPath();
+    if (!oopDownloadPath) {
+      throw new Error(
+        "Embedded Playwright download worker missing — please raise an issue at https://github.com/alumnium-hq/alumnium/issues.",
+      );
+    }
+    restoreFork = patchForkForOopDownload(oopDownloadPath);
+  }
+
+  try {
+    // ffmpeg is required for video recording (recordVideo is always enabled).
+    // chromium-headless-shell is used when headless mode is active.
+    await installBrowsersForNpmInstall([
+      "chromium",
+      "chromium-headless-shell",
+      "ffmpeg",
+    ]);
+  } finally {
+    restoreFork?.();
+  }
+
+  // Install system dependencies (shared libs, etc). Equivalent to
+  // `--with-deps`. Requires elevated privileges on Linux, so we swallow errors
+  // rather than failing the whole start call.
+  try {
+    await registry.installDeps(
+      [chromiumExecutable, chromiumHeadlessShellExecutable, ffmpegExecutable],
+      false,
+    );
+  } catch (err) {
+    logger.warn("Could not install Playwright system dependencies: {err}", {
+      err,
+    });
+  }
+
+  logger.info("Playwright Chromium installed successfully");
+}
+
+function isExeInstalled(executable: any): boolean {
+  const path = executable?.executablePath();
+  return path !== undefined && fs.existsSync(path);
+}
+
+// Redirects child_process.fork calls targeting oopDownloadBrowserMain.js (or .cjs)
+// to the pre-bundled self-contained CJS file extracted from the binary's assets.
+// BUN_BE_BUN=1 makes process.execPath (the alumnium binary) behave as the Bun CLI.
+function patchForkForOopDownload(extractedPath: string) {
+  const originalFork = childProcess.fork.bind(childProcess);
+
+  // @ts-expect-error — monkey-patching a built-in
+  childProcess.fork = (
+    modulePath: string,
+    args?: readonly string[],
+    options?: childProcess.ForkOptions,
+  ) => {
+    const basename = path.basename(String(modulePath));
+    if (
+      basename !== "oopDownloadBrowserMain.js" &&
+      basename !== "oopDownloadBrowserMain.cjs"
+    ) {
+      return originalFork(modulePath, args as string[], options);
+    }
+
+    logger.debug(
+      "Redirecting playwright fork to bundled worker: {extractedPath}",
+      {
+        extractedPath,
+      },
+    );
+
+    return originalFork(extractedPath, args as string[], {
+      ...options,
+      execPath: process.execPath,
+      env: { ...(options?.env ?? process.env), BUN_BE_BUN: "1" },
+    });
+  };
+
+  return () => {
+    childProcess.fork = originalFork as typeof childProcess.fork;
+  };
+}

--- a/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
+++ b/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { isSingleFileExecutable } from "../bundle.ts";
 import {
+  PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
   PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
   SELENIUM_ATOM_ASSET_PREFIX,
   SELENIUM_MANAGER_ASSET_NAMES,
@@ -32,6 +33,7 @@ const RUNTIME_SELENIUM_MANAGER_TARGETS = {
 
 interface ExtractedEmbeddedDependencies {
   playwrightPackageJsonPath: string;
+  playwrightOopDownloadPath: string;
   seleniumAtomsDir: string;
   seleniumManagerPath: string | undefined;
 }
@@ -42,10 +44,15 @@ interface EmbeddedFile extends Blob {
 
 let setupPromise: Promise<void> | undefined;
 let resolveHookInstalled = false;
+let extractedPlaywrightOopDownloadPath: string | undefined;
 
 export function setupEmbeddedDependencies() {
   setupPromise ??= setupEmbeddedDependenciesInternal();
   return setupPromise;
+}
+
+export function getExtractedPlaywrightOopDownloadPath(): string | undefined {
+  return extractedPlaywrightOopDownloadPath;
 }
 
 async function setupEmbeddedDependenciesInternal() {
@@ -57,6 +64,7 @@ async function setupEmbeddedDependenciesInternal() {
     process.env.SE_MANAGER_PATH ??= paths.seleniumManagerPath;
   }
 
+  extractedPlaywrightOopDownloadPath = paths.playwrightOopDownloadPath;
   installResolveHook(paths);
 }
 
@@ -75,6 +83,11 @@ async function extractEmbeddedDependencies(): Promise<ExtractedEmbeddedDependenc
     extractedDir,
     "playwright-core",
     "package.json",
+  );
+  const playwrightOopDownloadPath = path.join(
+    extractedDir,
+    "playwright-core",
+    "oopDownloadBrowserMain.cjs",
   );
 
   await Promise.all([
@@ -103,10 +116,16 @@ async function extractEmbeddedDependencies(): Promise<ExtractedEmbeddedDependenc
       PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
       playwrightPackageJsonPath,
     ),
+    writeEmbeddedFile(
+      filesByName,
+      PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
+      playwrightOopDownloadPath,
+    ),
   ]);
 
   return {
     playwrightPackageJsonPath,
+    playwrightOopDownloadPath,
     seleniumAtomsDir,
     seleniumManagerPath,
   };


### PR DESCRIPTION
Automatically installs Playwright browsers (Chromium, chromium-headless-shell, and FFmpeg) on the first start tool call when `ALUMNIUM_DRIVER=playwright` is set, so users no longer need to run `npx playwright install` manually. Because the compiled Bun binary bundles its own copy of playwright-core, using `npx` from the user's shell risks a version mismatch; instead, the install is driven programmatically using the same internal registry that backs npx playwright install, pinned to the bundled version. In the compiled binary, playwright-core downloads browsers by forking `oopDownloadBrowserMain.js`, but that script's relative imports only exist inside `$bunfs` and can't be executed directly — so `oopDownloadBrowserMain.js` is now pre-bundled at Alumnium build time into a self-contained CJS file with all imports inlined, embedded as an asset, extracted to a temp directory at runtime, and child_process.fork is briefly monkey-patched to redirect calls to it (with `BUN_BE_BUN=1` so the binary behaves as the Bun CLI). In dev mode the patch is skipped entirely and Playwright's normal fork path runs unchanged.