### PR TITLE
feat(ts): support OPENAI_DEFAULT_HEADERS for OpenAI provider

### DIFF
--- a/packages/typescript/src/Env.ts
+++ b/packages/typescript/src/Env.ts
@@ -248,6 +248,13 @@ export const Env = {
     return envVar("OPENAI_CUSTOM_URL", z.string().optional());
   },
 
+  get OPENAI_DEFAULT_HEADERS() {
+    return envVar(
+      "OPENAI_DEFAULT_HEADERS",
+      jsonString(z.record(z.string(), z.string())).optional(),
+    );
+  },
+
   get LT_USERNAME() {
     return secretEnvVar("LT_USERNAME", z.string().optional());
   },

--- a/packages/typescript/src/server/LlmFactory.ts
+++ b/packages/typescript/src/server/LlmFactory.ts
@@ -282,7 +282,10 @@ export class LlmFactory {
 
     const fields: ChatOpenAIFields = {
       model: model.name,
-      configuration: { baseURL: Env.OPENAI_CUSTOM_URL },
+      configuration: {
+        baseURL: Env.OPENAI_CUSTOM_URL,
+        defaultHeaders: new Headers(Env.OPENAI_DEFAULT_HEADERS),
+      },
       // TODO: Apparently the latest OpenAI models (o1, o3, o4, gpt-5) don't
       // accept temperature anymore, so we need to either conditionally include
       // it or figure out the correct way to set it for the new models.

--- a/websites/docs/src/content/docs/docs/guides/self-hosting.md
+++ b/websites/docs/src/content/docs/docs/guides/self-hosting.md
@@ -55,8 +55,6 @@ export AZURE_OPENAI_API_KEY="..."
 # Change as needed
 export AZURE_OPENAI_API_VERSION="2025-03-01-preview"
 export AZURE_OPENAI_ENDPOINT="https://my-model.openai.azure.com"
-# Optional: JSON object of extra headers sent on every request
-export AZURE_OPENAI_DEFAULT_HEADERS='{"x-custom-header":"value"}'
 ```
 
 ## Ollama

--- a/websites/docs/src/content/docs/docs/guides/self-hosting.md
+++ b/websites/docs/src/content/docs/docs/guides/self-hosting.md
@@ -55,6 +55,8 @@ export AZURE_OPENAI_API_KEY="..."
 # Change as needed
 export AZURE_OPENAI_API_VERSION="2025-03-01-preview"
 export AZURE_OPENAI_ENDPOINT="https://my-model.openai.azure.com"
+# Optional: JSON object of extra headers sent on every request
+export AZURE_OPENAI_DEFAULT_HEADERS='{"x-custom-header":"value"}'
 ```
 
 ## Ollama

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -203,6 +203,10 @@ Sets the URL for Ollama models if you host them externally on a server.
 
 Sets the URL for OpenAI models if you access them via custom endpoint.
 
+### `OPENAI_DEFAULT_HEADERS`
+
+JSON string of additional headers to send with OpenAI requests (e.g. `{"x-custom-header": "value"}`).
+
 [1]: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
 [2]: https://github.com/alumnium-hq/alumnium/issues/112
 [3]: /docs/guides/mcp


### PR DESCRIPTION
## Summary
   
  - Adds OPENAI_DEFAULT_HEADERS env var (JSON object string) to the TypeScript Env — mirrors the existing AZURE_OPENAI_DEFAULT_HEADERS pattern using the same                               
  jsonString(z.record(z.string(), z.string())) zod codec                                                                                                 
  - Wires the new var into LlmFactory.createOpenAiLlm via configuration.defaultHeaders, matching the Azure OpenAI implementation exactly                                                    
  - Documents the new var in reference.md and adds it to the OpenAI setup snippet in configuration.md; also adds AZURE_OPENAI_DEFAULT_HEADERS to the Azure OpenAI snippet in self-hosting.md
   (it was previously missing there)                                                                                                                                                        
                                                                                                                                                                                            
## Motivation                                                                                                                                                                              
                                                                                                                                                         
  Users on the openai provider had no way to attach custom headers to outbound requests — needed for proxies, internal gateways, request tagging, and auth shims. The Azure OpenAI provider 
  already supported this; this change brings parity.                                                                                                     
                                                                                                                                                                                            
##  Usage                                                                                                                                                                                     
  
  export ALUMNIUM_MODEL="gpt-5-nano"                                                                                                                                                            
  export OPENAI_API_KEY="sk-proj-..."                                                                                                                                                       
  export OPENAI_DEFAULT_HEADERS='{"x-my-header":"value"}'                                                                                                                                   
                                                                                                                                                                                            
 ## Test plan                                                                                                                                                                                 
                                                                                                                                                                                            
  - mise :types passes (no type errors)                                                                                                                                                     
  - mise :lint passes                                                                                                                                    
  - Manual: set OPENAI_DEFAULT_HEADERS='{"x-test":"1"}', run server, confirm header appears on outbound requests via proxy or debug logs                                                    
  - Negative: set OPENAI_DEFAULT_HEADERS='not-json', confirm startup fails with zod validation error   



## Type of Change

Mark the relevant options.

- [ ] Bug fix
- [X] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

## Checklist

Please verify the following before submitting:

- [ ] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [X] I have added or updated relevant documentation
- [ ] I have written or updated necessary tests
- [ ] I have tested the changes locally
- [ ] The changes follow the project's coding style and structure
- [X] I have not included any sensitive or credential-related information
- [ ] I have ensured these changes maintain or improve accessibility (for UI changes)
- [X ] I have considered security implications of these changes
