### PR TITLE
Fix/339 video recording optional v2

### DIFF
--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -1,4 +1,4 @@
-undefined/**
+
  * @module MCP State
  * State management for MCP server driver instances.
  */

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -1,4 +1,4 @@
-/**
+undefined/**
  * @module MCP State
  * State management for MCP server driver instances.
  */

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -1,5 +1,5 @@
 
- * @module MCP State
+
  * State management for MCP server driver instances.
  */
 

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -1,5 +1,3 @@
-
-
  * State management for MCP server driver instances.
  */
 

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -1,4 +1,4 @@
-undefined/**
+/**
  * Driver factory functions for different platforms.
  */
 

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -1,4 +1,4 @@
-/**
+undefined/**
  * Driver factory functions for different platforms.
  */
 


### PR DESCRIPTION
Fixes #339

Makes video recording optional in the MCP Playwright driver. Rebased on latest main.

**Changes:**
- `mcpDrivers.ts`: Wrapped video setup in `shouldRecordVideos` conditional
- `McpState.ts`: Added `recordVideos?: boolean` to `DriverOptions`

**Disable via env var:** `ALUMNIUM_MCP_RECORD_VIDEOS=false`
**Disable via capability:** `{"alumnium:options": {"recordVideos": false}}`