### PR TITLE
refactor: type-safe, centralized, and validated env vars access

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [],
+  "plugins": ["import"],
   "options": {
     "typeAware": true
   },
@@ -10,7 +10,10 @@
     // TODO: Create an issue in Oxlint or corresponding ESLint repo.
     "typescript/no-base-to-string": "off", // Useful but fails to detect branded types
     // TODO: Create an issue in Oxlint suggesting to add `exactOptionalPropertyTypes` support.
-    "typescript/no-duplicate-type-constituents": "off" // Useful but fails on optional arguments with `| undefined`
+    "typescript/no-duplicate-type-constituents": "off", // Useful but fails on optional arguments with `| undefined`
+
+    // Disallow circular dependencies (except for types).
+    "import/no-cycle": "error"
   },
   "settings": {
     "jsdoc": {

--- a/mise.lock
+++ b/mise.lock
@@ -498,3 +498,51 @@ provenance = "github-attestations"
 checksum = "sha256:7a0c424c7bc55a74751f13592235953ebbe182fa00355f7ae3fb7ab734a51638"
 url = "https://github.com/astral-sh/uv/releases/download/0.11.10/uv-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
+
+[[tools.watchexec]]
+version = "2.5.1"
+backend = "aqua:watchexec/watchexec"
+
+[tools.watchexec."platforms.linux-arm64"]
+checksum = "sha256:c073887583d502fa0b393a8b847bb4460a111b3b0a199d1f70dafd5d89e71a2f"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-aarch64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.linux-arm64-musl"]
+checksum = "sha256:c073887583d502fa0b393a8b847bb4460a111b3b0a199d1f70dafd5d89e71a2f"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-aarch64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.linux-x64"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.linux-x64-baseline"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.linux-x64-musl"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:9efabd08de720c1ee7e57b487fe11904f0966828e76146e2b5ea5deee90626be"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-unknown-linux-musl.tar.xz"
+
+[tools.watchexec."platforms.macos-arm64"]
+checksum = "sha256:c5e405dd1109940b2510398d2182990c1be59063b94e11d7ace9c7b435cb1df1"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-aarch64-apple-darwin.tar.xz"
+
+[tools.watchexec."platforms.macos-x64"]
+checksum = "sha256:bb74bf33286ff7f31dd8e763e017fbc0418360d88baefd35bc57d662d28394e2"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-apple-darwin.tar.xz"
+
+[tools.watchexec."platforms.macos-x64-baseline"]
+checksum = "sha256:bb74bf33286ff7f31dd8e763e017fbc0418360d88baefd35bc57d662d28394e2"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-apple-darwin.tar.xz"
+
+[tools.watchexec."platforms.windows-x64"]
+checksum = "sha256:aa448c2704ca1a37ce0f1fc75381d9a411946dd293cf6236293f549426a577f7"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-pc-windows-msvc.zip"
+
+[tools.watchexec."platforms.windows-x64-baseline"]
+checksum = "sha256:aa448c2704ca1a37ce0f1fc75381d9a411946dd293cf6236293f549426a577f7"
+url = "https://github.com/watchexec/watchexec/releases/download/v2.5.1/watchexec-2.5.1-x86_64-pc-windows-msvc.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,7 @@ oxfmt = "latest" # TS formatter
 "pipx:pyprojectsort" = "latest" # pyproject.toml formatter
 "pipx:wheel" = "latest" # Python wheel builder
 ollama = "latest"
+watchexec = "latest" # File system watcher
 
 [env]
 '_'.source = "scripts/env.sh"

--- a/packages/typescript/.oxlintrc.json
+++ b/packages/typescript/.oxlintrc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./../../node_modules/oxlint/configuration_schema.json",
   "extends": ["./../../.oxlintrc.json"],
+  "plugins": ["node"],
   "rules": {
     "no-restricted-imports": [
       "error",
@@ -19,7 +20,7 @@
           }
         ]
       }
-    ]
+    ],
 
     // TODO: Enabled when available in Oxlint, see: https://github.com/oxc-project/oxc/issues/479
     // "no-restricted-syntax": [
@@ -40,6 +41,9 @@
     //     "property": "join",
     //     "message": "Use `safePathJoin` instead of `path.join`"
     //   }
-    // ]
+    // ],
+
+    // Disallow `using process.env` directly, use `Env.get` instead.
+    "node/no-process-env": "error"
   }
 }

--- a/packages/typescript/mise.toml
+++ b/packages/typescript/mise.toml
@@ -218,6 +218,9 @@ run = "fnox exec -- bun evalite"
 [tasks.lint]
 run = "bun oxlint ."
 
+[tasks."lint:watch"]
+run = "watchexec --exts ts,js --clear -- bun oxlint ."
+
 [tasks."lint:fix"]
 run = "bun oxlint --fix ."
 

--- a/packages/typescript/scripts/build.ts
+++ b/packages/typescript/scripts/build.ts
@@ -32,6 +32,7 @@ const BASE_BUILD_TARGETS = [
 const BuildTarget = z.enum(BASE_BUILD_TARGETS);
 
 const BUILD_ONLY =
+  // oxlint-disable-next-line no-process-env -- It is ok in a script
   process.env.BUILD_ONLY?.split(",")?.map((target) =>
     BuildTarget.parse(target),
   ) || BASE_BUILD_TARGETS;

--- a/packages/typescript/scripts/get-ollama-model.ts
+++ b/packages/typescript/scripts/get-ollama-model.ts
@@ -2,6 +2,6 @@
 
 // This script outputs the current Ollama model id.
 
-import { ModelName } from "../src/Model.ts";
+import { Model } from "../src/Model.ts";
 
-process.stdout.write(ModelName.DEFAULT.ollama);
+process.stdout.write(Model.defaultProviderModel("ollama"));

--- a/packages/typescript/src/Env.ts
+++ b/packages/typescript/src/Env.ts
@@ -1,0 +1,340 @@
+import ansi from "picocolors";
+import { canonize } from "smolcanon";
+import { xxh32Str } from "smolxxh/str";
+import z from "zod";
+import { Driver } from "./drivers/Driver.ts";
+import { Model } from "./Model.ts";
+import { LoggerSchema } from "./telemetry/LoggerSchema.ts";
+import {
+  arrayString,
+  filenameString,
+  jsonString,
+  pathString,
+} from "./utils/schema.ts";
+import { maskString } from "./utils/string.ts";
+
+export namespace Env {
+  export type VarsRecord = Record<string, unknown>;
+
+  export interface InspectResult {
+    vars: VarsRecord;
+    valid: boolean;
+  }
+}
+
+const secrets = new Set();
+
+let cachedVars: Env.VarsRecord = {};
+let envLogger: LoggerSchema.Like | undefined = undefined;
+
+export const Env = {
+  get ALUMNIUM_CACHE() {
+    return envVar(
+      "ALUMNIUM_CACHE",
+      z
+        .union([z.enum(["sqlite", "filesystem"]), z.stringbool()])
+        .default("filesystem"),
+    );
+  },
+
+  get ALUMNIUM_CACHE_PATH() {
+    return envVar("ALUMNIUM_CACHE_PATH", pathString().optional());
+  },
+
+  get ALUMNIUM_CHANGE_ANALYSIS() {
+    return envVar("ALUMNIUM_CHANGE_ANALYSIS", z.stringbool().default(false));
+  },
+
+  get ALUMNIUM_DELAY() {
+    return envVar("ALUMNIUM_DELAY", z.coerce.number().default(0.5));
+  },
+
+  get ALUMNIUM_EXCLUDE_ATTRIBUTES() {
+    return envVar("ALUMNIUM_EXCLUDE_ATTRIBUTES", arrayString().default([]));
+  },
+
+  get ALUMNIUM_FULL_PAGE_SCREENSHOT() {
+    return envVar(
+      "ALUMNIUM_FULL_PAGE_SCREENSHOT",
+      z.stringbool().default(false),
+    );
+  },
+
+  get ALUMNIUM_LOG_LEVEL() {
+    return envVar("ALUMNIUM_LOG_LEVEL", LoggerSchema.Level);
+  },
+
+  get ALUMNIUM_LOG_PATH() {
+    return envVar("ALUMNIUM_LOG_PATH", pathString().optional());
+  },
+
+  get ALUMNIUM_LOG_FILENAME() {
+    return envVar("ALUMNIUM_LOG_FILENAME", filenameString().optional());
+  },
+
+  get ALUMNIUM_LOG_DEBUG_EXTRA() {
+    return envVar(
+      "ALUMNIUM_LOG_DEBUG_EXTRA",
+      arrayString(LoggerSchema.DebugExtra).default([]),
+    );
+  },
+
+  get ALUMNIUM_PRUNE_LOGS() {
+    // NOTE: We ignore invalid values here to avoid missing logs due to misconfiguration.
+    return envVar("ALUMNIUM_PRUNE_LOGS", z.stringbool().catch(true));
+  },
+
+  get ALUMNIUM_LOG_BUFFER_SIZE() {
+    // NOTE: We ignore invalid values here to avoid missing logs due to misconfiguration.
+    return envVar("ALUMNIUM_LOG_BUFFER_SIZE", z.coerce.number().catch(4096));
+  },
+
+  get ALUMNIUM_LOG_FLUSH_INTERVAL() {
+    // NOTE: We ignore invalid values here to avoid missing logs due to misconfiguration.
+    return envVar("ALUMNIUM_LOG_FLUSH_INTERVAL", z.coerce.number().catch(500));
+  },
+
+  get ALUMNIUM_TRACE() {
+    return envVar("ALUMNIUM_TRACE", z.stringbool().default(false));
+  },
+
+  get ALUMNIUM_DRIVER() {
+    return envVar("ALUMNIUM_DRIVER", Driver.Id);
+  },
+
+  get ALUMNIUM_APPIUM_SERVER() {
+    return envVar(
+      "ALUMNIUM_APPIUM_SERVER",
+      z.httpUrl().default("http://localhost:4723"),
+    );
+  },
+
+  get ALUMNIUM_MODEL() {
+    return envVar(
+      "ALUMNIUM_MODEL",
+      z
+        .union([
+          Model.Provider,
+          z.templateLiteral([Model.Provider, "/", z.string()]),
+        ])
+        .optional()
+        .transform((val): Model => {
+          const defaultProvider: Model.Provider = Env.GITHUB_ACTIONS
+            ? "github"
+            : "openai";
+          return Model.parse(typeof val === "string" ? val : defaultProvider);
+        }),
+    );
+  },
+
+  get ALUMNIUM_MCP_ARTIFACTS_DIR() {
+    return envVar("ALUMNIUM_MCP_ARTIFACTS_DIR", pathString().optional());
+  },
+
+  get ALUMNIUM_MCP_PROFILES_DIR() {
+    return envVar("ALUMNIUM_MCP_PROFILES_DIR", pathString().optional());
+  },
+
+  get ALUMNIUM_SERVER_URL() {
+    return envVar("ALUMNIUM_SERVER_URL", z.string().optional());
+  },
+
+  get ALUMNIUM_SERVER_DAEMONIZE() {
+    return envVar("ALUMNIUM_SERVER_DAEMONIZE", z.stringbool().default(false));
+  },
+
+  get ALUMNIUM_SERVER_PID_PATH() {
+    return envVar("ALUMNIUM_SERVER_PID_PATH", pathString().optional());
+  },
+
+  get ALUMNIUM_MODEL_RETRIES() {
+    return envVar("ALUMNIUM_MODEL_RETRIES", z.coerce.number().default(8));
+  },
+
+  get ALUMNIUM_MODEL_TIMEOUT() {
+    return envVar("ALUMNIUM_MODEL_TIMEOUT", z.coerce.number().default(90));
+  },
+
+  get ALUMNIUM_OLLAMA_URL() {
+    return envVar("ALUMNIUM_OLLAMA_URL", z.httpUrl().optional());
+  },
+
+  get ALUMNIUM_PLANNER() {
+    return envVar("ALUMNIUM_PLANNER", z.stringbool().default(true));
+  },
+
+  get ALUMNIUM_RETRIES() {
+    return envVar("ALUMNIUM_RETRIES", z.coerce.number().default(2));
+  },
+
+  get ALUMNIUM_NO_RETRY() {
+    return envVar("ALUMNIUM_NO_RETRY", z.stringbool().default(false));
+  },
+
+  get ALUMNIUM_STORE_DIR() {
+    return envVar("ALUMNIUM_STORE_DIR", pathString().default(".alumnium"));
+  },
+
+  get ALUMNIUM_PLAYWRIGHT_HEADLESS() {
+    return envVar("ALUMNIUM_PLAYWRIGHT_HEADLESS", z.stringbool().default(true));
+  },
+
+  get ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT() {
+    return envVar(
+      "ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT",
+      z.coerce.number().default(200),
+    );
+  },
+
+  get ALUMNIUM_DEV_DATA_TYPES_SCAN() {
+    return envVar(
+      "ALUMNIUM_DEV_DATA_TYPES_SCAN",
+      z.stringbool().default(false),
+    );
+  },
+
+  get ALUMNIUM_EVAL_TRIAL_COUNT() {
+    return envVar("ALUMNIUM_EVAL_TRIAL_COUNT", z.coerce.number().default(25));
+  },
+
+  get AWS_ACCESS_KEY() {
+    return secretEnvVar("AWS_ACCESS_KEY", z.string().optional());
+  },
+
+  get AWS_REGION_NAME() {
+    return secretEnvVar("AWS_REGION_NAME", z.string().default("us-east-1"));
+  },
+
+  get AWS_SECRET_KEY() {
+    return secretEnvVar("AWS_SECRET_KEY", z.string().optional());
+  },
+
+  get AZURE_FOUNDRY_API_KEY() {
+    return secretEnvVar("AZURE_FOUNDRY_API_KEY", z.string().optional());
+  },
+
+  get AZURE_FOUNDRY_API_VERSION() {
+    return envVar("AZURE_FOUNDRY_API_VERSION", z.string().optional());
+  },
+
+  get AZURE_FOUNDRY_TARGET_URI() {
+    return secretEnvVar("AZURE_FOUNDRY_TARGET_URI", z.string().optional());
+  },
+
+  get AZURE_OPENAI_API_KEY() {
+    return secretEnvVar("AZURE_OPENAI_API_KEY", z.string().optional());
+  },
+
+  get AZURE_OPENAI_API_VERSION() {
+    return envVar("AZURE_OPENAI_API_VERSION", z.string().optional());
+  },
+
+  get AZURE_OPENAI_DEFAULT_HEADERS() {
+    return envVar(
+      "AZURE_OPENAI_DEFAULT_HEADERS",
+      jsonString(z.record(z.string(), z.string())).optional(),
+    );
+  },
+
+  get AZURE_OPENAI_ENDPOINT() {
+    return secretEnvVar("AZURE_OPENAI_ENDPOINT", z.string().optional());
+  },
+
+  get OLLAMA_HOST() {
+    return envVar("OLLAMA_HOST", z.string().optional());
+  },
+
+  get OPENAI_CUSTOM_URL() {
+    return envVar("OPENAI_CUSTOM_URL", z.string().optional());
+  },
+
+  get LT_USERNAME() {
+    return secretEnvVar("LT_USERNAME", z.string().optional());
+  },
+
+  get LT_ACCESS_KEY() {
+    return secretEnvVar("LT_ACCESS_KEY", z.string().optional());
+  },
+
+  get CI() {
+    return envVar("CI", z.stringbool().default(false));
+  },
+
+  get GITHUB_ACTIONS() {
+    return envVar("GITHUB_ACTIONS", z.stringbool().default(false));
+  },
+
+  reset(): void {
+    cachedVars = {};
+  },
+
+  init(logger: LoggerSchema.Like): Env.InspectResult {
+    envLogger = logger;
+
+    const vars: Env.VarsRecord = {};
+    let valid = true;
+
+    for (const prop in Env) {
+      if (Object.getOwnPropertyDescriptor(Env, prop)?.get) {
+        try {
+          const val = Env[prop as keyof typeof Env];
+          vars[prop] = maskedValue(val, isSecret(val));
+        } catch {
+          valid = false;
+          vars[prop] = "<INVALID VALUE>";
+        }
+      }
+    }
+
+    return { vars, valid };
+  },
+};
+
+function secretEnvVar<Type>(name: string, Schema: z.ZodType<Type>): Type {
+  return envVar(name, Schema, true);
+}
+
+function envVar<Type>(
+  name: string,
+  Schema: z.ZodType<Type>,
+  isSecretVar?: boolean,
+): Type {
+  if (!(name in cachedVars)) {
+    // oxlint-disable-next-line no-process-env -- We need it to read env vars
+    const envVal = process.env[name];
+    const parsedVar = Schema.safeParse(envVal);
+
+    if (!parsedVar.success) {
+      const maskedVal = maskedValue(envVal, isSecretVar);
+      const message = `Invalid environment variable ${name} value \`${maskedVal}\``;
+
+      if (envLogger) envLogger.error(message);
+      else console.error(`${ansi.red("Error:")} ${message}`);
+
+      throw parsedVar.error;
+    }
+
+    const val = parsedVar.data;
+    if (isSecretVar) addSecret(val);
+
+    cachedVars[name] = val;
+  }
+
+  return cachedVars[name] as Type;
+}
+
+function isSecret(val: unknown): boolean {
+  return secrets.has(hashSecret(val));
+}
+
+function addSecret(val: unknown): void {
+  secrets.add(hashSecret(val));
+}
+
+function hashSecret(val: unknown): string {
+  return xxh32Str(canonize(val));
+}
+
+function maskedValue(val: unknown, isSecretVar: boolean | undefined): unknown {
+  return val != null && isSecretVar ? maskString(String(val)) : val;
+}

--- a/packages/typescript/src/FileStore/FileStore.ts
+++ b/packages/typescript/src/FileStore/FileStore.ts
@@ -172,7 +172,7 @@ export class FileStore {
    * be configured via environment variable or resolved from the specified
    * relative (to the global store directory `.alumnium`) path.
    *
-   * @param envDir Environment variable value, e.g. `process.env.ALUMNIUM_MCP_ARTIFACTS_DIR`.
+   * @param envDir Environment variable value, e.g. `Env.ALUMNIUM_MCP_ARTIFACTS_DIR`.
    * @param defaultDir Default subdirectory under global store, e.g. `artifacts`.
    * @param nestedDir Optional nested directory under the resolved subdirectory, e.g. driver ID.
    * @returns FileStore instance for the resolved directory.
@@ -189,7 +189,7 @@ export class FileStore {
    * Resolves a subdirectory path under the global store directory, allowing
    * override via environment variable.
    *
-   * @param envDir Environment variable value, e.g. `process.env.ALUMNIUM_MCP_ARTIFACTS_DIR`.
+   * @param envDir Environment variable value, e.g. `Env.ALUMNIUM_MCP_ARTIFACTS_DIR`.
    * @param defaultDir Default subdirectory under global store, e.g. `artifacts`.
    * @param nestedDir Optional nested directory under the resolved subdirectory, e.g. driver ID.
    * @returns Resolved path.

--- a/packages/typescript/src/FileStore/GlobalFileStorePaths.test.ts
+++ b/packages/typescript/src/FileStore/GlobalFileStorePaths.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { pushTeardown } from "../../tests/unit/mocks.ts";
+import { describe, expect, it, vi } from "vitest";
+import { pushMock } from "../../tests/unit/mocks.ts";
+import { Env } from "../Env.ts";
 import { GlobalFileStorePaths } from "./GlobalFileStorePaths.ts";
 
 describe("GlobalFileStorePaths", () => {
@@ -10,10 +11,9 @@ describe("GlobalFileStorePaths", () => {
     });
 
     it("allows to override global store directory via env var", () => {
-      process.env.ALUMNIUM_STORE_DIR = ".custom";
-      pushTeardown(() => {
-        delete process.env.ALUMNIUM_STORE_DIR;
-      });
+      pushMock(
+        vi.spyOn(Env, "ALUMNIUM_STORE_DIR", "get").mockReturnValue(".custom"),
+      );
       const result = GlobalFileStorePaths.globalSubDir("sub/dir");
       expect(result).toBe(".custom/sub/dir");
     });
@@ -25,11 +25,11 @@ describe("GlobalFileStorePaths", () => {
     });
 
     it("allows to override global store directory via env var", () => {
-      process.env.ALUMNIUM_STORE_DIR = ".custom";
-      pushTeardown(() => {
-        delete process.env.ALUMNIUM_STORE_DIR;
-      });
-      expect(GlobalFileStorePaths.globalDir).toBe(".custom");
+      pushMock(
+        vi.spyOn(Env, "ALUMNIUM_STORE_DIR", "get").mockReturnValue(".custom"),
+      );
+      const result = GlobalFileStorePaths.globalDir;
+      expect(result).toBe(".custom");
     });
   });
 });

--- a/packages/typescript/src/FileStore/GlobalFileStorePaths.ts
+++ b/packages/typescript/src/FileStore/GlobalFileStorePaths.ts
@@ -1,6 +1,5 @@
+import { Env } from "../Env.ts";
 import { safePathJoin } from "../utils/fs.ts";
-
-const DEFAULT_GLOBAL_STORE_DIR = ".alumnium";
 
 export abstract class GlobalFileStorePaths {
   /**
@@ -9,7 +8,7 @@ export abstract class GlobalFileStorePaths {
    * @returns The global store directory path.
    */
   static get globalDir(): string {
-    return process.env.ALUMNIUM_STORE_DIR ?? DEFAULT_GLOBAL_STORE_DIR;
+    return Env.ALUMNIUM_STORE_DIR;
   }
 
   /**

--- a/packages/typescript/src/Model.ts
+++ b/packages/typescript/src/Model.ts
@@ -1,135 +1,88 @@
 import z from "zod";
-import { Logger } from "./telemetry/Logger.ts";
-
-const logger = Logger.get(import.meta.url);
-
-const ALUMNIUM_MODEL = process.env.ALUMNIUM_MODEL || "";
 
 export namespace Model {
-  export type Schema = z.infer<typeof Model.Schema>;
+  export type Provider = z.infer<typeof ModelProvider>;
 
-  export type Dev = z.infer<typeof Model.Dev>;
-
-  export type Provider = z.infer<typeof Model.Provider>;
+  export type Dev = z.infer<typeof ModelDev>;
 }
 
-export class ModelName {
-  static readonly DEFAULT: Record<Model.Provider, string> = {
-    azure_foundry: "gpt-5-nano",
-    azure_openai: "gpt-5-nano",
-    anthropic: "claude-haiku-4-5-20251001",
-    aws_anthropic: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-    aws_meta: "us.meta.llama4-maverick-17b-instruct-v1:0",
-    codex: "gpt-5.4-mini",
-    deepseek: "deepseek-reasoner",
-    github: "gpt-4o-mini",
-    google: "gemini-3.1-flash-lite-preview",
-    mistralai: "mistral-medium-2505",
-    ollama: "qwen3.6",
-    openai: "gpt-5-nano-2025-08-07",
-    xai: "grok-4-1-fast-reasoning",
-  };
-}
-
-// TODO: Make class abstract and use plain object instead.
-export class Model {
-  static PROVIDERS = [
-    "azure_foundry",
-    "azure_openai",
-    "anthropic",
-    "aws_anthropic",
-    "aws_meta",
-    "codex",
-    "deepseek",
-    "github",
-    "google",
-    "mistralai",
-    "ollama",
-    "openai",
-    "xai",
-  ] as const;
-
-  static Provider = z.enum(Model.PROVIDERS);
-
-  static DEVS = [
-    "anthropic",
-    "google",
-    "deepseek",
-    "meta",
-    "mistralai",
-    "ollama",
-    "xai",
-    "openai",
-  ] as const;
-
-  static Dev = z.enum(Model.DEVS);
-
-  static Schema = z.object({
-    provider: Model.Provider,
-    name: z.string(),
-  });
-
+export interface Model {
   provider: Model.Provider;
   name: string;
-
-  static #currentModel: Model | undefined;
-
-  static get current(): Model {
-    if (!this.#currentModel) this.#currentModel = this.initialize();
-    return this.#currentModel;
-  }
-
-  constructor(provider?: Model.Provider | undefined, name?: string) {
-    // If provider is not provided, use the current model setup
-    if (!provider) {
-      const defaults = Model.defaults();
-      this.provider = defaults.provider;
-      this.name = defaults.name;
-      return;
-    }
-
-    // Apply model setup from arguments
-    this.provider = provider;
-    this.name = name || ModelName.DEFAULT[this.provider];
-  }
-
-  private static initialize() {
-    if (ALUMNIUM_MODEL) {
-      logger.debug(`Initializing model from ALUMNIUM_MODEL: ${ALUMNIUM_MODEL}`);
-    } else {
-      logger.debug(
-        "ALUMNIUM_MODEL not set, using default model for environment",
-      );
-    }
-
-    const model = new Model();
-    logger.debug(`Initialized current model ${model.provider}/${model.name}`);
-    return model;
-  }
-
-  static defaults(): Model.Schema {
-    let [providerStr, name] = ALUMNIUM_MODEL.toLowerCase().split("/");
-
-    let provider: Model.Provider = "openai";
-    if (providerStr) {
-      provider = Model.Provider.parse(providerStr);
-    } else if (process.env.GITHUB_ACTIONS) {
-      provider = "github";
-      name = ModelName.DEFAULT.github;
-    }
-
-    if (!name) name = ModelName.DEFAULT[provider];
-
-    return { provider, name };
-  }
-
-  toString() {
-    return `${this.provider}/${this.name}`;
-  }
-
-  static fromString(modelStr: string): Model {
-    const [providerStr, name] = modelStr.toLowerCase().split("/");
-    const provider = Model.Provider.parse(providerStr);
-    return new Model(provider, name);
-  }
 }
+
+const providers = [
+  "azure_foundry",
+  "azure_openai",
+  "anthropic",
+  "aws_anthropic",
+  "aws_meta",
+  "codex",
+  "deepseek",
+  "github",
+  "google",
+  "mistralai",
+  "ollama",
+  "openai",
+  "xai",
+] as const;
+
+const defaultModels: Record<Model.Provider, string> = {
+  azure_foundry: "gpt-5-nano",
+  azure_openai: "gpt-5-nano",
+  anthropic: "claude-haiku-4-5-20251001",
+  aws_anthropic: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+  aws_meta: "us.meta.llama4-maverick-17b-instruct-v1:0",
+  codex: "gpt-5.4-mini",
+  deepseek: "deepseek-reasoner",
+  github: "gpt-4o-mini",
+  google: "gemini-3.1-flash-lite-preview",
+  mistralai: "mistral-medium-2505",
+  ollama: "qwen3.6",
+  openai: "gpt-5-nano-2025-08-07",
+  xai: "grok-4-1-fast-reasoning",
+};
+
+const ModelProvider = z.enum(providers);
+
+const devs = [
+  "anthropic",
+  "google",
+  "deepseek",
+  "meta",
+  "mistralai",
+  "ollama",
+  "xai",
+  "openai",
+] as const;
+
+const ModelDev = z.enum(devs);
+
+export const Model = {
+  Provider: ModelProvider,
+
+  Dev: ModelDev,
+
+  new(
+    providerStr: string | Model.Provider,
+    nameStr: string | undefined,
+  ): Model {
+    const provider = Model.Provider.parse(providerStr, { reportInput: true });
+    const name = nameStr || Model.defaultProviderModel(provider);
+    return { provider, name };
+  },
+
+  parse(modelStr: string): Model {
+    const [provider, name] = modelStr.split("/");
+    if (!provider) throw new Error(`Invalid model string: ${modelStr}`);
+    return this.new(provider, name);
+  },
+
+  toString(modelId: Model): string {
+    return `${modelId.provider}/${modelId.name}`;
+  },
+
+  defaultProviderModel(provider: Model.Provider): string {
+    return defaultModels[provider];
+  },
+};

--- a/packages/typescript/src/cli/binWrapper.ts
+++ b/packages/typescript/src/cli/binWrapper.ts
@@ -10,6 +10,7 @@ async function main() {
 
   const child = spawn(binPath, process.argv.slice(2), {
     stdio: "inherit",
+    // oxlint-disable-next-line no-process-env -- We need it to pass env vars
     env: process.env,
   });
 

--- a/packages/typescript/src/client/Alumni.ts
+++ b/packages/typescript/src/client/Alumni.ts
@@ -14,6 +14,7 @@ import {
   PlaywrightDriver,
   SeleniumDriver,
 } from "../drivers/index.ts";
+import { Env } from "../Env.ts";
 import { LlmUsageStats } from "../llm/llmSchema.ts";
 import { Model } from "../Model.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
@@ -27,14 +28,6 @@ import type { DoResult, DoStep } from "./result.ts";
 
 const { tracer, logger } = Telemetry.get(import.meta.url);
 const { span } = tracer.dec();
-
-const CHANGE_ANALYSIS =
-  (process.env.ALUMNIUM_CHANGE_ANALYSIS || "false").toLowerCase() === "true";
-const PLANNER =
-  (process.env.ALUMNIUM_PLANNER || "true").toLowerCase() === "true";
-const EXCLUDE_ATTRIBUTES = (process.env.ALUMNIUM_EXCLUDE_ATTRIBUTES || "")
-  .split(",")
-  .filter(Boolean);
 
 /**
  * @deprecated Use `Alumni.Options` instead.
@@ -87,7 +80,8 @@ export class Alumni {
 
     const { url, model } = options;
 
-    this.changeAnalysis = options.changeAnalysis ?? CHANGE_ANALYSIS;
+    this.changeAnalysis =
+      options.changeAnalysis ?? Env.ALUMNIUM_CHANGE_ANALYSIS;
     this.llm = options.llm;
 
     // Wrap driver or use directly if already wrapped
@@ -112,13 +106,14 @@ export class Alumni {
       this.tools[tool.name] = tool;
     }
 
-    const planner = options.planner ?? PLANNER;
+    const planner = options.planner ?? Env.ALUMNIUM_PLANNER;
 
     const clientProps: Client.Props = {
       platform: this.driver.platform,
       tools: this.tools,
       planner,
-      excludeAttributes: options.excludeAttributes ?? EXCLUDE_ATTRIBUTES,
+      excludeAttributes:
+        options.excludeAttributes ?? Env.ALUMNIUM_EXCLUDE_ATTRIBUTES,
     };
 
     if (url) {
@@ -130,7 +125,7 @@ export class Alumni {
       });
     } else {
       this.client = new NativeClient({
-        model: Model.current,
+        model: model || Env.ALUMNIUM_MODEL,
         llm: this.llm,
         ...clientProps,
       });

--- a/packages/typescript/src/clients/HttpClient.ts
+++ b/packages/typescript/src/clients/HttpClient.ts
@@ -276,7 +276,7 @@ export class HttpClient extends Client {
       body,
     );
 
-    this.#model = Model.fromString(result.model);
+    this.#model = Model.parse(result.model);
     const sessionId = result.session_id;
     logger.debug(`Session initialized with ID: ${sessionId}`);
     return sessionId;

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -1,5 +1,6 @@
 import { Key as SeleniumKey } from "selenium-webdriver";
 import type { Browser } from "webdriverio";
+import z from "zod";
 import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts";
 import { UIAutomator2AccessibilityTree } from "../accessibility/UIAutomator2AccessibilityTree.ts";
 import { XCUITestAccessibilityTree } from "../accessibility/XCUITestAccessibilityTree.ts";
@@ -17,9 +18,19 @@ import type { Keys } from "./keys.ts";
 const { tracer, logger } = Telemetry.get(import.meta.url);
 const { span } = tracer.dec();
 
+export namespace AppiumDriver {
+  export type Platform = z.infer<typeof AppiumDriver.Platform>;
+}
+
 export class AppiumDriver extends BaseDriver {
+  static platforms = ["uiautomator2", "xcuitest"] as const;
+
+  static Platform = z.enum(AppiumDriver.platforms);
+
+  public platform: AppiumDriver.Platform;
+
   private driver: Browser;
-  public platform: "xcuitest" | "uiautomator2";
+
   public supportedTools: Set<ToolClass> = new Set([
     ClickTool,
     DragAndDropTool,
@@ -305,7 +316,7 @@ export class AppiumDriver extends BaseDriver {
   }
 }
 
-function spanAttrs(this: AppiumDriver): Tracer.SpansDriverAttrsBase {
+function spanAttrs(this: AppiumDriver): Tracer.SpansDriverAttrs {
   return {
     "driver.kind": "appium",
     "driver.platform": this.platform,

--- a/packages/typescript/src/drivers/Driver.ts
+++ b/packages/typescript/src/drivers/Driver.ts
@@ -1,11 +1,91 @@
 import { z } from "zod";
 
 export namespace Driver {
+  export type ChromiumPlatform = z.infer<typeof Driver.ChromiumPlatform>;
+
+  export type AppiumPlatform = z.infer<typeof Driver.AppiumPlatform>;
+
+  export type AppiumOs = z.infer<typeof Driver.AppiumOs>;
+
   export type Platform = z.infer<typeof Driver.Platform>;
+
+  export type Kind = z.infer<typeof Driver.Kind>;
+
+  export type Id = z.infer<typeof Driver.Id>;
 }
 
 export abstract class Driver {
-  static PLATFORMS = ["chromium", "uiautomator2", "xcuitest"] as const;
+  static chromiumPlatform = "chromium" as const;
 
-  static Platform = z.enum(this.PLATFORMS);
+  static chromiumPlatformAliases = [this.chromiumPlatform, "chrome"] as const;
+
+  static ChromiumPlatformAlias = z.enum(this.chromiumPlatformAliases);
+
+  static ChromiumPlatformStrict = z.literal(this.chromiumPlatform);
+
+  static ChromiumPlatform = z.preprocess((val) => {
+    // Normalize "chromium" aliases
+    const parsedAlias = this.ChromiumPlatformAlias.safeParse(val);
+    if (parsedAlias.success) return this.chromiumPlatform;
+    return val;
+  }, this.ChromiumPlatformStrict);
+
+  static appiumOses = ["android", "ios"] as const;
+
+  static AppiumOs = z.enum(this.appiumOses);
+
+  static appiumPlatforms = ["uiautomator2", "xcuitest"] as const;
+
+  static AppiumPlatformStrict = z.enum(this.appiumPlatforms);
+
+  static AppiumPlatform = z.preprocess((val): unknown => {
+    // Normalize Appium OS to platform
+    const parsedOs = this.AppiumOs.safeParse(val);
+    switch (parsedOs.data) {
+      case "android":
+        return "uiautomator2";
+      case "ios":
+        return "xcuitest";
+      case undefined:
+        return val;
+    }
+  }, this.AppiumPlatformStrict);
+
+  static PlatformStrict = z.enum([
+    this.chromiumPlatform,
+    ...this.appiumPlatforms,
+  ]);
+
+  static Platform = z.preprocess((val) => {
+    const parsedChromium = this.ChromiumPlatform.safeParse(val);
+    if (parsedChromium.success) return parsedChromium.data;
+
+    const parsedAppium = this.AppiumPlatform.safeParse(val);
+    if (parsedAppium.success) return parsedAppium.data;
+
+    return val;
+  }, this.PlatformStrict);
+
+  static chromiumKinds = ["selenium", "playwright"] as const;
+
+  static ChromiumKind = z.enum(this.chromiumKinds);
+
+  static appiumKind = "appium" as const;
+
+  static AppiumKind = z.literal(this.appiumKind);
+
+  static kinds = [...this.chromiumKinds, this.appiumKind] as const;
+
+  static Kind = z.enum(this.kinds).default("selenium");
+
+  static Id = z
+    .union([
+      this.ChromiumKind,
+      z.templateLiteral([this.AppiumKind, "-", this.AppiumOs]),
+    ])
+    .default("selenium");
+
+  static isAppium(kind: Driver.Id): boolean {
+    return kind.startsWith("appium");
+  }
 }

--- a/packages/typescript/src/drivers/DriverId.ts
+++ b/packages/typescript/src/drivers/DriverId.ts
@@ -1,0 +1,15 @@
+export namespace DriverId {
+  export interface Selenium {
+    kind: "selenium";
+  }
+
+  export interface Playwright {
+    kind: "playwright";
+  }
+
+  export type Appium = "appium";
+}
+export type DriverId =
+  | DriverId.Selenium
+  | DriverId.Playwright
+  | DriverId.Appium;

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -16,6 +16,7 @@ import type { Keys } from "./keys.ts";
 // doesn't support it. For now, we bundle assets with scripts/generate.ts.
 // import { readScript } from "./scripts/scripts.js" with { type: "macro" };
 import { AppId } from "../AppId.ts";
+import { Env } from "../Env.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
 import type { Tracer } from "../telemetry/Tracer.ts";
 import { retry } from "../utils/retry.ts";
@@ -78,14 +79,9 @@ export class PlaywrightDriver extends BaseDriver {
     TypeTool,
     UploadTool,
   ]);
-  public newTabTimeout = parseInt(
-    process.env.ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT || "200",
-    10,
-  );
-  public autoswitchToNewTab: boolean = true;
-  public fullPageScreenshot: boolean =
-    (process.env.ALUMNIUM_FULL_PAGE_SCREENSHOT || "false").toLowerCase() ===
-    "true";
+  public newTabTimeout = Env.ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT;
+  public autoswitchToNewTab = true;
+  public fullPageScreenshot = Env.ALUMNIUM_FULL_PAGE_SCREENSHOT;
 
   constructor(page: Page) {
     super();
@@ -826,7 +822,7 @@ export class PlaywrightDriver extends BaseDriver {
   }
 }
 
-function spanAttrs(this: PlaywrightDriver): Tracer.SpansDriverAttrsBase {
+function spanAttrs(this: PlaywrightDriver): Tracer.SpansDriverAttrs {
   return {
     "driver.kind": "playwright",
     "driver.platform": this.platform,

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -29,6 +29,7 @@ import { Keys } from "./keys.ts";
 // import { readScript } from "./scripts/scripts.js" with { type: "macro" };
 import type { ChromiumWebDriver } from "selenium-webdriver/chromium.js";
 import { AppId } from "../AppId.ts";
+import { Env } from "../Env.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
 import type { Tracer } from "../telemetry/Tracer.ts";
 import type { Driver } from "./Driver.ts";
@@ -62,10 +63,8 @@ const WAIT_FOR_SCRIPT = waitForScriptSource;
 export class SeleniumDriver extends BaseDriver {
   protected driver: ChromiumWebDriver;
   public platform: Driver.Platform = "chromium";
-  #autoswitchToNewTabEnabled: boolean = true;
-  public fullPageScreenshot: boolean =
-    (process.env.ALUMNIUM_FULL_PAGE_SCREENSHOT || "false").toLowerCase() ===
-    "true";
+  #autoswitchToNewTabEnabled = true;
+  public fullPageScreenshot = Env.ALUMNIUM_FULL_PAGE_SCREENSHOT;
   public supportedTools: Set<ToolClass> = new Set([
     ClickTool,
     DragAndDropTool,
@@ -565,7 +564,7 @@ export class SeleniumDriver extends BaseDriver {
   }
 }
 
-function spanAttrs(this: SeleniumDriver): Tracer.SpansDriverAttrsBase {
+function spanAttrs(this: SeleniumDriver): Tracer.SpansDriverAttrs {
   return {
     "driver.kind": "selenium",
     "driver.platform": this.platform,

--- a/packages/typescript/src/mcp/McpArtifactsStore.test.ts
+++ b/packages/typescript/src/mcp/McpArtifactsStore.test.ts
@@ -8,6 +8,7 @@ import {
   pushTeardown,
   setupBeforeEach,
 } from "../../tests/unit/mocks.ts";
+import { Env } from "../Env.ts";
 import { McpArtifactsStore } from "./McpArtifactsStore.ts";
 import type { McpDriver } from "./mcpDrivers.ts";
 import { McpState } from "./McpState.ts";
@@ -23,10 +24,11 @@ describe("McpArtifactsStore", () => {
     });
 
     it("allows to override the base dir via environment variable", () => {
-      process.env.ALUMNIUM_MCP_ARTIFACTS_DIR = ".custom";
-      pushTeardown(() => {
-        delete process.env.ALUMNIUM_MCP_ARTIFACTS_DIR;
-      });
+      pushMock(
+        vi
+          .spyOn(Env, "ALUMNIUM_MCP_ARTIFACTS_DIR", "get")
+          .mockReturnValue(".custom"),
+      );
       const store = new McpArtifactsStore("test-driver");
       const resolvedPath = store.resolve("sub/dir/file.txt");
       expect(resolvedPath).toBe(`.custom/test-driver/sub/dir/file.txt`);
@@ -36,10 +38,11 @@ describe("McpArtifactsStore", () => {
   describe("saveScreenshot", () => {
     const setup = setupBeforeEach(async () => {
       const mockDir = await createMockDir();
-      process.env.ALUMNIUM_MCP_ARTIFACTS_DIR = mockDir.path;
-      pushTeardown(() => {
-        delete process.env.ALUMNIUM_MCP_ARTIFACTS_DIR;
-      });
+      pushMock(
+        vi
+          .spyOn(Env, "ALUMNIUM_MCP_ARTIFACTS_DIR", "get")
+          .mockReturnValue(mockDir.path),
+      );
       const id = "test-driver";
       const artifactsStore = new McpArtifactsStore(id);
       const pixelB64 =

--- a/packages/typescript/src/mcp/McpArtifactsStore.ts
+++ b/packages/typescript/src/mcp/McpArtifactsStore.ts
@@ -1,4 +1,5 @@
 import { kebabCase } from "case-anything";
+import { Env } from "../Env.ts";
 import { FileStore } from "../FileStore/FileStore.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { McpState } from "./McpState.ts";
@@ -15,11 +16,7 @@ export namespace McpArtifactsStore {
 export class McpArtifactsStore extends FileStore {
   constructor(id: string) {
     super(
-      FileStore.subResolve(
-        process.env.ALUMNIUM_MCP_ARTIFACTS_DIR,
-        "artifacts",
-        id,
-      ),
+      FileStore.subResolve(Env.ALUMNIUM_MCP_ARTIFACTS_DIR, "artifacts", id),
     );
   }
 

--- a/packages/typescript/src/mcp/McpCommand.ts
+++ b/packages/typescript/src/mcp/McpCommand.ts
@@ -3,6 +3,8 @@ import { CliCommand } from "../cli/CliCommand.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { McpServer } from "./McpServer.ts";
 
+const logger = Logger.get(import.meta.url);
+
 export namespace McpCommand {}
 
 export const McpCommand = CliCommand.define({
@@ -13,6 +15,7 @@ export const McpCommand = CliCommand.define({
 
   action: async ({ logFilenameHint }) => {
     Logger.path = { filename: logFilenameHint };
+    await Logger.initEnv(logger);
 
     const server = new McpServer();
     await server.run();

--- a/packages/typescript/src/mcp/McpProfilesStore.ts
+++ b/packages/typescript/src/mcp/McpProfilesStore.ts
@@ -1,11 +1,12 @@
 import os from "node:os";
 import path from "node:path";
+import { Env } from "../Env.ts";
 import { FileStore } from "../FileStore/FileStore.ts";
 
 export class McpProfilesStore extends FileStore {
   constructor() {
     super(
-      process.env.ALUMNIUM_MCP_PROFILES_DIR ??
+      Env.ALUMNIUM_MCP_PROFILES_DIR ??
         path.join(os.homedir(), ".alumnium", "profiles"),
     );
   }

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -7,9 +7,8 @@ import { Alumni } from "../client/Alumni.ts";
 import { PlaywrightDriver } from "../drivers/PlaywrightDriver.ts";
 import { LlmUsageStats } from "../llm/llmSchema.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
-import { McpArtifactsStore } from "./McpArtifactsStore.ts";
+import type { McpArtifactsStore } from "./McpArtifactsStore.ts";
 import type { McpDriver } from "./mcpDrivers.ts";
-import { startMcpTool } from "./tools/startMcpTool.ts";
 
 const { logger, tracer } = Telemetry.get(import.meta.url);
 const { span } = tracer.dec();
@@ -81,9 +80,7 @@ export abstract class McpState {
     if (!driverState) {
       logger.error(`Driver state for ${id} not found`);
       // NOTE: This error is required for the controlling agent calling MCP.
-      throw new Error(
-        `Driver ${id} not found. Call ${startMcpTool.name} first.`,
-      );
+      throw new Error(`Driver ${id} not found. Call start first.`);
     }
     return driverState;
   }

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -11,6 +11,8 @@ import {
   remote as remoteWebdriverio,
   type Browser as WebdriverIoBrowser,
 } from "webdriverio";
+import type { Driver } from "../drivers/Driver.ts";
+import { Env } from "../Env.ts";
 import { FileStore } from "../FileStore/FileStore.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { TypeUtils } from "../typeUtils.ts";
@@ -52,9 +54,9 @@ export function createChromeDriver(
   artifactsStore: FileStore,
   driverOptions: McpDriver.DriverOptions = {},
 ): Promise<McpDriver> {
-  const driverType = (process.env.ALUMNIUM_DRIVER || "selenium").toLowerCase();
-  logger.info(`Creating Chrome driver using ${driverType}`);
-  if (driverType === "playwright") {
+  const driverKind = Env.ALUMNIUM_DRIVER;
+  logger.info(`Creating Chrome driver using ${driverKind}`);
+  if (driverKind === "playwright") {
     return createPlaywrightDriver(capabilities, artifactsStore, driverOptions);
   } else {
     return createSeleniumDriver(capabilities, serverUrl, driverOptions);
@@ -243,67 +245,21 @@ export async function createSeleniumDriver(
 }
 
 /**
- * Create Appium iOS driver from capabilities.
+ * Create Appium driver from capabilities.
  */
-export async function createIosDriver(
+export async function createAppiumDriver(
+  platform: Driver.AppiumPlatform,
   capabilities: McpDriver.Capabilities,
   serverUrl: string | null | undefined,
 ): Promise<WebdriverIoBrowser> {
   const settings = capabilities["appium:settings"] || {};
   delete capabilities["appium:settings"];
 
-  const remoteServer =
-    serverUrl || process.env.ALUMNIUM_APPIUM_SERVER || "http://localhost:4723";
+  const remoteServer = serverUrl || Env.ALUMNIUM_APPIUM_SERVER;
 
-  logger.info(`Creating iOS driver (server=${remoteServer})`);
-
-  const remoteServerUrl = new URL(remoteServer);
-  const remoteOptions =
-    TypeUtils.fromExactOptionalTypes<McpDriver.WebdriverioProps>({
-      protocol: remoteServerUrl.protocol.replace(":", ""),
-      hostname: remoteServerUrl.hostname,
-      port:
-        Number.parseInt(remoteServerUrl.port, 10) ||
-        (remoteServerUrl.protocol === "https:" ? 443 : 80),
-      path: `${remoteServerUrl.pathname}${remoteServerUrl.search}`,
-      capabilities,
-      enableDirectConnect: true,
-    });
-
-  if (process.env.LT_USERNAME) {
-    remoteOptions.user = process.env.LT_USERNAME;
-  }
-  if (process.env.LT_ACCESS_KEY) {
-    remoteOptions.key = process.env.LT_ACCESS_KEY;
-  }
-
-  const driver = await remoteWebdriverio(remoteOptions);
-
-  if (Object.keys(settings).length) {
-    logger.debug("Applying Appium settings: {settings}", { settings });
-    await driver.updateSettings(settings);
-  }
-
-  logger.debug("iOS driver created successfully");
-  return driver;
-}
-
-/**
- * Create Appium Android driver from capabilities.
- */
-export async function createAndroidDriver(
-  capabilities: McpDriver.Capabilities,
-  serverUrl: string | null | undefined,
-): Promise<WebdriverIoBrowser> {
-  const settings =
-    (capabilities["appium:settings"] as Record<string, unknown> | undefined) ||
-    {};
-  delete capabilities["appium:settings"];
-
-  const remoteServer =
-    serverUrl || process.env.ALUMNIUM_APPIUM_SERVER || "http://localhost:4723";
-
-  logger.info(`Creating Android driver (server=${remoteServer})`);
+  logger.info(
+    `Creating Appium driver for ${platform} (server=${remoteServer})`,
+  );
 
   const remoteServerUrl = new URL(remoteServer);
   const remoteOptions =
@@ -318,12 +274,11 @@ export async function createAndroidDriver(
       enableDirectConnect: true,
     });
 
-  if (process.env.LT_USERNAME) {
-    remoteOptions.user = process.env.LT_USERNAME;
-  }
-  if (process.env.LT_ACCESS_KEY) {
-    remoteOptions.key = process.env.LT_ACCESS_KEY;
-  }
+  const ltUsername = Env.LT_USERNAME;
+  if (ltUsername) remoteOptions.user = ltUsername;
+
+  const ltAccessKey = Env.LT_ACCESS_KEY;
+  if (ltAccessKey) remoteOptions.key = ltAccessKey;
 
   const driver = await remoteWebdriverio(remoteOptions);
 
@@ -332,6 +287,6 @@ export async function createAndroidDriver(
     await driver.updateSettings(settings);
   }
 
-  logger.debug("Android driver created successfully");
+  logger.debug(`Appium driver for ${platform} created successfully`);
   return driver;
 }

--- a/packages/typescript/src/mcp/tools/McpTool.ts
+++ b/packages/typescript/src/mcp/tools/McpTool.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { Logger } from "../../telemetry/Logger.ts";
+import type { LoggerSchema } from "../../telemetry/LoggerSchema.ts";
 import { Telemetry } from "../../telemetry/Telemetry.ts";
 
 const { tracer, logger } = Telemetry.get(import.meta.url);
@@ -28,7 +29,7 @@ export namespace McpTool {
   ) => Promise<Output>;
 
   export interface ExecuteHelpers {
-    logger: Logger.Like;
+    logger: LoggerSchema.Like;
   }
 
   export type OutputContent = z.infer<typeof McpTool.OutputContent>;

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -1,8 +1,10 @@
+import { never } from "alwaysly";
 import fs from "node:fs";
 import path from "node:path";
 import z from "zod";
 import { Alumni } from "../../client/Alumni.ts";
 import { NativeClient } from "../../clients/NativeClient.ts";
+import { Driver } from "../../drivers/Driver.ts";
 import { Telemetry } from "../../telemetry/Telemetry.ts";
 import { DragSliderTool } from "../../tools/DragSliderTool.ts";
 import { ExecuteJavascriptTool } from "../../tools/ExecuteJavascriptTool.ts";
@@ -13,13 +15,12 @@ import { ScrollTool } from "../../tools/ScrollTool.ts";
 import { SwitchToNextTabTool } from "../../tools/SwitchToNextTabTool.ts";
 import { SwitchToPreviousTabTool } from "../../tools/SwitchToPreviousTabTool.ts";
 import { McpArtifactsStore } from "../McpArtifactsStore.ts";
-import { McpProfilesStore } from "../McpProfilesStore.ts";
 import {
-  createAndroidDriver,
+  createAppiumDriver,
   createChromeDriver,
-  createIosDriver,
   type McpDriver,
 } from "../mcpDrivers.ts";
+import { McpProfilesStore } from "../McpProfilesStore.ts";
 import { McpState } from "../McpState.ts";
 import { McpTool } from "./McpTool.ts";
 
@@ -193,48 +194,51 @@ export const startMcpTool = McpTool.define("start", {
     logger.info(`Starting driver ${id} for platform: ${platformName}`);
 
     // Detect platform and create appropriate driver
+    const platform = Driver.Platform.safeParse(platformName).data;
     let driver: McpDriver;
-    if (["chrome", "chromium"].includes(platformName)) {
-      driver = await tracer.span(
-        "mcp.driver.start",
+    switch (platform) {
+      case "chromium": {
+        driver = await tracer.span(
+          "mcp.driver.start",
+          {
+            "mcp.driver.id": id,
+            "driver.kind": "playwright",
+            "driver.platform": platform,
+          },
+          () =>
+            createChromeDriver(
+              capabilities,
+              serverUrl,
+              artifactsStore,
+              driverOptions,
+            ),
+        );
+        break;
+      }
+
+      case "xcuitest":
+      case "uiautomator2":
         {
-          "mcp.driver.id": id,
-          "mcp.driver.kind": "playwright",
-          "mcp.driver.platform": platformName,
-        },
-        () =>
-          createChromeDriver(
-            capabilities,
-            serverUrl,
-            artifactsStore,
-            driverOptions,
-          ),
-      );
-    } else if (platformName === "ios") {
-      driver = await tracer.span(
-        "mcp.driver.start",
-        {
-          "mcp.driver.id": id,
-          "mcp.driver.kind": "appium",
-          "mcp.driver.platform": platformName,
-        },
-        () => createIosDriver(capabilities, serverUrl),
-      );
-    } else if (platformName === "android") {
-      driver = await tracer.span(
-        "mcp.driver.start",
-        {
-          "mcp.driver.id": id,
-          "mcp.driver.kind": "appium",
-          "mcp.driver.platform": platformName,
-        },
-        async () => createAndroidDriver(capabilities, serverUrl),
-      );
-    } else {
-      logger.error(`Unsupported platformName: ${platformName}`);
-      throw new Error(
-        `Unsupported platformName: ${platformName}. Supported values: chrome, chromium, ios, android`,
-      );
+          driver = await tracer.span(
+            "mcp.driver.start",
+            {
+              "mcp.driver.id": id,
+              "driver.kind": "appium",
+              "driver.platform": platform,
+            },
+            () => createAppiumDriver(platform, capabilities, serverUrl),
+          );
+        }
+        break;
+
+      case undefined:
+        logger.error(`Unsupported platformName: ${platformName}`);
+        throw new Error(
+          `Unsupported platformName: ${platformName}. Supported values: chrome, chromium, ios, android`,
+        );
+
+      default:
+        never(platform);
     }
 
     tracer.span("mcp.driver.active", { "mcp.driver.id": id }, id);

--- a/packages/typescript/src/server/CacheFactory.ts
+++ b/packages/typescript/src/server/CacheFactory.ts
@@ -1,3 +1,4 @@
+import { Env } from "../Env.ts";
 import { Model } from "../Model.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { CacheStore } from "./cache/CacheStore.ts";
@@ -17,9 +18,7 @@ export class CacheFactory {
     llmContext: LlmContext,
     model: Model,
   ): ServerCache {
-    const cacheProvider = (
-      process.env.ALUMNIUM_CACHE ?? "filesystem"
-    ).toLowerCase();
+    const cacheProvider = Env.ALUMNIUM_CACHE;
 
     switch (cacheProvider) {
       case "sqlite":
@@ -27,6 +26,7 @@ export class CacheFactory {
           "ALUMNIUM_CACHE=sqlite is no longer supported. Use ALUMNIUM_CACHE=filesystem.",
         );
 
+      case true:
       case "filesystem": {
         logger.info("Using filesystem cache");
         const cacheStore = new CacheStore(sessionContext, model);
@@ -36,16 +36,9 @@ export class CacheFactory {
         ]);
       }
 
-      case "false":
-      case "0":
-      case "none":
-      case "null":
+      case false:
         logger.info("Using null cache");
         return new NullCache(sessionContext);
-
-      default:
-        logger.error(`Unknown cache provider: ${cacheProvider}`);
-        throw new Error(`Unknown cache provider: ${cacheProvider}`);
     }
   }
 }

--- a/packages/typescript/src/server/LlmFactory.ts
+++ b/packages/typescript/src/server/LlmFactory.ts
@@ -16,23 +16,15 @@ import {
 import { ChatXAI } from "@langchain/xai";
 import type { DocumentType } from "@smithy/types";
 import { never } from "alwaysly";
+import { Env } from "../Env.ts";
 import { Model } from "../Model.ts";
 import { Logger } from "../telemetry/Logger.ts";
+import { maskString } from "../utils/string.ts";
 
 const logger = Logger.get(import.meta.url);
 
-const parsedModelTimeout = parseInt(process.env.ALUMNIUM_MODEL_TIMEOUT ?? "90");
-export const MODEL_TIMEOUT_SEC = Number.isFinite(parsedModelTimeout)
-  ? parsedModelTimeout
-  : 90;
-
-const DEFAULT_LLM_RETRIES = 8;
-
-export let MODEL_RETRIES = parseInt(
-  process.env.ALUMNIUM_MODEL_RETRIES || String(DEFAULT_LLM_RETRIES),
-);
-if (isNaN(MODEL_RETRIES)) MODEL_RETRIES = DEFAULT_LLM_RETRIES;
-if (MODEL_RETRIES < 0) MODEL_RETRIES = 0;
+export const MODEL_TIMEOUT_SEC = Env.ALUMNIUM_MODEL_TIMEOUT;
+export const MODEL_RETRIES = Env.ALUMNIUM_MODEL_RETRIES;
 
 /**
  * Factory for creating LLM instances based on model configuration.
@@ -105,7 +97,7 @@ export class LlmFactory {
     model: Model,
     defaults: Partial<AzureChatOpenAIFields>,
   ): AzureChatOpenAIFields {
-    const openAIApiVersion = process.env.AZURE_FOUNDRY_API_VERSION;
+    const openAIApiVersion = Env.AZURE_FOUNDRY_API_VERSION;
     if (!openAIApiVersion) {
       throw new Error(
         "AZURE_FOUNDRY_API_VERSION environment variable is required for Azure Foundry models",
@@ -123,7 +115,7 @@ export class LlmFactory {
     model: Model,
     defaults: Partial<AzureChatOpenAIFields>,
   ): AzureChatOpenAIFields {
-    const azureOpenAIApiKey = process.env.AZURE_OPENAI_API_KEY;
+    const azureOpenAIApiKey = Env.AZURE_OPENAI_API_KEY;
     if (!azureOpenAIApiKey) {
       throw new Error(
         "AZURE_OPENAI_API_KEY environment variable is required for Azure OpenAI models",
@@ -131,7 +123,7 @@ export class LlmFactory {
     }
     logMaskedSecret("Azure OpenAI API Key", azureOpenAIApiKey);
 
-    const azureOpenAIEndpoint = process.env.AZURE_OPENAI_ENDPOINT;
+    const azureOpenAIEndpoint = Env.AZURE_OPENAI_ENDPOINT;
     if (!azureOpenAIEndpoint) {
       throw new Error(
         "AZURE_OPENAI_ENDPOINT environment variable is required for Azure OpenAI models",
@@ -139,7 +131,7 @@ export class LlmFactory {
     }
     logMaskedSecret("Azure OpenAI API Endpoint", azureOpenAIEndpoint);
 
-    const azureOpenAIApiVersion = process.env.AZURE_OPENAI_API_VERSION;
+    const azureOpenAIApiVersion = Env.AZURE_OPENAI_API_VERSION;
     if (!azureOpenAIApiVersion) {
       throw new Error(
         "AZURE_OPENAI_API_VERSION environment variable is required for Azure OpenAI models",
@@ -147,17 +139,8 @@ export class LlmFactory {
     }
     logMaskedSecret("Azure OpenAI API Version", azureOpenAIApiVersion);
 
-    let defaultHeaders: Headers | undefined;
-    const envHeaders = process.env.AZURE_OPENAI_DEFAULT_HEADERS;
-    if (envHeaders) {
-      try {
-        defaultHeaders = new Headers(JSON.parse(envHeaders));
-      } catch {
-        logger.warn(
-          "Failed to parse AZURE_OPENAI_DEFAULT_HEADERS, it should be a valid JSON string. Ignoring the variable.",
-        );
-      }
-    }
+    const envHeaders = Env.AZURE_OPENAI_DEFAULT_HEADERS;
+    const defaultHeaders = new Headers(envHeaders);
 
     return {
       model: model.name,
@@ -192,9 +175,9 @@ export class LlmFactory {
   static createAwsLlm(model: Model, cache: BaseCache): BaseChatModel {
     logger.debug(`Creating AWS LLM with model ${model.name}`);
 
-    const accessKeyId = process.env.AWS_ACCESS_KEY ?? "";
-    const secretAccessKey = process.env.AWS_SECRET_KEY ?? "";
-    const region = process.env.AWS_REGION_NAME ?? "us-east-1";
+    const accessKeyId = Env.AWS_ACCESS_KEY || "";
+    const secretAccessKey = Env.AWS_SECRET_KEY || "";
+    const region = Env.AWS_REGION_NAME;
     const additionalModelRequestFields: DocumentType = {};
 
     if (model.provider === "aws_anthropic") {
@@ -279,7 +262,7 @@ export class LlmFactory {
   static createOllamaLlm(model: Model, cache: BaseCache): BaseChatModel {
     logger.debug(`Creating Ollama LLM with model ${model.name}`);
 
-    const baseUrl = process.env.OLLAMA_HOST || process.env.ALUMNIUM_OLLAMA_URL;
+    const baseUrl = Env.OLLAMA_HOST || Env.ALUMNIUM_OLLAMA_URL;
     if (baseUrl) {
       return new ChatOllama({
         model: model.name,
@@ -299,7 +282,7 @@ export class LlmFactory {
 
     const fields: ChatOpenAIFields = {
       model: model.name,
-      configuration: { baseURL: process.env.OPENAI_CUSTOM_URL },
+      configuration: { baseURL: Env.OPENAI_CUSTOM_URL },
       // TODO: Apparently the latest OpenAI models (o1, o3, o4, gpt-5) don't
       // accept temperature anymore, so we need to either conditionally include
       // it or figure out the correct way to set it for the new models.
@@ -316,7 +299,7 @@ export class LlmFactory {
     };
 
     if (model.name.includes("gpt-4o")) {
-      if (!process.env.OPENAI_CUSTOM_URL) {
+      if (!Env.OPENAI_CUSTOM_URL) {
         // TODO: The seed parameter is deprecated and missing the LangChain
         // types, so we need to figure out the correct way to move forward.
         //
@@ -346,19 +329,7 @@ export class LlmFactory {
 }
 
 function logMaskedSecret(name: string, secret: string) {
-  logger.debug(`${name} is set: ${maskStr(secret)}`);
-}
-
-function maskStr(str: string, unmaskedStart = 4, unmaskedEnd = 4): string {
-  if (str.length <= unmaskedStart + unmaskedEnd) {
-    return "*".repeat(str.length);
-  }
-  const maskedLength = str.length - unmaskedStart - unmaskedEnd;
-  return (
-    str.slice(0, unmaskedStart) +
-    "*".repeat(maskedLength) +
-    str.slice(str.length - unmaskedEnd)
-  );
+  logger.debug(`${name} is set: ${maskString(secret)}`);
 }
 
 class ReasonableChatDeepSeek extends ChatDeepSeek {

--- a/packages/typescript/src/server/ServerCommand.ts
+++ b/packages/typescript/src/server/ServerCommand.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import z from "zod";
 import { isSingleFileExecutable } from "../bundle.ts";
 import { CliCommand } from "../cli/CliCommand.ts";
+import { Env } from "../Env.ts";
 import { GlobalFileStorePaths } from "../FileStore/GlobalFileStorePaths.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { sleep } from "../utils/timers.ts";
@@ -96,6 +97,12 @@ export const ServerCommand = CliCommand.define({
   }),
 
   action: async ({ args, logFilenameHint }) => {
+    // NOTE: We do it first thing, to make sure all the logs go to the right place
+    if (Env.ALUMNIUM_SERVER_DAEMONIZE)
+      Logger.path = { filename: logFilenameHint };
+
+    await Logger.initEnv(logger);
+
     const {
       host,
       port,
@@ -107,7 +114,7 @@ export const ServerCommand = CliCommand.define({
       daemonWaitTimeout,
     } = args;
     const pidPath =
-      process.env.ALUMNIUM_SERVER_PID_PATH ??
+      Env.ALUMNIUM_SERVER_PID_PATH ??
       GlobalFileStorePaths.globalSubDir(daemonPid || DEFAULT_DAEMON_PID_NAME);
 
     if (daemonKill) {
@@ -145,9 +152,7 @@ export const ServerCommand = CliCommand.define({
       process.exit(0);
     }
 
-    if (process.env.ALUMNIUM_SERVER_DAEMONIZE === "1") {
-      Logger.path = { filename: logFilenameHint };
-
+    if (Env.ALUMNIUM_SERVER_DAEMONIZE) {
       await writePidFile(pidPath);
 
       const cleanup = removePidFileSync.bind(null, pidPath);
@@ -194,8 +199,9 @@ async function startDaemon(pidPath: string, force: boolean): Promise<void> {
     detached: true,
     stdio: ["ignore", "ignore", "ignore"],
     env: {
+      // oxlint-disable-next-line no-process-env -- We need it to pass env vars
       ...process.env,
-      ALUMNIUM_SERVER_DAEMONIZE: "1",
+      ALUMNIUM_SERVER_DAEMONIZE: z.stringbool().encode(true),
     },
   });
   child.unref();

--- a/packages/typescript/src/server/agents/BaseAgent.ts
+++ b/packages/typescript/src/server/agents/BaseAgent.ts
@@ -11,6 +11,7 @@ import z from "zod";
 import { Lchain } from "../../llm/Lchain.ts";
 import { LchainSchema } from "../../llm/LchainSchema.ts";
 import { createLlmUsage, LlmUsage } from "../../llm/llmSchema.ts";
+import type { LoggerSchema } from "../../telemetry/LoggerSchema.ts";
 import { Telemetry } from "../../telemetry/Telemetry.ts";
 import { retry } from "../../utils/retry.ts";
 import { LlmContext } from "../LlmContext.ts";
@@ -350,7 +351,7 @@ export class BaseAgent {
   }
 
   protected logData(
-    logger: Logger.Like,
+    logger: LoggerSchema.Like,
     dir: BaseAgent.LogDir,
     data: BaseAgent.LogData,
   ) {

--- a/packages/typescript/src/server/agents/RetrieverAgent.eval.ts
+++ b/packages/typescript/src/server/agents/RetrieverAgent.eval.ts
@@ -2,18 +2,15 @@ import { evalite } from "evalite";
 import { nanoid } from "nanoid";
 import { lit } from "smollit";
 import type { AppId } from "../../AppId.ts";
-import { Model } from "../../Model.ts";
 import { Logger } from "../../telemetry/Logger.ts";
 import { NullCache } from "../cache/NullCache.ts";
 import { LlmContext } from "../LlmContext.ts";
 import { LlmFactory } from "../LlmFactory.ts";
 import { SessionContext } from "../session/SessionContext.ts";
 import { RetrieverAgent } from "./RetrieverAgent.ts";
+import { Env } from "../../Env.ts";
 
 Logger.level = "warning";
-
-let TRIAL_COUNT = parseInt(process.env.ALUMNIUM_EVAL_TRIAL_COUNT || "25");
-if (isNaN(TRIAL_COUNT) || TRIAL_COUNT <= 0) TRIAL_COUNT = 25;
 
 evalite("RetrieverAgent", {
   data: [
@@ -124,7 +121,7 @@ evalite("RetrieverAgent", {
     },
   ],
 
-  trialCount: TRIAL_COUNT,
+  trialCount: Env.ALUMNIUM_EVAL_TRIAL_COUNT,
 
   columns: ({ output, expected }) => {
     const parsed = RetrieverAgent.Output.safeParse(output);
@@ -142,7 +139,7 @@ evalite("RetrieverAgent", {
   },
 
   task: async (input) => {
-    const model = Model.current;
+    const model = Env.ALUMNIUM_MODEL;
     const llmContext = new LlmContext(model);
     const sessionContext = new SessionContext({
       app: "eval" as AppId,

--- a/packages/typescript/src/server/agents/prompts/prompts.ts
+++ b/packages/typescript/src/server/agents/prompts/prompts.ts
@@ -2,7 +2,7 @@ import { always } from "alwaysly";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { type Model } from "../../../Model.ts";
+import type { Model } from "../../../Model.ts";
 import { safePathJoin } from "../../../utils/fs.ts";
 import type { Agent } from "../Agent.ts";
 

--- a/packages/typescript/src/server/cache/CacheStore.ts
+++ b/packages/typescript/src/server/cache/CacheStore.ts
@@ -1,4 +1,5 @@
 import type { AppId } from "../../AppId.ts";
+import { Env } from "../../Env.ts";
 import { FileStore } from "../../FileStore/FileStore.ts";
 import { GlobalFileStorePaths } from "../../FileStore/GlobalFileStorePaths.ts";
 import { Model } from "../../Model.ts";
@@ -9,8 +10,7 @@ export class CacheStore extends FileStore {
   #sessionContext: SessionContext;
   #model: Model;
   #baseDir =
-    process.env.ALUMNIUM_CACHE_PATH ??
-    GlobalFileStorePaths.globalSubDir("cache");
+    Env.ALUMNIUM_CACHE_PATH ?? GlobalFileStorePaths.globalSubDir("cache");
   #subDir: string;
   #appOverride: AppId | undefined;
 

--- a/packages/typescript/src/server/cache/ElementsCache/ElementsCache.test.ts
+++ b/packages/typescript/src/server/cache/ElementsCache/ElementsCache.test.ts
@@ -5,6 +5,7 @@ import {
   setupBeforeEach,
 } from "../../../../tests/unit/mocks.ts";
 import { AppId } from "../../../AppId.ts";
+import { Env } from "../../../Env.ts";
 import { GlobalFileStorePaths } from "../../../FileStore/GlobalFileStorePaths.ts";
 import { LchainFactory } from "../../../llm/__factories__/LchainFactory.ts";
 import { Lchain } from "../../../llm/Lchain.ts";
@@ -30,9 +31,11 @@ describe("ElementsCache", () => {
         .spyOn(GlobalFileStorePaths, "globalSubDir")
         .mockReturnValue(cacheDir.path),
     );
-    const cacheStore = new CacheStore(sessionContext, Model.current);
 
-    const llmContext = new LlmContext(Model.current);
+    const model = Env.ALUMNIUM_MODEL;
+    const cacheStore = new CacheStore(sessionContext, model);
+
+    const llmContext = new LlmContext(model);
 
     const cache = new ElementsCache(sessionContext, cacheStore, llmContext);
 
@@ -402,7 +405,7 @@ describe("ElementsCache", () => {
       ]);
       await cache.save();
 
-      const model = Model.current.toString();
+      const model = Model.toString(Env.ALUMNIUM_MODEL);
       const baseDir = `${app}/${model}/elements/planner/ffa5f4be241f9c48`;
       expect(await cacheDir.flatTree()).toEqual([
         `${baseDir}/elements.json`,
@@ -432,7 +435,7 @@ describe("ElementsCache", () => {
         await cache.update(prompt1, llmKey, [generation]);
         await cache.save();
 
-        const model = Model.current.toString();
+        const model = Model.toString(Env.ALUMNIUM_MODEL);
         const baseDir = `test-app/${model}/elements/planner/b3806cd36b301287`;
         const responsePath = `${baseDir}/response.json`;
         const instructionPath = `${baseDir}/instruction.json`;
@@ -485,7 +488,7 @@ describe("ElementsCache", () => {
         await cache.update(prompt1, llmKey, [generation]);
         await cache.save();
 
-        const model = Model.current.toString();
+        const model = Model.toString(Env.ALUMNIUM_MODEL);
         const baseDir = `test-app/${model}/elements/actor/fb8d7f17ec7416d7`;
         const responsePath = `${baseDir}/response.json`;
         const instructionPath = `${baseDir}/instruction.json`;

--- a/packages/typescript/src/server/cache/ResponseCache.test.ts
+++ b/packages/typescript/src/server/cache/ResponseCache.test.ts
@@ -2,6 +2,7 @@ import type { Generation } from "@langchain/core/outputs";
 import { describe, expect, it, vi } from "vitest";
 import { createMockDir, pushMock } from "../../../tests/unit/mocks.ts";
 import { AppId } from "../../AppId.ts";
+import { Env } from "../../Env.ts";
 import { GlobalFileStorePaths } from "../../FileStore/GlobalFileStorePaths.ts";
 import { Lchain } from "../../llm/Lchain.ts";
 import { Model } from "../../Model.ts";
@@ -105,15 +106,17 @@ async function setup() {
 
   const cacheDir = await createMockDir({ prefix: "response-cache" });
 
-  const fixedModel = new Model("openai", "gpt-5-nano-2025-08-07");
+  const defaultModel = Model.parse("ollama");
+  const contextModel = Model.parse("openai/gpt-5-nano-2025-08-07");
+
   pushMock(
-    vi.spyOn(Model, "current", "get").mockReturnValue(fixedModel),
+    vi.spyOn(Env, "ALUMNIUM_MODEL", "get").mockReturnValue(defaultModel),
     vi
       .spyOn(GlobalFileStorePaths, "globalSubDir")
       .mockReturnValue(cacheDir.path),
   );
 
-  const llmContext = new LlmContext(Model.current);
+  const llmContext = new LlmContext(contextModel);
   const cacheStore = new CacheStore(sessionContext, llmContext.model);
 
   const prompt1 = "prompt 1" as LlmContext.Prompt;
@@ -136,6 +139,8 @@ async function setup() {
     meta1,
     meta2,
     llmKey,
+    defaultModel,
+    contextModel,
   };
 }
 

--- a/packages/typescript/src/server/serverApp.ts
+++ b/packages/typescript/src/server/serverApp.ts
@@ -1,6 +1,7 @@
 import { cors } from "@elysiajs/cors";
 import { Elysia } from "elysia";
 import { LlmUsageStats } from "../llm/llmSchema.ts";
+import { Model } from "../Model.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
 import { AccessibilityTreeDiff } from "./accessibility/AccessibilityTreeDiff.ts";
 import { ChangesAnalyzerAgent } from "./agents/ChangesAnalyzerAgent.ts";
@@ -57,7 +58,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
           const session = ctx.store.sessions.createSession(ctx.body);
           return {
             session_id: session.sessionId,
-            model: session.model.toString(),
+            model: Model.toString(session.model),
             platform: session.platform,
           };
         },

--- a/packages/typescript/src/server/session/SessionManager.ts
+++ b/packages/typescript/src/server/session/SessionManager.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from "@langchain/core/language_models/base";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { AppId } from "../../AppId.ts";
 import type { Driver } from "../../drivers/Driver.ts";
+import { Env } from "../../Env.ts";
 import {
   createLlmUsageStats,
   LlmUsage,
@@ -67,7 +68,9 @@ export class SessionManager {
       ...restProps
     } = props;
 
-    const model = new Model(provider, modelName);
+    const model = provider
+      ? Model.new(provider, modelName)
+      : Env.ALUMNIUM_MODEL;
     const session = new Session({
       ...restProps,
       sessionId,

--- a/packages/typescript/src/standalone/installPlaywrightBrowsers.ts
+++ b/packages/typescript/src/standalone/installPlaywrightBrowsers.ts
@@ -161,6 +161,7 @@ function patchForkForOopDownload(extractedPath: string) {
     return originalFork(extractedPath, args as string[], {
       ...options,
       execPath: process.execPath,
+      // oxlint-disable-next-line no-process-env -- We need it to pass env vars
       env: { ...(options?.env ?? process.env), BUN_BE_BUN: "1" },
     });
   };

--- a/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
+++ b/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
@@ -61,6 +61,7 @@ async function setupEmbeddedDependenciesInternal() {
   const paths = await extractEmbeddedDependencies();
 
   if (paths.seleniumManagerPath) {
+    // oxlint-disable-next-line no-process-env -- We need it to set the path for Selenium Manager
     process.env.SE_MANAGER_PATH ??= paths.seleniumManagerPath;
   }
 

--- a/packages/typescript/src/telemetry/Instrumentation.test.ts
+++ b/packages/typescript/src/telemetry/Instrumentation.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { Telemetry } from "../telemetry/Telemetry.ts";
+import { Instrumentation } from "./Instrumentation.ts";
 
-describe("Telemetry", () => {
+describe("Instrumentation", () => {
   describe("moduleUrlToName", () => {
     it("should convert module URL to telemetry name", () => {
       expect(
-        Telemetry.moduleUrlToName(
+        Instrumentation.moduleUrlToName(
           "file:///home/koss/code/alumnium/packages/typescript/src/bundle.ts",
         ),
       ).toBe("bundle");
       expect(
-        Telemetry.moduleUrlToName(
+        Instrumentation.moduleUrlToName(
           "file:///home/koss/code/alumnium/packages/typescript/src/server/agents/AreaAgent.ts",
         ),
       ).toBe("server.agents.area_agent");

--- a/packages/typescript/src/telemetry/Instrumentation.ts
+++ b/packages/typescript/src/telemetry/Instrumentation.ts
@@ -1,0 +1,15 @@
+import { always } from "alwaysly";
+import { snakeCase } from "case-anything";
+
+const MODULE_URL_RE = /(src|dist)\/(.+)\.ts/;
+
+export abstract class Instrumentation {
+  static readonly serviceName = "alumnium";
+
+  static moduleUrlToName(moduleUrl: string): string {
+    const matches = moduleUrl.match(MODULE_URL_RE);
+    always(matches?.[2]);
+    const parts = matches[2].split("/").map((part) => snakeCase(part));
+    return parts.join(".");
+  }
+}

--- a/packages/typescript/src/telemetry/Logger.ts
+++ b/packages/typescript/src/telemetry/Logger.ts
@@ -2,6 +2,8 @@ import { getFileSink } from "@logtape/file";
 import {
   ansiColorFormatter,
   configure,
+  dispose,
+  disposeSync,
   getConsoleSink,
   getLogger as logtapeGetLogger,
   type Config as LogtapeConfig,
@@ -10,43 +12,14 @@ import {
 import { getOpenTelemetrySink } from "@logtape/otel";
 import * as fs from "node:fs/promises";
 import path from "node:path";
-import { z } from "zod";
+import { Env } from "../Env.ts";
 import { GlobalFileStorePaths } from "../FileStore/GlobalFileStorePaths.ts";
-import { Telemetry } from "./Telemetry.ts";
+import { Instrumentation } from "./Instrumentation.ts";
+import { LoggerSchema } from "./LoggerSchema.ts";
 import { Tracer } from "./Tracer.ts";
 
-const PRUNE_LOGS = process.env.ALUMNIUM_PRUNE_LOGS !== "false";
-const FILENAME = process.env.ALUMNIUM_LOG_FILENAME;
-const PATH = process.env.ALUMNIUM_LOG_PATH;
-const DEFAULT_LEVEL = process.env.ALUMNIUM_LOG_LEVEL?.toLowerCase().trim();
-const DEBUG_EXTRA_STR = process.env.ALUMNIUM_LOG_DEBUG_EXTRA;
-const BUFFER_SIZE = Number(process.env.ALUMNIUM_LOG_BUFFER_SIZE || 4096);
-const FLUSH_INTERVAL = Number(process.env.ALUMNIUM_LOG_FLUSH_INTERVAL || 500);
-
 export namespace Logger {
-  //#region Schemas
-
-  export type Level = z.infer<typeof Logger.Level>;
-
-  export type Method = z.infer<typeof Logger.Method>;
-
-  export type DebugExtra = z.infer<typeof Logger.DebugExtra>;
-
-  //#endregion
-
-  //#region API
-
-  export type Like = {
-    [method in Method]: LikeMethodFn;
-  };
-
-  export type LikeMethodFn = (message: string, payload?: any) => void;
-
   export type BindMessageFn = (message: string) => string;
-
-  //#endregion
-
-  //#region Configuration
 
   export interface ConfigureProps {
     reset?: boolean | undefined;
@@ -58,93 +31,73 @@ export namespace Logger {
     path?: string | undefined;
   }
 
-  //#endregion
+  export type Sinks = Record<string, Sink>;
 }
 
 export abstract class Logger {
-  //#region Schemas
-
-  static levels = [
-    "debug",
-    "error",
-    "fatal",
-    "info",
-    "trace",
-    "warning",
-  ] as const;
-
-  static Level = z.enum(Logger.levels).catch(() => "info" as const);
-
-  static methods = [
-    "debug",
-    "error",
-    "fatal",
-    "info",
-    "trace",
-    "warn",
-  ] as const;
-
-  static Method = z.enum(Logger.methods);
-
-  static DebugExtra = z.enum([
-    "all",
-    "langchain",
-    "tree",
-    "reasoning",
-    "http",
-    "scenarios",
-  ]);
-
-  //#endregion
-
   //#region API
 
-  static get(moduleUrl: string): Logger.Like {
-    return new Proxy({} as Logger.Like, {
+  static get(moduleUrl: string): LoggerSchema.Like {
+    return new Proxy({} as LoggerSchema.Like, {
       get: (_, prop) => {
-        const methodResult = this.Method.safeParse(prop);
+        const methodResult = LoggerSchema.Method.safeParse(prop);
         if (!methodResult.success)
           throw new Error(`Invalid log method: ${String(prop)}`);
         const method = methodResult.data;
 
-        return (...args: Parameters<Logger.LikeMethodFn>) => {
+        return (...args: Parameters<LoggerSchema.LikeMethodFn>) => {
           void this.#get(moduleUrl).then((logger) => logger[method](...args));
         };
       },
     });
   }
 
-  static #loggerPromise: Promise<Logger.Like> | undefined;
+  static #loggerPromise: Promise<LoggerSchema.Like> | undefined;
 
-  static #get(moduleUrl: string): Promise<Logger.Like> {
+  static #get(moduleUrl: string): Promise<LoggerSchema.Like> {
     if (!this.#loggerPromise) this.#loggerPromise = this.#configure(moduleUrl);
     return this.#loggerPromise;
   }
 
   static bind(
-    logger: Logger.Like,
+    logger: LoggerSchema.Like,
     messageFn: Logger.BindMessageFn,
-  ): Logger.Like {
+  ): LoggerSchema.Like {
     const boundLogger = Object.fromEntries(
-      this.levels.map((level) => {
-        const method: Logger.Method = level === "warning" ? "warn" : level;
-        const methodFn: Logger.LikeMethodFn = (
+      LoggerSchema.levels.map((level) => {
+        const method: LoggerSchema.Method =
+          level === "warning" ? "warn" : level;
+        const methodFn: LoggerSchema.LikeMethodFn = (
           message: string,
           payload?: any,
         ) => logger[method](messageFn(message), payload);
         return [method, methodFn];
       }),
     );
-    return boundLogger as Logger.Like;
+    return boundLogger as LoggerSchema.Like;
+  }
+
+  static async initEnv(logger?: LoggerSchema.Like): Promise<void> {
+    const envLogger = logger || this.#logger();
+
+    const { vars, valid } = Env.init(envLogger);
+    envLogger.debug("Environment variables: {vars}", {
+      vars: this.debugExtra("env", vars),
+    });
+
+    if (!valid) {
+      await this.#flush();
+      process.exit(1);
+    }
   }
 
   //#endregion
 
   //#region Configuration
 
-  static #level = this.Level.parse(DEFAULT_LEVEL);
+  static #level: LoggerSchema.Level | undefined;
 
-  static set level(newLevel: Logger.Level) {
+  static set level(newLevel: LoggerSchema.Level) {
     // NOTE: Currently, we lock configuration changes as we evaluate
     // configuration lazily when first log method is called. It allows to reduce
     // complexity of reconfiguration when using `getLogger` in module scope.
@@ -161,8 +114,11 @@ export abstract class Logger {
 
   static set path(newLogPath: string | Logger.PathObj) {
     // NOTE: See NOTE in `level`.
-    if (this.#loggerPromise)
-      throw new Error("Cannot set logger level, already configured");
+    if (this.#loggerPromise) {
+      const message = `Cannot set logger path ${newLogPath}, the logger is already configured`;
+      this.#logger().error(message);
+      throw new Error(message);
+    }
 
     this.#path = this.#resolvePath(newLogPath);
   }
@@ -175,37 +131,38 @@ export abstract class Logger {
         ? { path: propsOrPathStr }
         : propsOrPathStr || {};
 
-    const path = PATH || props.path;
+    const path = Env.ALUMNIUM_LOG_PATH || props.path;
     if (path) return path;
 
-    const filename = FILENAME || props.filename;
+    const filename = Env.ALUMNIUM_LOG_FILENAME || props.filename;
     if (filename) return GlobalFileStorePaths.globalSubDir(`logs/${filename}`);
   }
 
-  static async #configure(moduleUrl: string): Promise<Logger.Like> {
+  static async #configure(moduleUrl: string): Promise<LoggerSchema.Like> {
     const config = await this.#config();
     await configure(config);
     return logtapeGetLogger([
-      Telemetry.serviceName,
-      Telemetry.moduleUrlToName(moduleUrl),
+      Instrumentation.serviceName,
+      Instrumentation.moduleUrlToName(moduleUrl),
     ]);
   }
 
   static async #config(): Promise<LogtapeConfig<string, string>> {
     if (this.#path) {
       await fs.mkdir(path.dirname(this.#path), { recursive: true });
-      if (PRUNE_LOGS) await fs.rm(this.#path, { force: true });
+      if (Env.ALUMNIUM_PRUNE_LOGS) await fs.rm(this.#path, { force: true });
     }
 
     const consoleSink = getConsoleSink({ formatter: ansiColorFormatter });
     const mainSinks: string[] = ["main"];
+    const flushInterval = Env.ALUMNIUM_LOG_FLUSH_INTERVAL;
 
-    const sinks: Record<string, Sink> = {
+    const sinks: Logger.Sinks = {
       console: consoleSink,
       main: this.#path
         ? getFileSink(this.#path, {
-            bufferSize: BUFFER_SIZE,
-            flushInterval: FLUSH_INTERVAL,
+            bufferSize: Env.ALUMNIUM_LOG_BUFFER_SIZE,
+            flushInterval,
           })
         : consoleSink,
     };
@@ -213,9 +170,7 @@ export abstract class Logger {
     // NOTE: Wait for flush on process exit to ensure all logs are written.
     if (this.#path) {
       process.on("exit", () => {
-        void new Promise((resolve) => {
-          setTimeout(resolve, FLUSH_INTERVAL + 100);
-        });
+        void this.#flush();
       });
     }
 
@@ -223,7 +178,7 @@ export abstract class Logger {
       mainSinks.push("otel");
 
       sinks.otel = getOpenTelemetrySink({
-        serviceName: Telemetry.serviceName,
+        serviceName: Instrumentation.serviceName,
       });
     }
 
@@ -237,23 +192,32 @@ export abstract class Logger {
           sinks: ["console"],
         },
         {
-          category: [Telemetry.serviceName],
-          lowestLevel: Logger.#level,
+          category: [Instrumentation.serviceName],
+          lowestLevel: Logger.#level || Env.ALUMNIUM_LOG_LEVEL,
           sinks: mainSinks,
         },
       ],
     };
   }
 
+  static #logger(): LoggerSchema.Like {
+    return Logger.get(import.meta.url);
+  }
+
+  static async #flush() {
+    await this.#loggerPromise;
+    disposeSync();
+    await dispose();
+  }
+
   //#endregion
 
   //#region Debug extra
 
-  static #debugExtra: Logger.DebugExtra[] =
-    this.#resolveDebugExtra(DEBUG_EXTRA_STR);
+  static #debugExtra: LoggerSchema.DebugExtra[] = Env.ALUMNIUM_LOG_DEBUG_EXTRA;
 
   static debugExtra<Type>(
-    extra: Logger.DebugExtra,
+    extra: LoggerSchema.DebugExtra,
     value: Type,
   ): Type | string {
     return this.#debugExtraEnabled(extra)
@@ -261,16 +225,7 @@ export abstract class Logger {
       : `<DISABLED: USE ALUMNIUM_LOG_DEBUG_EXTRA="${extra}">`;
   }
 
-  static #resolveDebugExtra(extraStr: string | undefined): Logger.DebugExtra[] {
-    return (
-      extraStr?.split(",").flatMap((s) => {
-        const parsed = this.DebugExtra.safeParse(s.trim()).data;
-        return parsed ? [parsed] : [];
-      }) || []
-    );
-  }
-
-  static #debugExtraEnabled(extra: Logger.DebugExtra) {
+  static #debugExtraEnabled(extra: LoggerSchema.DebugExtra) {
     return this.#debugExtra.includes(extra) || this.#debugExtra.includes("all");
   }
 

--- a/packages/typescript/src/telemetry/LoggerSchema.ts
+++ b/packages/typescript/src/telemetry/LoggerSchema.ts
@@ -1,0 +1,49 @@
+import z from "zod";
+
+export namespace LoggerSchema {
+  export type Level = z.infer<typeof LoggerSchema.Level>;
+
+  export type Method = z.infer<typeof LoggerSchema.Method>;
+
+  export type DebugExtra = z.infer<typeof LoggerSchema.DebugExtra>;
+
+  export type Like = {
+    [method in LoggerSchema.Method]: LikeMethodFn;
+  };
+
+  export type LikeMethodFn = (message: string, payload?: any) => void;
+}
+
+export abstract class LoggerSchema {
+  static levels = [
+    "debug",
+    "error",
+    "fatal",
+    "info",
+    "trace",
+    "warning",
+  ] as const;
+
+  static Level = z.enum(this.levels).default("info");
+
+  static methods = [
+    "debug",
+    "error",
+    "fatal",
+    "info",
+    "trace",
+    "warn",
+  ] as const;
+
+  static Method = z.enum(this.methods);
+
+  static DebugExtra = z.enum([
+    "all",
+    "langchain",
+    "tree",
+    "reasoning",
+    "http",
+    "scenarios",
+    "env",
+  ]);
+}

--- a/packages/typescript/src/telemetry/Telemetry.ts
+++ b/packages/typescript/src/telemetry/Telemetry.ts
@@ -1,27 +1,15 @@
-import { always } from "alwaysly";
-import { snakeCase } from "case-anything";
 import { Logger } from "./Logger.ts";
+import type { LoggerSchema } from "./LoggerSchema.ts";
 import { Tracer } from "./Tracer.ts";
-
-const MODULE_URL_RE = /(src|dist)\/(.+)\.ts/;
 
 export namespace Telemetry {
   export interface Like {
     tracer: Tracer.Like;
-    logger: Logger.Like;
+    logger: LoggerSchema.Like;
   }
 }
 
 export abstract class Telemetry {
-  static readonly serviceName = "alumnium";
-
-  static moduleUrlToName(moduleUrl: string): string {
-    const matches = moduleUrl.match(MODULE_URL_RE);
-    always(matches?.[2]);
-    const parts = matches[2].split("/").map((part) => snakeCase(part));
-    return parts.join(".");
-  }
-
   static get(moduleUrl: string): Telemetry.Like {
     const tracer = Tracer.get(moduleUrl);
     const logger = Logger.get(moduleUrl);

--- a/packages/typescript/src/telemetry/Tracer.ts
+++ b/packages/typescript/src/telemetry/Tracer.ts
@@ -14,14 +14,13 @@ import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import { nanoid } from "nanoid";
 import type { Driver } from "../drivers/Driver.ts";
+import { Env } from "../Env.ts";
 import type { Model } from "../Model.ts";
 import type { Agent } from "../server/agents/Agent.ts";
 import type { ElementsCache } from "../server/cache/ElementsCache/ElementsCache.ts";
 import type { SessionId } from "../server/session/SessionId.ts";
 import { TypeUtils } from "../typeUtils.ts";
-import { Telemetry } from "./Telemetry.ts";
-
-const TRACE = process.env.ALUMNIUM_TRACE?.toLowerCase();
+import { Instrumentation } from "./Instrumentation.ts";
 
 export namespace Tracer {
   //#region Defs
@@ -165,103 +164,103 @@ export namespace Tracer {
 
   export interface SpansDriver {
     "driver.get_accessibility_tree": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.click": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.drag_slider": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.drag_and_drop": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.hover": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.press_key": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.back": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.visit": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.scroll_to": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.quit": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.screenshot": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.title": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.type": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.upload": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.url": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.app": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.find_element": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.execute_script": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.switch_to_next_tab": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.switch_to_previous_tab": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.wait": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.wait_for_selector": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.wait_for_page_to_load": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.print_to_pdf": {
-      Attrs: SpansDriverAttrsBase;
+      Attrs: SpansDriverAttrs;
     };
 
     "driver.internal.cdp_command": {
-      Attrs: SpansDriverAttrsBase & {
+      Attrs: SpansDriverAttrs & {
         "driver.internal.cdp_command.name": string;
       };
     };
@@ -295,8 +294,8 @@ export namespace Tracer {
     };
   }
 
-  export interface SpansDriverAttrsBase {
-    "driver.kind": "appium" | "selenium" | "playwright";
+  export interface SpansDriverAttrs {
+    "driver.kind": Driver.Kind;
     "driver.platform": Driver.Platform;
   }
 
@@ -428,10 +427,7 @@ export namespace Tracer {
     };
 
     "mcp.driver.start": {
-      Attrs: SpansMcpToolAttrsDriverBase & {
-        "mcp.driver.kind": "appium" | "selenium" | "playwright";
-        "mcp.driver.platform": string;
-      };
+      Attrs: SpansMcpToolAttrsDriverBase & SpansDriverAttrs;
     };
 
     "mcp.driver.shutdown": {
@@ -464,11 +460,11 @@ export namespace Tracer {
 
   export interface SpansLlm {
     "llm.request": {
-      Attrs: SpansModelAttrs;
+      Attrs: SpansLlmModelAttrs;
     };
   }
 
-  export interface SpansModelAttrs {
+  export interface SpansLlmModelAttrs {
     "llm.model.name": string;
     "llm.model.provider": Model.Provider;
   }
@@ -765,12 +761,12 @@ export abstract class Tracer {
 
   static readonly serviceName = "alumnium";
 
-  static get enabled() {
-    return !!TRACE && !["0", "false", "no", "off"].includes(TRACE);
+  static get enabled(): boolean {
+    return Env.ALUMNIUM_TRACE;
   }
 
   static get(moduleUrl: string): Tracer.Like {
-    const moduleName = Telemetry.moduleUrlToName(moduleUrl);
+    const moduleName = Instrumentation.moduleUrlToName(moduleUrl);
 
     function traceAttrs(attrs: object) {
       const compactedAttrs = Tracer.#compactAttrs(attrs);

--- a/packages/typescript/src/tools/HoverTool.ts
+++ b/packages/typescript/src/tools/HoverTool.ts
@@ -1,5 +1,5 @@
-import { PlaywrightDriver } from "../drivers/PlaywrightDriver.ts";
-import { SeleniumDriver } from "../drivers/SeleniumDriver.ts";
+import type { PlaywrightDriver } from "../drivers/PlaywrightDriver.ts";
+import type { SeleniumDriver } from "../drivers/SeleniumDriver.ts";
 import { BaseTool } from "./BaseTool.ts";
 import { field, type FieldMetadata } from "./Field.ts";
 

--- a/packages/typescript/src/tools/UploadTool.ts
+++ b/packages/typescript/src/tools/UploadTool.ts
@@ -1,5 +1,5 @@
-import { PlaywrightDriver } from "../drivers/PlaywrightDriver.ts";
-import { SeleniumDriver } from "../drivers/SeleniumDriver.ts";
+import type { PlaywrightDriver } from "../drivers/PlaywrightDriver.ts";
+import type { SeleniumDriver } from "../drivers/SeleniumDriver.ts";
 import { BaseTool } from "./BaseTool.ts";
 import { field, type FieldMetadata } from "./Field.ts";
 

--- a/packages/typescript/src/utils/fsState.ts
+++ b/packages/typescript/src/utils/fsState.ts
@@ -1,9 +1,0 @@
-import path from "node:path";
-import { safePathJoin } from "./fs.ts";
-
-export const DEFAULT_FS_STATE_PATH = safePathJoin(process.cwd(), ".alumnium");
-
-export function fsStatePath(segment: string = "."): string {
-  const basePath = process.env.ALUMNIUM_STATE_PATH || DEFAULT_FS_STATE_PATH;
-  return path.resolve(basePath, segment);
-}

--- a/packages/typescript/src/utils/logFormat.ts
+++ b/packages/typescript/src/utils/logFormat.ts
@@ -1,6 +1,7 @@
 import { capitalCase } from "case-anything";
 import { z } from "zod";
 import { Logger } from "../telemetry/Logger.ts";
+import type { LoggerSchema } from "../telemetry/LoggerSchema.ts";
 
 const logger = Logger.get(import.meta.url);
 
@@ -25,7 +26,7 @@ export namespace LogBlocks {
 }
 
 export function logBlocks(
-  method: Logger.Method,
+  method: LoggerSchema.Method,
   message: string,
   blocks: LogBlocks,
 ) {

--- a/packages/typescript/src/utils/retry.ts
+++ b/packages/typescript/src/utils/retry.ts
@@ -1,15 +1,8 @@
 import { always } from "alwaysly";
+import { Env } from "../Env.ts";
 import { Logger } from "../telemetry/Logger.ts";
 
 const logger = Logger.get(import.meta.url);
-
-const DEFAULT_DELAY_SEC = 0.5; // seconds
-let DELAY_MS = parseFloat(process.env.ALUMNIUM_DELAY || "0.5") * 1000; // Convert to milliseconds
-if (isNaN(DELAY_MS) || DELAY_MS < 0) DELAY_MS = DEFAULT_DELAY_SEC * 1000;
-
-const DEFAULT_RETRIES = 2;
-let RETRIES = parseInt(process.env.ALUMNIUM_RETRIES || String(DEFAULT_RETRIES));
-if (isNaN(RETRIES) || RETRIES < 0) RETRIES = DEFAULT_RETRIES;
 
 export namespace retry {
   export interface Options {
@@ -43,8 +36,8 @@ export async function retry<Type>(
     fn = maybeFn!;
   }
 
-  const maxAttempts = options.maxAttempts ?? RETRIES;
-  const backOff = options.backOff ?? DELAY_MS;
+  const maxAttempts = options.maxAttempts ?? Env.ALUMNIUM_RETRIES;
+  const backOff = options.backOff ?? Env.ALUMNIUM_DELAY * 1000;
 
   let lastError: Error | undefined;
 
@@ -63,7 +56,7 @@ export async function retry<Type>(
         throw lastError;
       }
 
-      if (process.env.ALUMNIUM_NO_RETRY) {
+      if (Env.ALUMNIUM_NO_RETRY) {
         logger.info(
           "ALUMNIUM_NO_RETRY is set, not retrying after error: {error}",
           { error: lastError },

--- a/packages/typescript/src/utils/schema.test.ts
+++ b/packages/typescript/src/utils/schema.test.ts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { filenameString, pathString } from "./schema.ts";
+
+describe("pathString", () => {
+  it("normalizes path separators", () => {
+    const result = pathString().parse("foo\\bar/baz");
+    expect(result).toBe(path.join("foo", "bar", "baz"));
+  });
+
+  it("rejects empty paths", () => {
+    const result = pathString().safeParse("");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("filenameString", () => {
+  it("accepts filenames", () => {
+    expect(filenameString().parse("asd.log")).toBe("asd.log");
+    expect(filenameString().parse("alumnium-debug.log")).toBe(
+      "alumnium-debug.log",
+    );
+  });
+
+  it("rejects paths", () => {
+    expect(filenameString().safeParse("logs/asd.log").success).toBe(false);
+    expect(filenameString().safeParse("logs\\asd.log").success).toBe(false);
+  });
+
+  it("rejects unsafe filenames", () => {
+    expect(filenameString().safeParse("file:name.log").success).toBe(false);
+    expect(filenameString().safeParse("CON").success).toBe(false);
+  });
+});

--- a/packages/typescript/src/utils/schema.ts
+++ b/packages/typescript/src/utils/schema.ts
@@ -1,0 +1,51 @@
+import filenamify from "filenamify";
+import path from "node:path";
+import z from "zod";
+
+export const jsonString = <Type extends z.core.$ZodType>(schema: Type) =>
+  z.codec(z.string(), schema, {
+    decode: (str, ctx) => {
+      try {
+        return JSON.parse(str);
+      } catch (err) {
+        ctx.issues.push({
+          code: "invalid_format",
+          format: "json",
+          input: str,
+          message: String(err),
+        });
+        return z.NEVER;
+      }
+    },
+    encode: (value) => JSON.stringify(value),
+  });
+
+export const arrayString = <Schema extends z.ZodEnum<any> | z.ZodString>(
+  schema: Schema = z.string() as Schema,
+) =>
+  z.codec(z.string(), z.array(schema), {
+    decode: (str) =>
+      str
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .map((s) => schema.parse(s)),
+    encode: (value) => value.join(","),
+  });
+
+const ANY_SEP_RE = /[/\\]+/g;
+
+export const pathString = () =>
+  z.codec(z.string().min(1), z.string(), {
+    decode: (value) => path.normalize(value.replace(ANY_SEP_RE, path.sep)),
+    encode: (value) => value,
+  });
+
+export const filenameString = () =>
+  z.string().min(1).refine(isFilename, { message: "Invalid filename" });
+
+function isFilename(value: string): boolean {
+  return (
+    !ANY_SEP_RE.test(value) && filenamify(value, { replacement: "_" }) === value
+  );
+}

--- a/packages/typescript/src/utils/string.ts
+++ b/packages/typescript/src/utils/string.ts
@@ -4,3 +4,19 @@ export function stringExcerpt(str: string, maxLength = 25): string {
     ? `${trimmed.slice(0, maxLength)}...`
     : trimmed;
 }
+
+export function maskString(
+  str: string,
+  unmaskedStart = 4,
+  unmaskedEnd = 4,
+): string {
+  if (str.length <= unmaskedStart + unmaskedEnd) {
+    return "*".repeat(str.length);
+  }
+  const maskedLength = str.length - unmaskedStart - unmaskedEnd;
+  return (
+    str.slice(0, unmaskedStart) +
+    "*".repeat(maskedLength) +
+    str.slice(str.length - unmaskedEnd)
+  );
+}

--- a/packages/typescript/src/utils/typesScan.ts
+++ b/packages/typescript/src/utils/typesScan.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { format } from "oxfmt";
 import { canonize } from "smolcanon";
 import { xxh64Str } from "smolxxh/str";
+import { Env } from "../Env.ts";
 
 export namespace TypesScan {
   export type Node = NodeType | NodeField;
@@ -111,7 +112,7 @@ export namespace scanTypes {
 export function scanTypes(props: scanTypes.Props): void {
   const { id, url, value } = props;
   const scanFilePath = getScanFilePath(url, id);
-  if (!process.env.ALUMNIUM_DEV_DATA_TYPES_SCAN) return;
+  if (!Env.ALUMNIUM_DEV_DATA_TYPES_SCAN) return;
 
   enqueueScan(scanFilePath, async () => {
     await withScanFileLock(scanFilePath, async () => {

--- a/packages/typescript/tests/system/dragAndDrop.test.ts
+++ b/packages/typescript/tests/system/dragAndDrop.test.ts
@@ -5,14 +5,14 @@ describe("Drag and Drop", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { model, driverType } = result;
+      const { model, isAppiumDriver } = result;
 
       // Skip if using DeepSeek (no vision support yet)
       if (model.provider === "deepseek")
         skip("DeepSeek does not support vision yet");
 
       // Skip if using Appium driver (no drag and drop support in mobile browsers)
-      if (driverType.startsWith("appium"))
+      if (isAppiumDriver)
         skip("Example doesn't support drag and drop in mobile browsers");
 
       return result;

--- a/packages/typescript/tests/system/dragSlider.test.ts
+++ b/packages/typescript/tests/system/dragSlider.test.ts
@@ -6,11 +6,10 @@ describe("Drag Slider", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { driverType } = result;
+      const { isAppiumDriver } = result;
 
       // Drag slider is not implemented in Appium yet
-      if (driverType.startsWith("appium"))
-        skip("Drag slider is not implemented in Appium yet");
+      if (isAppiumDriver) skip("Drag slider is not implemented in Appium yet");
 
       return result;
     };

--- a/packages/typescript/tests/system/fileUpload.test.ts
+++ b/packages/typescript/tests/system/fileUpload.test.ts
@@ -28,11 +28,10 @@ describe("File Upload", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { driverType } = result;
+      const { isAppiumDriver } = result;
 
       // File upload is not implemented in Appium yet
-      if (driverType.startsWith("appium"))
-        skip("File upload is not implemented in Appium yet");
+      if (isAppiumDriver) skip("File upload is not implemented in Appium yet");
 
       return result;
     };
@@ -67,9 +66,9 @@ describe("File Upload", () => {
   });
 
   it("should upload a hidden file", async ({ expect, setup, skip }) => {
-    const { al, $, driverType } = await setup();
+    const { al, $, driverId: driverKind } = await setup();
 
-    if (driverType === "selenium")
+    if (driverKind === "selenium")
       skip("Hidden file upload inputs are not supported in Selenium");
 
     await $.navigate("hidden_file_upload.html");

--- a/packages/typescript/tests/system/frames.test.ts
+++ b/packages/typescript/tests/system/frames.test.ts
@@ -5,10 +5,10 @@ describe("Frames", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { driverType } = result;
+      const { isAppiumDriver } = result;
 
       // Frames support is not implemented in Appium yet
-      if (driverType.startsWith("appium"))
+      if (isAppiumDriver)
         skip("Frames support is not implemented in Appium yet");
 
       return result;

--- a/packages/typescript/tests/system/helpers.ts
+++ b/packages/typescript/tests/system/helpers.ts
@@ -8,19 +8,14 @@ import { Builder, WebDriver, WebElement } from "selenium-webdriver";
 import { Options } from "selenium-webdriver/chrome.js";
 import { afterAll, inject, it as vitestIt } from "vitest";
 import { attach, type Browser } from "webdriverio";
-import { z } from "zod";
+import { Driver } from "../../src/drivers/Driver.ts";
+import { Env } from "../../src/Env.ts";
 import { Tracer } from "../../src/telemetry/Tracer.ts";
 
 // Make sure to flush the telemetry data after all tests are done.
 afterAll(() => {
   return Tracer.flush();
 });
-
-export const DriverType = z
-  .enum(["selenium", "playwright", "appium-ios"])
-  .default("selenium");
-
-export type DriverType = z.infer<typeof DriverType>;
 
 export namespace Setup {
   export interface Helpers {
@@ -35,7 +30,8 @@ export interface Setup {
   driver: Alumni.Driver;
   al: Alumni;
   $: Setup.Helpers;
-  driverType: DriverType;
+  driverId: Driver.Id;
+  isAppiumDriver: boolean;
   model: Model;
 }
 
@@ -49,17 +45,20 @@ export namespace useSetup {
 export async function useSetup(props: useSetup.Props): Promise<Setup> {
   const { onTestFinished } = props;
 
-  const driverType = DriverType.parse(process.env.ALUMNIUM_DRIVER);
-  const driver = await createDriver(driverType);
-  const $ = createHelpers(driverType, driver);
+  const driverId = Env.ALUMNIUM_DRIVER;
+  const driver = await createDriver(driverId);
+  const isAppiumDriver = Driver.isAppium(driverId);
 
-  const options: Alumni.Options = { ...props.options };
-  if (process.env.ALUMNIUM_SERVER_URL)
-    options.url = process.env.ALUMNIUM_SERVER_URL;
+  const $ = createHelpers(driverId, driver);
+
+  const options: Alumni.Options = {
+    ...props.options,
+    url: Env.ALUMNIUM_SERVER_URL,
+  };
 
   const al = new Alumni(driver, options);
 
-  if (driverType.startsWith("appium")) {
+  if (isAppiumDriver) {
     (al.driver as AppiumDriver).delay = 0.1;
   }
 
@@ -76,11 +75,11 @@ export async function useSetup(props: useSetup.Props): Promise<Setup> {
     await al.quit();
   });
 
-  return { driver, driverType, al, $, model };
+  return { driver, driverId, isAppiumDriver, al, $, model };
 }
 
-async function createDriver(driverType: DriverType): Promise<Alumni.Driver> {
-  switch (driverType) {
+async function createDriver(driverId: Driver.Id): Promise<Alumni.Driver> {
+  switch (driverId) {
     case "selenium": {
       const options = new Options();
       options.addArguments("--disable-blink-features=AutomationControlled");
@@ -99,7 +98,7 @@ async function createDriver(driverType: DriverType): Promise<Alumni.Driver> {
 
     case "playwright": {
       const browser = await chromium.launch({
-        headless: process.env.ALUMNIUM_PLAYWRIGHT_HEADLESS !== "false",
+        headless: Env.ALUMNIUM_PLAYWRIGHT_HEADLESS,
       });
       const context = await browser.newContext();
       const page = await context.newPage();
@@ -119,13 +118,17 @@ async function createDriver(driverType: DriverType): Promise<Alumni.Driver> {
       return driver;
     }
 
+    case "appium-android": {
+      throw new Error("Unimplemented");
+    }
+
     default:
       never();
   }
 }
 
 function createHelpers(
-  driverType: DriverType,
+  driverId: Driver.Id,
   driver: Alumni.Driver,
 ): Setup.Helpers {
   const $: Setup.Helpers = {
@@ -144,7 +147,7 @@ function createHelpers(
     },
 
     async navigate(url: string) {
-      switch (driverType) {
+      switch (driverId) {
         case "selenium":
           await (driver as WebDriver).get($.resolveUrl(url));
           return;
@@ -154,16 +157,17 @@ function createHelpers(
           return;
 
         case "appium-ios":
+        case "appium-android":
           await (driver as Browser).url($.resolveUrl(url));
           return;
 
         default:
-          driverType satisfies never;
+          driverId satisfies never;
       }
     },
 
     async type(element: Element | undefined, text: string) {
-      switch (driverType) {
+      switch (driverId) {
         case "selenium":
           return (element as WebElement).sendKeys(text);
 
@@ -171,15 +175,16 @@ function createHelpers(
           return (element as Locator).fill(text);
 
         case "appium-ios":
+        case "appium-android":
           return (element as WebdriverIO.Element).setValue(text);
 
         default:
-          driverType satisfies never;
+          driverId satisfies never;
       }
     },
 
     async click(element: Element | undefined) {
-      switch (driverType) {
+      switch (driverId) {
         case "selenium":
           return (element as WebElement).click();
 
@@ -187,10 +192,11 @@ function createHelpers(
           return (element as Locator).click();
 
         case "appium-ios":
+        case "appium-android":
           return (element as WebdriverIO.Element).click();
 
         default:
-          driverType satisfies never;
+          driverId satisfies never;
       }
     },
   };

--- a/packages/typescript/tests/system/setup.appium.ts
+++ b/packages/typescript/tests/system/setup.appium.ts
@@ -1,6 +1,7 @@
+import { Model } from "alumnium";
 import type { TestProject } from "vitest/node";
 import { remote } from "webdriverio";
-import { Model } from "alumnium";
+import { Env } from "../../src/Env.ts";
 
 interface WdioRemoteOptions {
   hostname: string;
@@ -19,9 +20,10 @@ declare module "vitest" {
 }
 
 export async function setup(project: TestProject) {
-  const useLambdaTest = !!(
-    process.env.LT_USERNAME && process.env.LT_ACCESS_KEY
-  );
+  const ltUsername = Env.LT_USERNAME;
+  const ltAccessKey = Env.LT_ACCESS_KEY;
+  const useLambdaTest = ltUsername && ltAccessKey;
+  const model = Env.ALUMNIUM_MODEL;
 
   const capabilities: WebdriverIO.Capabilities = useLambdaTest
     ? {
@@ -33,7 +35,7 @@ export async function setup(project: TestProject) {
         "appium:noReset": true,
         "lt:options": {
           build: "TypeScript - iOS",
-          name: `Vitest (${Model.current.provider}/${Model.current.name})`,
+          name: `Vitest (${Model.toString(model)})`,
           isRealMobile: true,
           network: false,
           visual: true,
@@ -56,8 +58,8 @@ export async function setup(project: TestProject) {
         hostname: "mobile-hub.lambdatest.com",
         path: "/wd/hub",
         port: 80,
-        ...(process.env.LT_USERNAME && { user: process.env.LT_USERNAME }),
-        ...(process.env.LT_ACCESS_KEY && { key: process.env.LT_ACCESS_KEY }),
+        user: ltUsername,
+        key: ltAccessKey,
       }
     : {
         hostname: "localhost",

--- a/packages/typescript/tests/system/table.test.ts
+++ b/packages/typescript/tests/system/table.test.ts
@@ -5,7 +5,7 @@ describe("Table", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { al, model, driverType } = result;
+      const { al, model, isAppiumDriver } = result;
 
       // These models double-click to sort
       if (model.provider === "mistralai")
@@ -14,7 +14,7 @@ describe("Table", () => {
       if (model.provider === "aws_meta")
         skip("Table area instructions need more work");
 
-      if (driverType.startsWith("appium"))
+      if (isAppiumDriver)
         skip("Area is not properly extracted from Appium source code.");
 
       return result;

--- a/packages/typescript/tests/system/tabs.test.ts
+++ b/packages/typescript/tests/system/tabs.test.ts
@@ -6,9 +6,9 @@ describe("Tabs", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { driverType } = result;
+      const { isAppiumDriver } = result;
 
-      if (driverType.startsWith("appium"))
+      if (isAppiumDriver)
         skip("Tabs functionality is not implemented in Appium yet");
 
       return result;

--- a/packages/typescript/tests/system/waiter.test.ts
+++ b/packages/typescript/tests/system/waiter.test.ts
@@ -5,9 +5,9 @@ describe("Waiter script", () => {
   const it = baseIt.override("setup", async ({ setup, skip }) => {
     return async (options) => {
       const result = await setup(options);
-      const { driverType } = result;
+      const { driverId } = result;
 
-      if (driverType === "appium-ios")
+      if (driverId === "appium-ios")
         skip("Synchronization is not implemented in Appium yet");
 
       return result;

--- a/packages/typescript/vitest.config.ts
+++ b/packages/typescript/vitest.config.ts
@@ -1,5 +1,13 @@
 import babel from "@rolldown/plugin-babel";
 import { defineConfig } from "vitest/config";
+import { Driver } from "./src/drivers/Driver.ts";
+import { Env } from "./src/Env.ts";
+import { Logger } from "./src/telemetry/Logger.ts";
+
+const driverKind = Env.ALUMNIUM_DRIVER;
+const isAppium = Driver.isAppium(driverKind);
+
+await Logger.initEnv();
 
 export default defineConfig({
   test: {
@@ -17,13 +25,11 @@ export default defineConfig({
           include: ["tests/system/**/*.test.ts"],
           testTimeout: 5 * 60_000, // 5 minutes
           retry: {
-            count: process.env.CI ? 1 : 0,
+            count: Env.CI ? 1 : 0,
             delay: 1000,
           },
-          globalSetup: process.env.ALUMNIUM_DRIVER?.startsWith("appium")
-            ? ["tests/system/setup.appium.ts"]
-            : [],
-          fileParallelism: !process.env.ALUMNIUM_DRIVER?.startsWith("appium"),
+          globalSetup: isAppium ? ["tests/system/setup.appium.ts"] : [],
+          fileParallelism: !isAppium,
         },
       },
     ],

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -49,8 +49,8 @@ Set to `true` to capture full-page screenshots instead of viewport-only screensh
 Sets the level used by Alumnium logger. Supported values are:
 
 - `debug`
-- `info`
-- `warning` (default)
+- `info` (default)
+- `warning`
 - `error`
 - `critical`
 


### PR DESCRIPTION
This PR wraps `process.env` into type-safe, centralized, and validated API. It utilizes Zod to define schemas for each variable, and centralizes default values and parsing rules.

Now every env variable is parsed, so no unexpected data can come in.

It also adds env vars to logger and prints all the values when the server, MCP, and tests start. Secret values are masked. 

Because the new API is so interconnected, I started getting circular dependency errors, so I enabled a linter rule to disallow circular imports and fixed all the found issues, including many of the existing ones. I had to refactor some classes, like `Model`, `Logger` and `Driver`, and extracted parts of the code into shared modules to break the loops.