### PR TITLE
fix(java/selenium): harden numeric casts in getShadowChildNodes to av…

### DIFF
--- a/packages/java/build.gradle
+++ b/packages/java/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     // Testing
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
     testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.mockito:mockito-core:5.12.0"
     testImplementation "org.seleniumhq.selenium:selenium-java:${seleniumVersion}"
     testImplementation "com.microsoft.playwright:playwright:${playwrightVersion}"
     testImplementation "io.appium:java-client:${appiumVersion}"

--- a/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
@@ -621,8 +621,19 @@ public final class SeleniumDriver extends BaseDriver {
       for (Map<String, Object> node : axNodes) {
         node.put("_is_shadow_dom", true);
         if (node.get("backendDOMNodeId") == null) {
-          Long bid = nodeIdToBackendId.get((Long) node.get("nodeId"));
-          if (bid != null) node.put("backendDOMNodeId", bid);
+          Object rawNodeId = node.get("nodeId");
+          Long lookUpId = null;
+          if (rawNodeId instanceof Number n) lookUpId = n.longValue();
+          else if (rawNodeId != null) {
+            try {
+              lookUpId = Long.parseLong(rawNodeId.toString());
+            } catch (NumberFormatException ignored) {
+            }
+          }
+          if (lookUpId != null) {
+            Long bid = nodeIdToBackendId.get(lookUpId);
+            if (bid != null) node.put("backendDOMNodeId", bid);
+          }
         }
         nodes.add(node);
 

--- a/packages/java/src/test/java/ai/alumnium/unit/driver/SeleniumDriverShadowCastTest.java
+++ b/packages/java/src/test/java/ai/alumnium/unit/driver/SeleniumDriverShadowCastTest.java
@@ -1,0 +1,73 @@
+package ai.alumnium.unit.driver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import ai.alumnium.driver.SeleniumDriver;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chromium.HasCdp;
+
+/**
+ * Verifies that SeleniumDriver.getShadowChildNodes handles non-Long numeric nodeId values (e.g.,
+ * Integer) returned by CDP and correctly looks up backendDOMNodeId.
+ */
+public class SeleniumDriverShadowCastTest {
+
+  @Test
+  void handlesIntegerNodeIdFromCdp() throws Exception {
+    // Create a mock WebDriver that also implements HasCdp
+    WebDriver webDriver = mock(WebDriver.class, withSettings().extraInterfaces(HasCdp.class));
+    HasCdp cdp = (HasCdp) webDriver;
+
+    // Stub CDP calls made in constructor and method under test
+    when(cdp.executeCdpCommand(eq("Target.setAutoAttach"), any(Map.class)))
+        .thenReturn(Map.of());
+
+    // Accessibility.queryAXTree will return nodes where nodeId is an Integer
+    Map<String, Object> axNode = new HashMap<>();
+    axNode.put("nodeId", Integer.valueOf(42)); // intentionally Integer, not Long
+    axNode.put("backendDOMNodeId", null);
+    axNode.put("childIds", new ArrayList<>()); // no children
+
+    Map<String, Object> queryAxTreeResp = new HashMap<>();
+    queryAxTreeResp.put("nodes", List.of(axNode));
+
+    when(cdp.executeCdpCommand(eq("Accessibility.queryAXTree"), any(Map.class)))
+        .thenReturn(queryAxTreeResp);
+
+    // Construct driver
+    SeleniumDriver driver = new SeleniumDriver(webDriver);
+
+    // Prepare inputs to private getShadowChildNodes(Long, Set<String>, Map<Long, Long>)
+    Long rootNodeId = 42L;
+    Set<String> processed = new HashSet<>();
+    Map<Long, Long> nodeIdToBackendId = new HashMap<>();
+    nodeIdToBackendId.put(42L, 999L);
+
+    // Invoke private method via reflection
+    Method m =
+        SeleniumDriver.class.getDeclaredMethod(
+            "getShadowChildNodes", Long.class, Set.class, Map.class);
+    m.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Map<String, Object>> out =
+        (List<Map<String, Object>>) m.invoke(driver, rootNodeId, processed, nodeIdToBackendId);
+
+    assertThat(out).hasSize(1);
+    Map<String, Object> returned = out.get(0);
+    assertThat(returned.get("backendDOMNodeId")).isEqualTo(999L);
+    assertThat(returned.get("_is_shadow_dom")).isEqualTo(true);
+  }
+}

--- a/packages/java/src/test/java/ai/alumnium/unit/driver/SeleniumDriverShadowCastTest.java
+++ b/packages/java/src/test/java/ai/alumnium/unit/driver/SeleniumDriverShadowCastTest.java
@@ -32,8 +32,7 @@ public class SeleniumDriverShadowCastTest {
     HasCdp cdp = (HasCdp) webDriver;
 
     // Stub CDP calls made in constructor and method under test
-    when(cdp.executeCdpCommand(eq("Target.setAutoAttach"), any(Map.class)))
-        .thenReturn(Map.of());
+    when(cdp.executeCdpCommand(eq("Target.setAutoAttach"), any(Map.class))).thenReturn(Map.of());
 
     // Accessibility.queryAXTree will return nodes where nodeId is an Integer
     Map<String, Object> axNode = new HashMap<>();


### PR DESCRIPTION
# fix(java/selenium): harden numeric casts in getShadowChildNodes to avoid CCE

## Summary
Prevents ClassCastException in Selenium shadow-DOM traversal when CDP JSON returns mixed numeric types (Integer/Long) for node IDs. The code previously used a direct `(Long)` cast, which can fail depending on the deserializer/runtime. We now coerce via `Number.longValue()` with a safe string fallback.

## Motivation
- CDP payloads for `Accessibility.queryAXTree` and `DOM.getFlattenedDocument` can contain `nodeId` as either Integer or Long.
- Direct casts like `(Long) node.get("nodeId")` may throw `ClassCastException`.
- This causes flakiness during shadow DOM traversal, making element finding unreliable.

## What changed
- In [packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java:0:0-0:0):
  - In [getShadowChildNodes(...)](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/SeleniumDriver.ts:714:2-760:3), replaced:
    - [nodeIdToBackendId.get((Long) node.get("nodeId"))](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:155:2-158:3)
  - With robust extraction:
    - If `nodeId` is a `Number`, use `n.longValue()`
    - Else, attempt `Long.parseLong(raw.toString())`
    - Only perform lookup when a valid long ID is obtained

No behavior change beyond eliminating the potential `ClassCastException`.

## Acceptance criteria
- No `ClassCastException` when CDP returns `nodeId` as `Integer` in [getShadowChildNodes](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/SeleniumDriver.ts:714:2-760:3).
- All Java unit tests pass.

## Scope
- Files touched:
  - [packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java:0:0-0:0) (targeted edit in [getShadowChildNodes](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/SeleniumDriver.ts:714:2-760:3))