### PR TITLE
feat: add Shadow DOM support for Playwright driver (#235)

### DIFF
--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -40,6 +40,7 @@ interface CDPNode {
   _frame?: object;
   _frame_chain?: number[];
   _parent_iframe_backend_node_id?: number | undefined;
+  _is_shadow_dom?: boolean;
 }
 
 interface CDPFrameInfo {
@@ -270,7 +271,122 @@ export class PlaywrightDriver extends BaseDriver {
       }
     }
 
+    // Collect shadow DOM nodes from the main frame
+    // Note: Shadow DOM piercing for iframes would require additional per-frame handling
+    try {
+      const shadowNodes = await this.getShadowDomNodes();
+      allNodes.push(...shadowNodes);
+      if (shadowNodes.length > 0) {
+        logger.debug(`  -> Shadow DOM: ${shadowNodes.length} nodes added`);
+      }
+    } catch (error) {
+      logger.debug(
+        `  -> Shadow DOM failed (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
+
     return new ChromiumAccessibilityTree({ nodes: allNodes });
+  }
+
+  /**
+   * Get shadow DOM nodes from the page using CDP.
+   * This pierces into shadow roots to make shadow DOM elements accessible.
+   */
+  private async getShadowDomNodes(): Promise<CDPNode[]> {
+    const shadowNodes: CDPNode[] = [];
+    const processedNodes = new Set<string>();
+
+    // Get all DOM nodes to find shadow hosts
+    // Note: DOM.getFlattenedDocument with pierce=true traverses into shadow roots
+    const domResponse = (await this.client.send("DOM.getFlattenedDocument", {
+      depth: -1,
+      pierce: true,
+    })) as { nodes: Array<{ nodeId: number; backendNodeId?: number; nodeName?: string; shadowRoots?: unknown[] }> };
+
+    if (!domResponse.nodes) return shadowNodes;
+
+    // Find shadow hosts (nodes with shadow roots)
+    for (const domNode of domResponse.nodes) {
+      if (domNode.shadowRoots && domNode.shadowRoots.length > 0) {
+        // Get accessibility info for shadow host
+        try {
+          const axResponse = (await this.client.send(
+            "Accessibility.queryAXTree",
+            {
+              nodeId: domNode.nodeId,
+            },
+          )) as { nodes: CDPNode[] };
+
+          if (axResponse.nodes) {
+            for (const axNode of axResponse.nodes) {
+              // Skip if we already have this node
+              if (processedNodes.has(axNode.nodeId)) continue;
+              processedNodes.add(axNode.nodeId);
+
+              // Mark as shadow DOM node
+              axNode._is_shadow_dom = true;
+              shadowNodes.push(axNode);
+
+              // Recursively get children from this shadow tree
+              if (axNode.childIds) {
+                for (const childId of axNode.childIds) {
+                  const childNodes = await this.getShadowChildNodes(
+                    childId,
+                    processedNodes,
+                  );
+                  shadowNodes.push(...childNodes);
+                }
+              }
+            }
+          }
+        } catch {
+          // Ignore errors for individual shadow hosts
+        }
+      }
+    }
+
+    return shadowNodes;
+  }
+
+  /**
+   * Recursively get child nodes from shadow DOM.
+   */
+  private async getShadowChildNodes(
+    nodeId: string,
+    processedNodes: Set<string>,
+  ): Promise<CDPNode[]> {
+    const nodes: CDPNode[] = [];
+
+    if (processedNodes.has(nodeId)) return nodes;
+    processedNodes.add(nodeId);
+
+    try {
+      const response = (await this.client.send("Accessibility.queryAXTree", {
+        nodeId: Number.parseInt(nodeId),
+      })) as { nodes: CDPNode[] };
+
+      if (response.nodes) {
+        for (const node of response.nodes) {
+          node._is_shadow_dom = true;
+          nodes.push(node);
+
+          // Recursively get grandchildren
+          if (node.childIds) {
+            for (const childId of node.childIds) {
+              const childNodes = await this.getShadowChildNodes(
+                childId,
+                processedNodes,
+              );
+              nodes.push(...childNodes);
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore errors for individual nodes
+    }
+
+    return nodes;
   }
 
   @span("driver.click", spanAttrs)

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -301,7 +301,14 @@ export class PlaywrightDriver extends BaseDriver {
     const domResponse = (await this.client.send("DOM.getFlattenedDocument", {
       depth: -1,
       pierce: true,
-    })) as { nodes: Array<{ nodeId: number; backendNodeId?: number; nodeName?: string; shadowRoots?: unknown[] }> };
+    })) as {
+      nodes: Array<{
+        nodeId: number;
+        backendNodeId?: number;
+        nodeName?: string;
+        shadowRoots?: unknown[];
+      }>;
+    };
 
     if (!domResponse.nodes) return shadowNodes;
 

--- a/packages/typescript/tests/system/shadow-dom.test.ts
+++ b/packages/typescript/tests/system/shadow-dom.test.ts
@@ -1,0 +1,28 @@
+import { describe } from "vitest";
+import { baseIt } from "./helpers.ts";
+
+describe("Shadow DOM support", () => {
+  const it = baseIt;
+
+  it("shadow DOM elements appear in accessibility tree", async ({ expect, setup }) => {
+    const { al, driver, $ } = await setup();
+    
+    // Navigate to the-internet.herokuapp.com shadow DOM test page
+    await $.navigate("https://the-internet.herokuapp.com/shadowdom");
+
+    // Get accessibility tree XML directly from driver
+    const tree = await al.driver.getAccessibilityTree();
+    const xml = tree.toStr();
+
+    // Log the XML for debugging
+    console.log("Accessibility Tree XML:\n", xml);
+    
+    // The herokuapp shadowdom page has a simple shadow DOM structure
+    // with content inside shadow roots
+    // Before the fix, shadow DOM content would NOT appear in the accessibility tree
+    
+    // Check for "Let's have some different text!" which appears in the shadow DOM
+    // If shadow DOM piercing works, this text should be in the accessibility tree
+    expect(xml).toContain("In a list!");
+  });
+});

--- a/packages/typescript/tests/system/shadow-dom.test.ts
+++ b/packages/typescript/tests/system/shadow-dom.test.ts
@@ -4,9 +4,12 @@ import { baseIt } from "./helpers.ts";
 describe("Shadow DOM support", () => {
   const it = baseIt;
 
-  it("shadow DOM elements appear in accessibility tree", async ({ expect, setup }) => {
+  it("shadow DOM elements appear in accessibility tree", async ({
+    expect,
+    setup,
+  }) => {
     const { al, driver, $ } = await setup();
-    
+
     // Navigate to the-internet.herokuapp.com shadow DOM test page
     await $.navigate("https://the-internet.herokuapp.com/shadowdom");
 
@@ -16,11 +19,11 @@ describe("Shadow DOM support", () => {
 
     // Log the XML for debugging
     console.log("Accessibility Tree XML:\n", xml);
-    
+
     // The herokuapp shadowdom page has a simple shadow DOM structure
     // with content inside shadow roots
     // Before the fix, shadow DOM content would NOT appear in the accessibility tree
-    
+
     // Check for "Let's have some different text!" which appears in the shadow DOM
     // If shadow DOM piercing works, this text should be in the accessibility tree
     expect(xml).toContain("In a list!");

--- a/packages/typescript/tests/system/shadow-dom.test.ts
+++ b/packages/typescript/tests/system/shadow-dom.test.ts
@@ -8,7 +8,7 @@ describe("Shadow DOM support", () => {
     expect,
     setup,
   }) => {
-    const { al, driver, $ } = await setup();
+    const { al, $ } = await setup();
 
     // Navigate to the-internet.herokuapp.com shadow DOM test page
     await $.navigate("https://the-internet.herokuapp.com/shadowdom");

--- a/packages/typescript/tests/system/shadow-dom.test.ts
+++ b/packages/typescript/tests/system/shadow-dom.test.ts
@@ -24,8 +24,56 @@ describe("Shadow DOM support", () => {
     // with content inside shadow roots
     // Before the fix, shadow DOM content would NOT appear in the accessibility tree
 
-    // Check for "Let's have some different text!" which appears in the shadow DOM
+    // Check for "In a list!" which appears in the shadow DOM
     // If shadow DOM piercing works, this text should be in the accessibility tree
     expect(xml).toContain("In a list!");
+  });
+
+  it("al.do() can click shadow DOM elements", async ({
+    expect,
+    setup,
+  }) => {
+    const { al, $ } = await setup();
+
+    // Navigate to the-internet.herokuapp.com shadow DOM test page
+    await $.navigate("https://the-internet.herokuapp.com/shadowdom");
+
+    // Use al.do() to click on "In a list!" which is inside shadow DOM
+    await al.do("click 'In a list!'");
+
+    // If we get here without error, the click worked
+    expect(true).toBe(true);
+  });
+
+  it("al.get() can retrieve text from shadow DOM elements", async ({
+    expect,
+    setup,
+  }) => {
+    const { al, $ } = await setup();
+
+    // Navigate to the-internet.herokuapp.com shadow DOM test page
+    await $.navigate("https://the-internet.herokuapp.com/shadowdom");
+
+    // Use al.get() to retrieve text from shadow DOM
+    const result = await al.get("text of the list item in shadow DOM");
+    
+    // The page has "In a list!" text inside shadow DOM
+    expect(result).toContain("In a list!");
+  });
+
+  it("al.check() can verify shadow DOM content", async ({
+    expect,
+    setup,
+  }) => {
+    const { al, $ } = await setup();
+
+    // Navigate to the-internet.herokuapp.com shadow DOM test page
+    await $.navigate("https://the-internet.herokuapp.com/shadowdom");
+
+    // Use al.check() to verify shadow DOM content exists
+    await al.check("page contains 'In a list!'");
+    
+    // If we get here without error, the check passed
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
Hi @p0deje,

## Summary
Adds Shadow DOM support for the Playwright driver in typescript to fix issue #235.

## What changed
- Added [getShadowDomNodes()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/PlaywrightDriver.ts:287:2-345:3) method using CDP's `DOM.getFlattenedDocument` with `pierce: true`
- Added [getShadowChildNodes()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/PlaywrightDriver.ts:347:2-386:3) for recursive shadow DOM traversal
- Shadow DOM elements now appear in the accessibility tree

## How it works
Uses Chrome DevTools Protocol to pierce shadow roots and collect accessibility nodes that were previously invisible to the AI agent.

## Testing
- Added [shadow-dom.test.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/tests/system/shadow-dom.test.ts:0:0-0:0) that verifies shadow DOM elements appear in accessibility tree
- Test passes against https://the-internet.herokuapp.com/shadowdom

## Verification
- TypeScript compiles without errors
- Shadow DOM test passes
- No breaking changes to existing functionality