### PR TITLE
feat: expose userAgent playwright driver option

### DIFF
--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -39,6 +39,7 @@ export namespace McpDriver {
     headless?: boolean;
     permissions?: string[];
     profileDir?: string;
+    userAgent?: string;
   }
 
   export interface SeleniumCdpConnection {
@@ -78,6 +79,7 @@ export async function createPlaywrightDriver(
     headers = {},
     permissions,
     profileDir,
+    userAgent,
   } = driverOptions;
 
   logger.info(
@@ -98,6 +100,7 @@ export async function createPlaywrightDriver(
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
+      ...(userAgent ? { userAgent } : {}),
     });
   } else {
     const browser = await chromium.launch({
@@ -107,6 +110,7 @@ export async function createPlaywrightDriver(
     context = await browser.newContext({
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
+      ...(userAgent ? { userAgent } : {}),
     });
   }
 

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -59,7 +59,8 @@ export const startMcpTool = McpTool.define("start", {
             - "newTabTimeout" (number, default 200) — ms to wait for new tab detection, Playwright only;
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
-            - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal".
+            - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
+            - "userAgent" (string) — custom User-Agent header sent with every request, Playwright only.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
         `
@@ -171,6 +172,9 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["executablePath"] === "string" && {
         executablePath: alumniumOptions["executablePath"],
       }),
+      ...(typeof alumniumOptions["userAgent"] === "string" && {
+        userAgent: alumniumOptions["userAgent"],
+      }),
     };
 
     const alumniumOptionsNonDriverKeys = new Set([
@@ -183,6 +187,7 @@ export const startMcpTool = McpTool.define("start", {
       "headless",
       "permissions",
       "planner",
+      "userAgent",
     ]);
     const driverSettings: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(alumniumOptions)) {

--- a/websites/docs/src/content/docs/docs/guides/mcp.mdx
+++ b/websites/docs/src/content/docs/docs/guides/mcp.mdx
@@ -227,6 +227,7 @@ Pass `alumnium:options` in capabilities to configure Alumnium and driver behavio
 | `permissions`             | Browser permissions to grant (e.g. `["geolocation"]`). Playwright only.                                                                                            |
 | `planner`                 | Enable or disable the planning step in `do()`. Default is `true`.                                                                                                  |
 | `profile`                 | Name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in `~/.alumnium/profiles/{name}`. Selenium and Playwright only. |
+| `userAgent`               | Custom User-Agent string sent with every request. Playwright only.                                                                                                 |
 
 #### `appium:settings`
 


### PR DESCRIPTION
## Summary

This let's users configure the user agent with which alumnium will start the playwright browser. Playwright already supports a `userAgent` option, so we just need to expose it in alumnium. Though playwright doesn't allow to set `userAgent` in `extraHTTPHeaders`, so we can't just pass it as a header in alumnium.

## Motivation

Some sites will look at the user agent header and not render the whole site if for example a headless browser is used. Setting the user agent to a non-headless browser is a decent workaround to minimizing the differences when testing a site headless vs headed.

## Type of Change

Mark the relevant options.

- [ ] Bug fix
- [x] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)


## Checklist

Please verify the following before submitting:

- [x] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [x] I have added or updated relevant documentation
- [x] I have written or updated necessary tests
- [x] I have tested the changes locally
- [x] The changes follow the project's coding style and structure
- [x] I have not included any sensitive or credential-related information
- [x] I have ensured these changes maintain or improve accessibility (for UI changes)
- [x] I have considered security implications of these changes

