### PR TITLE
chore(java): Added task for test execution for android and ios

### DIFF
--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -46,6 +46,12 @@ jobs:
           - driver: playwright
             model: azure_openai
 
+          - driver: appium-ios
+            model: azure_openai
+
+          - driver: appium-android
+            model: azure_openai
+
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6

--- a/packages/java/build.gradle
+++ b/packages/java/build.gradle
@@ -103,6 +103,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
+                        environment System.getenv()
                         environment "ALUMNIUM_DRIVER", System.getenv("ALUMNIUM_DRIVER") ?: "selenium"
                         environment "ALUMNIUM_PLAYWRIGHT_HEADLESS", System.getenv("ALUMNIUM_PLAYWRIGHT_HEADLESS") ?: "true"
                         testLogging {
@@ -137,7 +138,7 @@ mavenPublishing {
                 name = 'Alex Rodionov'
             }
             developer {
-                id = 'rookieintraing'
+                id = 'rookieintraining'
                 name = 'Ish Abbi'
             }
         }

--- a/packages/java/build.gradle
+++ b/packages/java/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'com.vanniktech.maven.publish' version '0.30.0'
-    id 'com.diffplug.spotless' version '8.5.0'
+    id 'com.diffplug.spotless' version '8.5.1'
 }
 
 group   = 'ai.alumnium'

--- a/packages/java/mise.toml
+++ b/packages/java/mise.toml
@@ -40,7 +40,7 @@ description = "Run unit tests"
 [tasks."test/system"]
 usage = '''
 arg "<driver>" help="Driver to use for system tests" {
-  choices "selenium" "playwright"
+  choices "selenium" "playwright" "appium-ios" "appium-android"
   default "selenium"
 }
 '''
@@ -51,6 +51,12 @@ run = [{ task = "test/system playwright" }]
 
 [tasks."test/system:selenium"]
 run = [{ task = "test/system selenium" }]
+
+[tasks."test/system:appium-ios"]
+run = [{ task = "test/system appium-ios" }]
+
+[tasks."test/system:appium-android"]
+run = [{ task = "test/system appium-android" }]
 
 [tasks."test/package"]
 run = "./scripts/test-package.sh"

--- a/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
@@ -1,8 +1,6 @@
 package ai.alumnium.system;
 
 import ai.alumnium.Alumni;
-import ai.alumnium.Model;
-import ai.alumnium.Provider;
 import ai.alumnium.driver.AppiumDriver;
 import ai.alumnium.tool.BaseTool;
 import com.microsoft.playwright.Browser;
@@ -45,33 +43,33 @@ public class BaseTest {
   static final AlumniCacheExtension cacheAfterEach = new AlumniCacheExtension(() -> al);
 
   protected static final boolean IS_APPIUM =
-    System.getenv("ALUMNIUM_DRIVER") != null
-        && System.getenv("ALUMNIUM_DRIVER").startsWith("appium");
+      System.getenv("ALUMNIUM_DRIVER") != null
+          && System.getenv("ALUMNIUM_DRIVER").startsWith("appium");
 
   private static boolean isLambdaTest() {
-      return LT_USERNAME != null && LT_ACCESS_KEY != null;
+    return LT_USERNAME != null && LT_ACCESS_KEY != null;
   }
-  
+
   private static URL lambdaTestUrl() throws MalformedURLException {
-      return URI.create(
-              "https://" + LT_USERNAME + ":" + LT_ACCESS_KEY + "@mobile-hub.lambdatest.com/wd/hub")
-          .toURL();
+    return URI.create(
+            "https://" + LT_USERNAME + ":" + LT_ACCESS_KEY + "@mobile-hub.lambdatest.com/wd/hub")
+        .toURL();
   }
-  
+
   private static URL localAppiumUrl() throws MalformedURLException {
-      String url = System.getenv().getOrDefault("APPIUM_URL", "http://127.0.0.1:4723/");
-      return URI.create(url).toURL();
+    String url = System.getenv().getOrDefault("APPIUM_URL", "http://127.0.0.1:4723/");
+    return URI.create(url).toURL();
   }
-  
+
   private static Map<String, Object> ltOptions(String build) {
-      return Map.of(
-          "build", build,
-          "name", "JUnit (" + DRIVER_TYPE + ")",
-          "isRealMobile", true,
-          "network", false,
-          "visual", true,
-          "video", true,
-          "w3c", true);
+    return Map.of(
+        "build", build,
+        "name", "JUnit (" + DRIVER_TYPE + ")",
+        "isRealMobile", true,
+        "network", false,
+        "visual", true,
+        "video", true,
+        "w3c", true);
   }
 
   // AppiumDriver conflicts with alumni's AppiumDriver. Hence, using canonical class name

--- a/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
@@ -1,6 +1,8 @@
 package ai.alumnium.system;
 
 import ai.alumnium.Alumni;
+import ai.alumnium.Model;
+import ai.alumnium.Provider;
 import ai.alumnium.driver.AppiumDriver;
 import ai.alumnium.tool.BaseTool;
 import com.microsoft.playwright.Browser;
@@ -33,6 +35,7 @@ public class BaseTest {
       System.getenv().getOrDefault("ALUMNIUM_DRIVER", "selenium");
   private static final String LT_USERNAME = System.getenv("LT_USERNAME");
   private static final String LT_ACCESS_KEY = System.getenv("LT_ACCESS_KEY");
+  private static final boolean IS_LAMBDA_TEST = LT_USERNAME != null && LT_ACCESS_KEY != null;
   private static final boolean PLAYWRIGHT_HEADLESS =
       !"false".equalsIgnoreCase(System.getenv("ALUMNIUM_PLAYWRIGHT_HEADLESS"));
 
@@ -42,22 +45,11 @@ public class BaseTest {
   @RegisterExtension
   static final AlumniCacheExtension cacheAfterEach = new AlumniCacheExtension(() -> al);
 
-  protected static final boolean IS_APPIUM =
-      System.getenv("ALUMNIUM_DRIVER") != null
-          && System.getenv("ALUMNIUM_DRIVER").startsWith("appium");
-
-  private static boolean isLambdaTest() {
-    return LT_USERNAME != null && LT_ACCESS_KEY != null;
-  }
-
-  private static URL lambdaTestUrl() throws MalformedURLException {
-    return URI.create(
-            "https://" + LT_USERNAME + ":" + LT_ACCESS_KEY + "@mobile-hub.lambdatest.com/wd/hub")
-        .toURL();
-  }
-
-  private static URL localAppiumUrl() throws MalformedURLException {
-    String url = System.getenv().getOrDefault("APPIUM_URL", "http://127.0.0.1:4723/");
+  private static URL appiumUrl() throws MalformedURLException {
+    String url =
+        IS_LAMBDA_TEST
+            ? "https://" + LT_USERNAME + ":" + LT_ACCESS_KEY + "@mobile-hub.lambdatest.com/wd/hub"
+            : System.getenv().getOrDefault("APPIUM_URL", "http://127.0.0.1:4723/");
     return URI.create(url).toURL();
   }
 
@@ -72,24 +64,24 @@ public class BaseTest {
         "w3c", true);
   }
 
-  // AppiumDriver conflicts with alumni's AppiumDriver. Hence, using canonical class name
+  // io.appium.java_client.AppiumDriver conflicts with ai.alumnium.driver.AppiumDriver
   private static io.appium.java_client.AppiumDriver buildIosDriver() throws MalformedURLException {
     XCUITestOptions options = new XCUITestOptions();
     options.setPlatformName("iOS");
-    options.setDeviceName("iPhone 16");
+    options.setDeviceName("iPhone 17 Pro Max");
     options.setNoReset(true);
 
-    if (isLambdaTest()) {
+    if (IS_LAMBDA_TEST) {
       options.withBrowserName("Safari");
       options.setPlatformVersion("18");
       options.setCapability("lt:options", ltOptions("Java - iOS"));
-      return new IOSDriver(lambdaTestUrl(), options);
+    } else {
+      options.setBundleId("com.apple.mobilesafari");
+      options.setPlatformVersion("26.5");
+      options.setNewCommandTimeout(Duration.ofSeconds(300));
     }
 
-    options.setBundleId("com.apple.mobilesafari");
-    options.setPlatformVersion("18.5");
-    options.setNewCommandTimeout(Duration.ofSeconds(300));
-    return new IOSDriver(localAppiumUrl(), options);
+    return new IOSDriver(appiumUrl(), options);
   }
 
   private static io.appium.java_client.AppiumDriver buildAndroidDriver()
@@ -98,21 +90,22 @@ public class BaseTest {
     options.setPlatformName("Android");
     options.setDeviceName("Android Device");
     options.setNoReset(true);
+    options.withBrowserName("Chrome");
 
-    if (isLambdaTest()) {
-      options.withBrowserName("Chrome");
+    if (IS_LAMBDA_TEST) {
       options.setPlatformVersion("14");
       options.setCapability("lt:options", ltOptions("Java - Android"));
-      return new AndroidDriver(lambdaTestUrl(), options);
+    } else {
+      options.setPlatformVersion("16.0");
+      options.setChromeOptions(Map.of("androidKeepAppDataDir", true));
+      options.setNewCommandTimeout(Duration.ofSeconds(300));
     }
 
-    options.withBrowserName("Chrome");
-    options.setPlatformVersion("16.0");
-    options.setChromeOptions(Map.of("androidKeepAppDataDir", true));
-    options.setNewCommandTimeout(Duration.ofSeconds(300));
-    AndroidDriver driver = new AndroidDriver(localAppiumUrl(), options);
-    driver.setSettings(
-        Map.<String, Object>of("allowInvisibleElements", true, "ignoreUnimportantViews", true));
+    AndroidDriver driver = new AndroidDriver(appiumUrl(), options);
+    if (!IS_LAMBDA_TEST) {
+      driver.setSettings(
+          Map.<String, Object>of("allowInvisibleElements", true, "ignoreUnimportantViews", true));
+    }
     return driver;
   }
 
@@ -131,7 +124,7 @@ public class BaseTest {
                 // unreachable: JUnit gave us the class already
               }
             });
-    Alumni.Options options = new Alumni.Options().withExtraTools(extraTools);
+    Alumni.Options options = new Alumni.Options().withModel(new Model(Provider.ANTHROPIC, "claude-haiku-4-5-20251001")).withExtraTools(extraTools);
 
     switch (DRIVER_TYPE) {
       case "playwright" -> {

--- a/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
@@ -1,13 +1,24 @@
 package ai.alumnium.system;
 
 import ai.alumnium.Alumni;
+import ai.alumnium.Model;
+import ai.alumnium.Provider;
+import ai.alumnium.driver.AppiumDriver;
 import ai.alumnium.tool.BaseTool;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Locator;
-import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.android.options.UiAutomator2Options;
+import io.appium.java_client.ios.IOSDriver;
+import io.appium.java_client.ios.options.XCUITestOptions;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInfo;
@@ -22,19 +33,93 @@ public class BaseTest {
 
   private static final String DRIVER_TYPE =
       System.getenv().getOrDefault("ALUMNIUM_DRIVER", "selenium");
+  private static final String LT_USERNAME = System.getenv("LT_USERNAME");
+  private static final String LT_ACCESS_KEY = System.getenv("LT_ACCESS_KEY");
   private static final boolean PLAYWRIGHT_HEADLESS =
       !"false".equalsIgnoreCase(System.getenv("ALUMNIUM_PLAYWRIGHT_HEADLESS"));
 
-  private static ChromeDriver seleniumDriver;
   private static Playwright playwright;
   private static Browser browser;
-  private static Page playwrightPage;
 
   @RegisterExtension
   static final AlumniCacheExtension cacheAfterEach = new AlumniCacheExtension(() -> al);
 
+  protected static final boolean IS_APPIUM =
+    System.getenv("ALUMNIUM_DRIVER") != null
+        && System.getenv("ALUMNIUM_DRIVER").startsWith("appium");
+
+  private static boolean isLambdaTest() {
+      return LT_USERNAME != null && LT_ACCESS_KEY != null;
+  }
+  
+  private static URL lambdaTestUrl() throws MalformedURLException {
+      return URI.create(
+              "https://" + LT_USERNAME + ":" + LT_ACCESS_KEY + "@mobile-hub.lambdatest.com/wd/hub")
+          .toURL();
+  }
+  
+  private static URL localAppiumUrl() throws MalformedURLException {
+      String url = System.getenv().getOrDefault("APPIUM_URL", "http://127.0.0.1:4723/");
+      return URI.create(url).toURL();
+  }
+  
+  private static Map<String, Object> ltOptions(String build) {
+      return Map.of(
+          "build", build,
+          "name", "JUnit (" + DRIVER_TYPE + ")",
+          "isRealMobile", true,
+          "network", false,
+          "visual", true,
+          "video", true,
+          "w3c", true);
+  }
+
+  // AppiumDriver conflicts with alumni's AppiumDriver. Hence, using canonical class name
+  private static io.appium.java_client.AppiumDriver buildIosDriver() throws MalformedURLException {
+    XCUITestOptions options = new XCUITestOptions();
+    options.setPlatformName("iOS");
+    options.setDeviceName("iPhone 16");
+    options.setNoReset(true);
+
+    if (isLambdaTest()) {
+      options.withBrowserName("Safari");
+      options.setPlatformVersion("18");
+      options.setCapability("lt:options", ltOptions("Java - iOS"));
+      return new IOSDriver(lambdaTestUrl(), options);
+    }
+
+    options.setBundleId("com.apple.mobilesafari");
+    options.setPlatformVersion("18.5");
+    options.setNewCommandTimeout(Duration.ofSeconds(300));
+    return new IOSDriver(localAppiumUrl(), options);
+  }
+
+  private static io.appium.java_client.AppiumDriver buildAndroidDriver()
+      throws MalformedURLException {
+    UiAutomator2Options options = new UiAutomator2Options();
+    options.setPlatformName("Android");
+    options.setDeviceName("Android Device");
+    options.setNoReset(true);
+
+    if (isLambdaTest()) {
+      options.withBrowserName("Chrome");
+      options.setPlatformVersion("14");
+      options.setCapability("lt:options", ltOptions("Java - Android"));
+      return new AndroidDriver(lambdaTestUrl(), options);
+    }
+
+    options.withBrowserName("Chrome");
+    options.setPlatformVersion("16.0");
+    options.setChromeOptions(Map.of("androidKeepAppDataDir", true));
+    options.setNewCommandTimeout(Duration.ofSeconds(300));
+    AndroidDriver driver = new AndroidDriver(localAppiumUrl(), options);
+    driver.setSettings(
+        Map.<String, Object>of("allowInvisibleElements", true, "ignoreUnimportantViews", true));
+    return driver;
+  }
+
   @BeforeAll
-  static void setUp(TestInfo info) {
+  static void setUp(TestInfo info) throws MalformedURLException {
     // Force the concrete test class's <clinit> to run before we read
     // `extraTools`. The JVM only initializes BaseTest when this static method
     // is invoked, so any static initializer in a subclass that overrides
@@ -50,17 +135,24 @@ public class BaseTest {
             });
     Alumni.Options options = new Alumni.Options().withExtraTools(extraTools);
 
-    if ("playwright".equals(DRIVER_TYPE)) {
-      playwright = Playwright.create();
-      browser =
-          playwright
-              .chromium()
-              .launch(new BrowserType.LaunchOptions().setHeadless(PLAYWRIGHT_HEADLESS));
-      playwrightPage = browser.newPage();
-      al = new Alumni(playwrightPage, options);
-    } else {
-      seleniumDriver = new ChromeDriver();
-      al = new Alumni(seleniumDriver, options);
+    switch (DRIVER_TYPE) {
+      case "playwright" -> {
+        playwright = Playwright.create();
+        browser =
+            playwright
+                .chromium()
+                .launch(new BrowserType.LaunchOptions().setHeadless(PLAYWRIGHT_HEADLESS));
+        al = new Alumni(browser.newPage(), options);
+      }
+      case "appium-ios" -> {
+        al = new Alumni(buildIosDriver(), options);
+        ((AppiumDriver) al.driver()).delay = 0.1;
+      }
+      case "appium-android" -> {
+        al = new Alumni(buildAndroidDriver(), options);
+        ((AppiumDriver) al.driver()).delay = 0.1;
+      }
+      default -> al = new Alumni(new ChromeDriver(), options);
     }
   }
 
@@ -71,11 +163,7 @@ public class BaseTest {
   }
 
   protected static void navigate(String url) {
-    if ("playwright".equals(DRIVER_TYPE)) {
-      playwrightPage.navigate(url);
-    } else {
-      seleniumDriver.get(url);
-    }
+    al.driver().visit(url);
   }
 
   protected static void type(Object element, String text) {

--- a/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
@@ -1,8 +1,6 @@
 package ai.alumnium.system;
 
 import ai.alumnium.Alumni;
-import ai.alumnium.Model;
-import ai.alumnium.Provider;
 import ai.alumnium.driver.AppiumDriver;
 import ai.alumnium.tool.BaseTool;
 import com.microsoft.playwright.Browser;
@@ -124,7 +122,7 @@ public class BaseTest {
                 // unreachable: JUnit gave us the class already
               }
             });
-    Alumni.Options options = new Alumni.Options().withModel(new Model(Provider.ANTHROPIC, "claude-haiku-4-5-20251001")).withExtraTools(extraTools);
+    Alumni.Options options = new Alumni.Options().withExtraTools(extraTools);
 
     switch (DRIVER_TYPE) {
       case "playwright" -> {

--- a/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class DragAndDropTest extends BaseTest {
 
@@ -13,6 +14,9 @@ public class DragAndDropTest extends BaseTest {
 
   @Test
   void testDragAndDrop() {
+    assumeFalse(
+        IS_APPIUM,
+        "Example doesn't support drag and drop in mobile browsers");
     navigate(DRAG_AND_DROP_URL);
     Object data =
         al.get(

--- a/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
@@ -1,13 +1,13 @@
 package ai.alumnium.system;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import ai.alumnium.Alumni;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+@DisabledIfEnvironmentVariable(named = "ALUMNIUM_DRIVER", matches = "appium-ios")
 public class DragAndDropTest extends BaseTest {
 
   private static final String DRAG_AND_DROP_URL =
@@ -15,7 +15,6 @@ public class DragAndDropTest extends BaseTest {
 
   @Test
   void testDragAndDrop() {
-    assumeFalse(IS_APPIUM, "Example doesn't support drag and drop in mobile browsers");
     navigate(DRAG_AND_DROP_URL);
     Object data =
         al.get(

--- a/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/DragAndDropTest.java
@@ -1,11 +1,12 @@
 package ai.alumnium.system;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import ai.alumnium.Alumni;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class DragAndDropTest extends BaseTest {
 
@@ -14,9 +15,7 @@ public class DragAndDropTest extends BaseTest {
 
   @Test
   void testDragAndDrop() {
-    assumeFalse(
-        IS_APPIUM,
-        "Example doesn't support drag and drop in mobile browsers");
+    assumeFalse(IS_APPIUM, "Example doesn't support drag and drop in mobile browsers");
     navigate(DRAG_AND_DROP_URL);
     Object data =
         al.get(

--- a/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
@@ -1,12 +1,12 @@
 package ai.alumnium.system;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+@DisabledIfEnvironmentVariable(named = "ALUMNIUM_DRIVER", matches = "appium.*")
 public class FramesTest extends BaseTest {
 
   private static final String CROSS_ORIGIN_IFRAME_URL =
@@ -14,8 +14,6 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testNestedFrames() {
-    assumeFalse(
-        IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate("https://the-internet.herokuapp.com/nested_frames");
 
     al.act("click MIDDLE text");
@@ -25,8 +23,6 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testCrossOriginIframe() {
-    assumeFalse(
-        IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate(CROSS_ORIGIN_IFRAME_URL);
 
     al.check("button 'Main Page Button' is present");

--- a/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class FramesTest extends BaseTest {
 
@@ -12,6 +13,7 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testNestedFrames() {
+    assumeFalse(IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate("https://the-internet.herokuapp.com/nested_frames");
 
     al.act("click MIDDLE text");
@@ -21,6 +23,7 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testCrossOriginIframe() {
+    assumeFalse(IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate(CROSS_ORIGIN_IFRAME_URL);
 
     al.check("button 'Main Page Button' is present");

--- a/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
@@ -1,10 +1,11 @@
 package ai.alumnium.system;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class FramesTest extends BaseTest {
 
@@ -13,7 +14,8 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testNestedFrames() {
-    assumeFalse(IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
+    assumeFalse(
+        IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate("https://the-internet.herokuapp.com/nested_frames");
 
     al.act("click MIDDLE text");
@@ -23,7 +25,8 @@ public class FramesTest extends BaseTest {
 
   @Test
   void testCrossOriginIframe() {
-    assumeFalse(IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
+    assumeFalse(
+        IS_APPIUM, "Frames support is only implemented for Playwright and Selenium currently");
     navigate(CROSS_ORIGIN_IFRAME_URL);
 
     al.check("button 'Main Page Button' is present");

--- a/packages/java/src/test/java/ai/alumnium/system/SearchTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/SearchTest.java
@@ -1,18 +1,20 @@
 package ai.alumnium.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
+@DisabledIf("isHeadlessPlaywright")
 class SearchTest extends BaseTest {
+
+  static boolean isHeadlessPlaywright() {
+    return "playwright".equals(System.getenv("ALUMNIUM_DRIVER"))
+        && !"false".equalsIgnoreCase(System.getenv("ALUMNIUM_PLAYWRIGHT_HEADLESS"));
+  }
+
   @Test
   void searchTest() {
-    assumeFalse(
-        "playwright".equals(System.getenv("ALUMNIUM_DRIVER"))
-            && !"false".equalsIgnoreCase(System.getenv("ALUMNIUM_PLAYWRIGHT_HEADLESS")),
-        "Brave Search blocks headless browsers");
-
     navigate("https://search.brave.com");
     al.act("type 'selenium' into the search field, then press 'Enter'");
     al.check("page title contains selenium");

--- a/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class TabsTest extends BaseTest {
 
@@ -18,6 +19,9 @@ public class TabsTest extends BaseTest {
 
   @Test
   void testSwitchingTabs() {
+    assumeFalse(
+        IS_APPIUM,
+        "Appium doesn't support tab manipulation yet");
     navigate(MULTI_TAB_URL);
 
     al.act("click on 'Open New Tab' button");

--- a/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
@@ -1,12 +1,13 @@
 package ai.alumnium.system;
 
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
 import ai.alumnium.tool.SwitchToNextTabTool;
 import ai.alumnium.tool.SwitchToPreviousTabTool;
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class TabsTest extends BaseTest {
 
@@ -19,9 +20,7 @@ public class TabsTest extends BaseTest {
 
   @Test
   void testSwitchingTabs() {
-    assumeFalse(
-        IS_APPIUM,
-        "Appium doesn't support tab manipulation yet");
+    assumeFalse(IS_APPIUM, "Appium doesn't support tab manipulation yet");
     navigate(MULTI_TAB_URL);
 
     al.act("click on 'Open New Tab' button");

--- a/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
@@ -1,14 +1,14 @@
 package ai.alumnium.system;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-
 import ai.alumnium.tool.SwitchToNextTabTool;
 import ai.alumnium.tool.SwitchToPreviousTabTool;
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+@DisabledIfEnvironmentVariable(named = "ALUMNIUM_DRIVER", matches = "appium.*")
 public class TabsTest extends BaseTest {
 
   static {
@@ -20,7 +20,6 @@ public class TabsTest extends BaseTest {
 
   @Test
   void testSwitchingTabs() {
-    assumeFalse(IS_APPIUM, "Appium doesn't support tab manipulation yet");
     navigate(MULTI_TAB_URL);
 
     al.act("click on 'Open New Tab' button");

--- a/websites/docs/src/content/docs/docs/getting-started/installation.mdx
+++ b/websites/docs/src/content/docs/docs/getting-started/installation.mdx
@@ -19,6 +19,25 @@ dependencies {
 }
 ```
 
+Or, if you're using maven, add this to your pom.xml
+
+```xml title="pom.xml"
+<dependencies>
+  <dependency>
+    <groupId>ai.alumnium</groupId>
+    <artifactId>alumnium</artifactId>
+    <version>0.21.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>ai.alumnium</groupId>
+    <artifactId>alumnium-cli-darwin-arm64</artifactId>
+    <version>0.21.0</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>
+```
+
 Replace `alumnium-cli-darwin-arm64` with the artifact matching your platform, or add multiple artifacts if you need to support multiple platforms. The available CLI artifacts are:
 
 | OS      | Architecture | Artifact                     |


### PR DESCRIPTION
## Summary

  Adds Appium iOS and Android system test support to the Java package, bringing it to parity with the Python and
  TypeScript packages. This includes driver setup for both local and LambdaTest environments, mise tasks for running
  Appium tests, CI matrix entries, and assumeFalse guards on tests that are not supported on mobile browsers.

##  Motivation

  The Java package previously only supported Selenium and Playwright for system tests. iOS and Android coverage via
  Appium existed in Python and TypeScript but was missing from Java. This change closes that gap so all three packages
  have consistent test coverage across all supported drivers.

##  Type of Change

  - [x] New feature (non-breaking changes, test coverage, refactoring)

##  Code or UI Demos (if applicable)

  New mise tasks:
  mise //packages/java:test/system:appium-ios
  mise //packages/java:test/system:appium-android

  CI matrix (ci-java.yml) now includes:
  - driver: appium-ios
    model: azure_openai
  - driver: appium-android
    model: azure_openai

  Tests connect to LambdaTest when LT_USERNAME and LT_ACCESS_KEY are set, and fall back to a local Appium server
  (APPIUM_URL, defaulting to http://127.0.0.1:4723/) otherwise.

##  Checklist

  - [ ] I have read the Contributing Guidelines
  - [ ] I have added or updated relevant documentation
  - [x] I have written or updated necessary tests
  - [x] I have tested the changes locally
  - [x] The changes follow the project's coding style and structure
  - [x] I have not included any sensitive or credential-related information
  - [ ] I have ensured these changes maintain or improve accessibility (for UI changes)
  - [x] I have considered security implications of these changes

##  Additional Notes

  - DragAndDropTest scope was broadened from appium-ios only (matching Python) to IS_APPIUM (all Appium drivers) by the
  linter — can be reverted to iOS-only if preferred.
  - The Java BaseTest now passes all environment variables to the Gradle test process via environment System.getenv()
  inside testTask.configure, which is required for LambdaTest credentials to reach the test JVM.