### PR TITLE
fix(java): server chooses model if omitted

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/Alumni.java
+++ b/packages/java/src/main/java/ai/alumnium/Alumni.java
@@ -58,10 +58,7 @@ public final class Alumni implements AutoCloseable {
         opts.changeAnalysis() != null ? opts.changeAnalysis() : Config.CHANGE_ANALYSIS;
     Set<String> excludeAttributes =
         opts.excludeAttributes() != null ? opts.excludeAttributes() : Config.EXCLUDE_ATTRIBUTES;
-    this.model = opts.model() != null ? opts.model() : Model.current();
     this.driver = wrapDriver(driver);
-
-    LOG.info("Using model: {}/{}", this.model.provider().value(), this.model.name());
 
     Map<String, Class<? extends BaseTool>> builtTools = new LinkedHashMap<>();
     for (Class<? extends BaseTool> tool : this.driver.supportedTools()) {
@@ -80,7 +77,16 @@ public final class Alumni implements AutoCloseable {
 
     this.client =
         new HttpClient(
-            serverUrl, this.model, this.driver.platform(), toolSchemas, planner, excludeAttributes);
+            serverUrl,
+            opts.model(),
+            this.driver.platform(),
+            toolSchemas,
+            planner,
+            excludeAttributes);
+
+    this.model = client.model();
+    LOG.info("Using model: {}/{}", this.model.provider().value(), this.model.name());
+
     this.cache = new Cache(this.client);
     LOG.info("Using HTTP client with server: {}", this.client.baseUrl());
   }

--- a/packages/java/src/main/java/ai/alumnium/Model.java
+++ b/packages/java/src/main/java/ai/alumnium/Model.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /** Identifies a model by {@link Provider} and model name. */
 public final class Model {
 
-  private static volatile Model current = buildFromEnv();
+  private static volatile Model current = fromEnv();
 
   private final Provider provider;
   private final String name;
@@ -30,7 +30,8 @@ public final class Model {
 
   /**
    * The process-default model, derived from {@code ALUMNIUM_MODEL} (format: {@code provider/name}).
-   * Falls back to {@link Provider#GITHUB} under GitHub Actions, otherwise {@link Provider#OPENAI}.
+   * Falls back to {@link Provider#GITHUB} when running under GitHub Actions. Returns {@code null}
+   * when neither is set.
    */
   public static Model current() {
     return current;
@@ -41,21 +42,40 @@ public final class Model {
     current = model;
   }
 
-  private static Model buildFromEnv() {
-    String raw = System.getenv().getOrDefault("ALUMNIUM_MODEL", "");
-    String providerToken = raw;
-    String nameToken = null;
-    int slash = raw.indexOf('/');
-    if (slash >= 0) {
-      providerToken = raw.substring(0, slash);
-      nameToken = raw.substring(slash + 1);
+  /**
+   * Parses a model string of the form {@code provider/name} (as returned by the alumnium server).
+   * The name is optional — when omitted, the provider's default model is used.
+   */
+  public static Model fromString(String model) {
+    if (model == null || model.isBlank()) {
+      return null;
     }
-    providerToken = providerToken.trim().toLowerCase();
-    if (providerToken.isEmpty() && System.getenv("GITHUB_ACTIONS") != null) {
-      providerToken = "github";
+
+    String providerToken = model;
+    String nameToken = null;
+    int slash = model.indexOf('/');
+    if (slash >= 0) {
+      providerToken = model.substring(0, slash);
+      nameToken = model.substring(slash + 1);
     }
     Provider provider = Provider.fromValue(providerToken).orElse(Provider.OPENAI);
     return new Model(provider, (nameToken == null || nameToken.isBlank()) ? null : nameToken);
+  }
+
+  /**
+   * Resolves the default model from environment variables. Mirrors Python's {@code
+   * Model.from_env()}: parses {@code ALUMNIUM_MODEL} when set, otherwise uses {@link
+   * Provider#GITHUB} under GitHub Actions, otherwise returns {@code null}.
+   */
+  private static Model fromEnv() {
+    Model fromConfig = fromString(Config.MODEL);
+    if (fromConfig != null) {
+      return fromConfig;
+    }
+    if (System.getenv("GITHUB_ACTIONS") != null) {
+      return new Model(Provider.GITHUB, null);
+    }
+    return null;
   }
 
   static final class Names {

--- a/packages/java/src/main/java/ai/alumnium/client/HttpClient.java
+++ b/packages/java/src/main/java/ai/alumnium/client/HttpClient.java
@@ -52,6 +52,7 @@ public final class HttpClient implements AutoCloseable {
 
   private final java.net.http.HttpClient http;
   private final String baseUrl;
+  private final Model model;
   private final AtomicReference<String> sessionId = new AtomicReference<>();
   private volatile String managedPidName;
   private Thread shutdownHook;
@@ -59,7 +60,8 @@ public final class HttpClient implements AutoCloseable {
   /**
    * @param url server base URL; null or blank auto-starts a managed server (requires an {@code
    *     alumnium-cli-*} JAR on the classpath); explicit values without a scheme get {@code http://}
-   * @param model {@link Model} to be used by the session
+   * @param model {@link Model} to be used by the session; {@code null} lets the server pick a
+   *     default
    * @param platform driver platform string (e.g. {@code "web-selenium"})
    * @param toolSchemas JSON-serialisable tool schemas (maps or annotated POJOs)
    * @param planner enable the planner agent
@@ -80,8 +82,10 @@ public final class HttpClient implements AutoCloseable {
     this.baseUrl = resolveUrl(url);
 
     Map<String, Object> body = new LinkedHashMap<>();
-    body.put("provider", model.provider().value());
-    body.put("name", model.name());
+    if (model != null) {
+      body.put("provider", model.provider().value());
+      body.put("name", model.name());
+    }
     body.put("tools", toolSchemas == null ? List.of() : toolSchemas);
     body.put("platform", platform);
     body.put("planner", planner);
@@ -90,11 +94,16 @@ public final class HttpClient implements AutoCloseable {
         excludeAttributes == null ? List.of() : List.copyOf(excludeAttributes));
 
     JsonNode resp = postJson("/v1/sessions", body, Duration.ofSeconds(30));
+    this.model = Model.fromString(resp.path("model").asText(null));
     sessionId.set(resp.path("session_id").asText(null));
   }
 
   public String baseUrl() {
     return baseUrl;
+  }
+
+  public Model model() {
+    return model;
   }
 
   public String sessionId() {


### PR DESCRIPTION
The old implementation always passed the model from the environment. Instead, it should have pass omitted passing model to the new session request completely. This lets the server choose a model for the client.
