### PR TITLE
fix(playwright): json loading on windows

### DIFF
--- a/packages/typescript/scripts/build.ts
+++ b/packages/typescript/scripts/build.ts
@@ -11,6 +11,7 @@ import { stringify as tomlStringify } from "smol-toml";
 import { z } from "zod";
 import { ALUMNIUM_VERSION } from "../src/package.ts";
 import {
+  PLAYWRIGHT_CORE_BROWSERS_JSON_ASSET_NAME,
   PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
   PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
   SELENIUM_ATOM_ASSET_PREFIX,
@@ -996,6 +997,11 @@ async function getStandaloneEmbeddedAssets(): Promise<
     {
       name: PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
       sourcePath: path.join(playwrightCorePkgDir, "package.json"),
+    },
+
+    {
+      name: PLAYWRIGHT_CORE_BROWSERS_JSON_ASSET_NAME,
+      sourcePath: path.join(playwrightCorePkgDir, "browsers.json"),
     },
   ];
 }

--- a/packages/typescript/src/standalone/embeddedAssetNames.ts
+++ b/packages/typescript/src/standalone/embeddedAssetNames.ts
@@ -3,6 +3,9 @@ export const SELENIUM_ATOM_ASSET_PREFIX = "selenium-atom-";
 export const PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME =
   "playwright-core-package.json";
 
+export const PLAYWRIGHT_CORE_BROWSERS_JSON_ASSET_NAME =
+  "playwright-core-browsers.json";
+
 export const PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME =
   "playwright-core-oopDownloadBrowserMain.cjs";
 

--- a/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
+++ b/packages/typescript/src/standalone/setupEmbeddedDependencies.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { isSingleFileExecutable } from "../bundle.ts";
 import {
+  PLAYWRIGHT_CORE_BROWSERS_JSON_ASSET_NAME,
   PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
   PLAYWRIGHT_CORE_PACKAGE_JSON_ASSET_NAME,
   SELENIUM_ATOM_ASSET_PREFIX,
@@ -33,6 +34,7 @@ const RUNTIME_SELENIUM_MANAGER_TARGETS = {
 
 interface ExtractedEmbeddedDependencies {
   playwrightPackageJsonPath: string;
+  playwrightBrowsersJsonPath: string;
   playwrightOopDownloadPath: string;
   seleniumAtomsDir: string;
   seleniumManagerPath: string | undefined;
@@ -85,6 +87,11 @@ async function extractEmbeddedDependencies(): Promise<ExtractedEmbeddedDependenc
     "playwright-core",
     "package.json",
   );
+  const playwrightBrowsersJsonPath = path.join(
+    extractedDir,
+    "playwright-core",
+    "browsers.json",
+  );
   const playwrightOopDownloadPath = path.join(
     extractedDir,
     "playwright-core",
@@ -119,6 +126,11 @@ async function extractEmbeddedDependencies(): Promise<ExtractedEmbeddedDependenc
     ),
     writeEmbeddedFile(
       filesByName,
+      PLAYWRIGHT_CORE_BROWSERS_JSON_ASSET_NAME,
+      playwrightBrowsersJsonPath,
+    ),
+    writeEmbeddedFile(
+      filesByName,
       PLAYWRIGHT_CORE_OOP_DOWNLOAD_ASSET_NAME,
       playwrightOopDownloadPath,
     ),
@@ -126,6 +138,7 @@ async function extractEmbeddedDependencies(): Promise<ExtractedEmbeddedDependenc
 
   return {
     playwrightPackageJsonPath,
+    playwrightBrowsersJsonPath,
     playwrightOopDownloadPath,
     seleniumAtomsDir,
     seleniumManagerPath,
@@ -180,9 +193,17 @@ function installResolveHook(paths: ExtractedEmbeddedDependencies) {
 
       if (
         request === "../../../package.json" ||
-        request.endsWith("playwright-core/package.json")
+        request.endsWith("playwright-core/package.json") ||
+        request.endsWith("playwright-core\\package.json")
       ) {
         return paths.playwrightPackageJsonPath;
+      }
+
+      if (
+        request.endsWith("playwright-core/browsers.json") ||
+        request.endsWith("playwright-core\\browsers.json")
+      ) {
+        return paths.playwrightBrowsersJsonPath;
       }
     }
 


### PR DESCRIPTION
Upgrade to 1.60 broke the interception of `package.json` loading on Windows. And we completely missed a new `browsers.json` file that was added in a new version of Playwright.