### PR TITLE
feat: expand commands in environment variables

### DIFF
--- a/packages/typescript/src/Env.test.ts
+++ b/packages/typescript/src/Env.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Env } from "./Env.ts";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  Env.reset();
+});
+
+describe("Env", () => {
+  it("applies the schema default when the variable is unset", () => {
+    vi.stubEnv("ALUMNIUM_CACHE", undefined);
+    expect(Env.ALUMNIUM_CACHE).toBe("filesystem");
+  });
+
+  it("reads a literal value", () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-literal");
+    expect(Env.OPENAI_API_KEY).toBe("sk-literal");
+  });
+
+  it("caches the value so it is only read once", () => {
+    vi.stubEnv("OPENAI_API_KEY", "sk-first");
+    expect(Env.OPENAI_API_KEY).toBe("sk-first");
+
+    vi.stubEnv("OPENAI_API_KEY", "sk-second");
+    expect(Env.OPENAI_API_KEY).toBe("sk-first");
+  });
+
+  it("throws on an invalid value", () => {
+    vi.stubEnv("ALUMNIUM_RETRIES", "not-a-number");
+    expect(() => Env.ALUMNIUM_RETRIES).toThrow();
+  });
+
+  describe("command expansion", () => {
+    it("expands a whole-value command substitution", () => {
+      vi.stubEnv("OPENAI_API_KEY", "$(echo hello)");
+      expect(Env.OPENAI_API_KEY).toBe("hello");
+    });
+
+    it("trims trailing newlines from command output", () => {
+      vi.stubEnv("OPENAI_API_KEY", "$(printf 'hello\\n\\n')");
+      expect(Env.OPENAI_API_KEY).toBe("hello");
+    });
+
+    it("does not expand inline substitution (whole-value only)", () => {
+      vi.stubEnv("OPENAI_API_KEY", "prefix $(echo x)");
+      expect(Env.OPENAI_API_KEY).toBe("prefix $(echo x)");
+    });
+
+    it("leaves literal values untouched", () => {
+      vi.stubEnv("OPENAI_API_KEY", "sk-literal");
+      expect(Env.OPENAI_API_KEY).toBe("sk-literal");
+    });
+
+    it("throws when the expansion command fails", () => {
+      vi.stubEnv("OPENAI_API_KEY", "$(exit 1)");
+      expect(() => Env.OPENAI_API_KEY).toThrow();
+    });
+  });
+});

--- a/packages/typescript/src/Env.ts
+++ b/packages/typescript/src/Env.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import ansi from "picocolors";
 import { canonize } from "smolcanon";
 import { xxh32Str } from "smolxxh/str";
@@ -197,6 +198,10 @@ export const Env = {
     return envVar("ALUMNIUM_EVAL_TRIAL_COUNT", z.coerce.number().default(25));
   },
 
+  get ANTHROPIC_API_KEY() {
+    return secretEnvVar("ANTHROPIC_API_KEY", z.string().optional());
+  },
+
   get AWS_ACCESS_KEY() {
     return secretEnvVar("AWS_ACCESS_KEY", z.string().optional());
   },
@@ -240,8 +245,24 @@ export const Env = {
     return secretEnvVar("AZURE_OPENAI_ENDPOINT", z.string().optional());
   },
 
+  get DEEPSEEK_API_KEY() {
+    return secretEnvVar("DEEPSEEK_API_KEY", z.string().optional());
+  },
+
+  get GOOGLE_API_KEY() {
+    return secretEnvVar("GOOGLE_API_KEY", z.string().optional());
+  },
+
+  get MISTRAL_API_KEY() {
+    return secretEnvVar("MISTRAL_API_KEY", z.string().optional());
+  },
+
   get OLLAMA_HOST() {
     return envVar("OLLAMA_HOST", z.string().optional());
+  },
+
+  get OPENAI_API_KEY() {
+    return secretEnvVar("OPENAI_API_KEY", z.string().optional());
   },
 
   get OPENAI_CUSTOM_URL() {
@@ -253,6 +274,10 @@ export const Env = {
       "OPENAI_DEFAULT_HEADERS",
       jsonString(z.record(z.string(), z.string())).optional(),
     );
+  },
+
+  get XAI_API_KEY() {
+    return secretEnvVar("XAI_API_KEY", z.string().optional());
   },
 
   get LT_USERNAME() {
@@ -308,7 +333,7 @@ function envVar<Type>(
 ): Type {
   if (!(name in cachedVars)) {
     // oxlint-disable-next-line no-process-env -- We need it to read env vars
-    const envVal = process.env[name];
+    const envVal = expandEnvCommand(name, process.env[name], isSecretVar);
     const parsedVar = Schema.safeParse(envVal);
 
     if (!parsedVar.success) {
@@ -344,4 +369,60 @@ function hashSecret(val: unknown): string {
 
 function maskedValue(val: unknown, isSecretVar: boolean | undefined): unknown {
   return val != null && isSecretVar ? maskString(String(val)) : val;
+}
+
+// NOTE: Matches a value that is *entirely* a command substitution, e.g.
+// `$(iap-auth)`. We intentionally don't support inline substitution or
+// backticks to keep the behavior predictable and the surface small.
+const COMMAND_SUBSTITUTION_RE = /^\$\((.+)\)$/s;
+const EXPANSION_TIMEOUT_MS = 30_000;
+
+/**
+ * Expand an environment variable value of the form `$(command)` by running the
+ * command and returning its stdout. Values that are not a whole-value command
+ * substitution (including `undefined`) are returned unchanged.
+ *
+ * On command failure, logs the error and throws so `Env.init()` marks the
+ * environment invalid and startup aborts.
+ */
+function expandEnvCommand(
+  name: string,
+  rawValue: string | undefined,
+  isSecretVar?: boolean,
+): string | undefined {
+  if (rawValue == null) return rawValue;
+
+  const match = rawValue.trim().match(COMMAND_SUBSTITUTION_RE);
+  if (!match?.[1]) return rawValue;
+
+  const command = match[1];
+
+  try {
+    const stdout = execSync(command, {
+      encoding: "utf8",
+      timeout: EXPANSION_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    // NOTE: Mirror shell command substitution, which strips trailing newlines.
+    return stdout.replace(/\n+$/, "");
+  } catch (error) {
+    const stderr = extractStderr(error);
+    const maskedCommand = isSecretVar ? maskString(command) : command;
+    const message = `Failed to expand environment variable ${name} command \`${maskedCommand}\`${
+      stderr ? `: ${stderr}` : ""
+    }`;
+
+    if (envLogger) envLogger.error(message);
+    else console.error(`${ansi.red("Error:")} ${message}`);
+
+    throw error;
+  }
+}
+
+function extractStderr(error: unknown): string {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const { stderr } = error as { stderr?: unknown };
+    if (stderr != null) return String(stderr).trim();
+  }
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/typescript/src/server/LlmFactory.ts
+++ b/packages/typescript/src/server/LlmFactory.ts
@@ -164,6 +164,7 @@ export class LlmFactory {
 
     return new ChatAnthropic({
       model: model.name,
+      ...apiKeyField(Env.ANTHROPIC_API_KEY),
       thinking: {
         type: "enabled",
         budget_tokens: 1024,
@@ -209,6 +210,7 @@ export class LlmFactory {
 
     const deepSeek = new ReasonableChatDeepSeek({
       model: model.name,
+      ...apiKeyField(Env.DEEPSEEK_API_KEY),
       temperature: 0,
       cache,
     });
@@ -222,12 +224,14 @@ export class LlmFactory {
     if (model.name.includes("gemini-2.0")) {
       return new ChatGoogle({
         model: model.name,
+        ...apiKeyField(Env.GOOGLE_API_KEY),
         temperature: 0,
         cache,
       });
     } else {
       return new ChatGoogle({
         model: model.name,
+        ...apiKeyField(Env.GOOGLE_API_KEY),
         temperature: 0,
         thinkingConfig: {
           thinkingLevel: "LOW",
@@ -243,6 +247,7 @@ export class LlmFactory {
 
     return new ChatOpenAI({
       model: model.name,
+      ...apiKeyField(Env.OPENAI_API_KEY),
       configuration: { baseURL: "https://models.github.ai/inference" },
       temperature: 0,
       cache,
@@ -254,6 +259,7 @@ export class LlmFactory {
 
     return new ChatMistralAI({
       model: model.name,
+      ...apiKeyField(Env.MISTRAL_API_KEY),
       temperature: 0,
       cache,
     });
@@ -282,6 +288,7 @@ export class LlmFactory {
 
     const fields: ChatOpenAIFields = {
       model: model.name,
+      ...apiKeyField(Env.OPENAI_API_KEY),
       configuration: {
         baseURL: Env.OPENAI_CUSTOM_URL,
         defaultHeaders: new Headers(Env.OPENAI_DEFAULT_HEADERS),
@@ -325,10 +332,15 @@ export class LlmFactory {
 
     return new ChatXAI({
       model: model.name,
+      ...apiKeyField(Env.XAI_API_KEY),
       temperature: 0,
       cache,
     });
   }
+}
+
+function apiKeyField(apiKey: string | undefined): { apiKey: string } | object {
+  return apiKey ? { apiKey } : {};
 }
 
 function logMaskedSecret(name: string, secret: string) {

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -17,6 +17,8 @@ Alumnium currently supports Appium with XCUITest driver for iOS automation and U
 
 The following environment variables can be used to control the behavior of Alumnium.
 
+Any environment variable listed below may be set to a command substitution of the form `$(command)`. On startup Alumnium runs `command`, trims trailing newlines from its output, and uses the result as the variable's value:
+
 ### `ALUMNIUM_CACHE`
 
 Sets the cache provider used by Alumnium. Supported values are:
@@ -73,6 +75,22 @@ The following workflow step enables debug logging in Alumnium when they are enab
 ```
 
 :::
+
+### `ALUMNIUM_LOG_DEBUG_EXTRA`
+
+Comma-separated list of extra debug payloads to include in logs. Use `all` to enable everything. Supported values include `env` (environment variables) and others. Default is empty.
+
+### `ALUMNIUM_PRUNE_LOGS`
+
+Set to `false` to keep existing log files instead of truncating them on startup. Default is `true`.
+
+### `ALUMNIUM_LOG_BUFFER_SIZE`
+
+Buffer size, in bytes, used when writing logs to a file. Default is `4096`.
+
+### `ALUMNIUM_LOG_FLUSH_INTERVAL`
+
+Interval in milliseconds between flushes when writing logs to a file. Default is `500`.
 
 ### `ALUMNIUM_TRACE`
 
@@ -151,6 +169,10 @@ Set to `false` to start Playwright in headed mode. Only used in the [MCP server]
 
 Timeout in milliseconds when waiting for a new tab to open after interacting with elements using Playwright driver. Increase when Alumnium fails to detect a new tab. Default is 200.
 
+### `ANTHROPIC_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `anthropic`.
+
 ### `AWS_ACCESS_KEY`
 
 AWS access key used when `ALUMNIUM_MODEL` is set to `aws_anthropic` or `aws_meta`.
@@ -191,13 +213,29 @@ JSON string of additional headers to send with Azure OpenAI requests (e.g. `{"x-
 
 Endpoint URL used when `ALUMNIUM_MODEL` is set to `azure_openai`.
 
+### `DEEPSEEK_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `deepseek`.
+
+### `GOOGLE_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `google`.
+
 ### `LANGCHAIN_CODEX_LITTERBOX_UPLOAD`
 
 Set to `true` to enable vision support for the `codex` provider by temporarily uploading screenshots to a third-party image host ([litterbox.catbox.moe][4]) before sending them to the model. Codex models only accept image URLs, so this is required for vision checks. Default is `false`.
 
+### `MISTRAL_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `mistralai`.
+
 ### `OLLAMA_HOST`
 
 Sets the URL for Ollama models if you host them externally on a server.
+
+### `OPENAI_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `openai` (or `github`, which authenticates with a GitHub personal access token via this variable).
 
 ### `OPENAI_CUSTOM_URL`
 
@@ -206,6 +244,10 @@ Sets the URL for OpenAI models if you access them via custom endpoint.
 ### `OPENAI_DEFAULT_HEADERS`
 
 JSON string of additional headers to send with OpenAI requests (e.g. `{"x-custom-header": "value"}`).
+
+### `XAI_API_KEY`
+
+API key used when `ALUMNIUM_MODEL` is set to `xai`.
 
 [1]: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging
 [2]: https://github.com/alumnium-hq/alumnium/issues/112

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -17,7 +17,7 @@ Alumnium currently supports Appium with XCUITest driver for iOS automation and U
 
 The following environment variables can be used to control the behavior of Alumnium.
 
-Any environment variable listed below may be set to a command substitution of the form `$(command)`. On startup Alumnium runs `command`, trims trailing newlines from its output, and uses the result as the variable's value:
+Any environment variable listed below may be set to a command substitution of the form `$(command)`. On startup Alumnium runs `command`, trims trailing newlines from its output, and uses the result as the variable's value.
 
 ### `ALUMNIUM_CACHE`
 


### PR DESCRIPTION
Adds support for command substitution in environment variables read by the TypeScript core: when a recognized variable is set to a whole-value `$(command)` (e.g. `OPENAI_API_KEY="$(get-token)`"), Alumnium now runs the command at startup and uses its trimmed stdout as the value, with failures logged (secrets masked) and treated as invalid config so startup aborts. 

Expansion is wired into Env's accessor so it applies to every known variable. Provider API keys (`ANTHROPIC_API_KEY, DEEPSEEK_API_KEY, GOOGLE_API_KEY, MISTRAL_API_KEY, OPENAI_API_KEY, XAI_API_KEY`) were added as `Env` getters and are now passed explicitly into the LangChain clients in LlmFactory so they flow through the same expansion path.