### PR TITLE
fix(model): keep slashes in model name when parsing ALUMNIUM_MODEL

### DIFF
--- a/packages/typescript/src/Model.test.ts
+++ b/packages/typescript/src/Model.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Model } from "./Model.ts";
+
+describe("Model.parse", () => {
+  it("uses the provider's default model when only a provider is given", () => {
+    expect(Model.parse("openai")).toEqual({
+      provider: "openai",
+      name: "gpt-5-nano-2025-08-07",
+    });
+  });
+
+  it("parses a single-segment model name", () => {
+    expect(Model.parse("openai/gpt-5")).toEqual({
+      provider: "openai",
+      name: "gpt-5",
+    });
+  });
+
+  it("keeps slashes in the model name (e.g. OpenRouter/Fireworks ids)", () => {
+    expect(Model.parse("openai/xiaomi/mimo-v2.5")).toEqual({
+      provider: "openai",
+      name: "xiaomi/mimo-v2.5",
+    });
+  });
+
+  it("throws on an empty string", () => {
+    expect(() => Model.parse("")).toThrow();
+  });
+
+  it("throws on an unknown provider", () => {
+    expect(() => Model.parse("notaprovider/model")).toThrow();
+  });
+});
+
+describe("Model.toString", () => {
+  it("round-trips a model id whose name contains slashes", () => {
+    const model = Model.parse("openai/xiaomi/mimo-v2.5");
+    expect(Model.toString(model)).toBe("openai/xiaomi/mimo-v2.5");
+    expect(Model.parse(Model.toString(model))).toEqual(model);
+  });
+});

--- a/packages/typescript/src/Model.ts
+++ b/packages/typescript/src/Model.ts
@@ -73,7 +73,14 @@ export const Model = {
   },
 
   parse(modelStr: string): Model {
-    const [provider, name] = modelStr.split("/");
+    // Split on the first "/" only: the provider is a single segment, but the
+    // model name may itself contain slashes (e.g. OpenRouter/Fireworks ids like
+    // "openai/xiaomi/mimo-v2.5"). A plain split("/") would drop everything after
+    // the second segment and send a truncated model id to the provider.
+    const slashIndex = modelStr.indexOf("/");
+    const provider =
+      slashIndex === -1 ? modelStr : modelStr.slice(0, slashIndex);
+    const name = slashIndex === -1 ? undefined : modelStr.slice(slashIndex + 1);
     if (!provider) throw new Error(`Invalid model string: ${modelStr}`);
     return this.new(provider, name);
   },


### PR DESCRIPTION
## Problem

`Model.parse` truncates any model name that contains a `/`:

```ts
const [provider, name] = modelStr.split("/");
```

`"openai/xiaomi/mimo-v2.5".split("/")` → `["openai", "xiaomi", "mimo-v2.5"]`, and destructuring keeps only the first two — so `name` becomes `"xiaomi"` and `/mimo-v2.5` is silently dropped.

This makes OpenAI-compatible providers reached via `OPENAI_CUSTOM_URL` unusable whenever their model ids contain a slash — which is the norm for OpenRouter (`xiaomi/mimo-v2.5`, `minimax/minimax-m3`, …) and Fireworks. The truncated id is sent upstream and rejected:

```
400 xiaomi is not a valid model ID
```

(`ALUMNIUM_MODEL`'s env validation already accepts these — `z.templateLiteral([Model.Provider, "/", z.string()])` in `Env.ts` — so only `parse` was dropping the tail.)

## Fix

Split on the first `/` only: the provider is the single leading segment, the remainder is the model name (which may contain further slashes). Behaviour preserved:

- bare provider (`openai`) → provider default model
- single segment (`openai/gpt-5`) → unchanged
- empty string still throws

## Tests

Adds `Model.test.ts` (there was no existing one) covering bare-provider defaulting, single-segment, the multi-slash regression, empty-string + unknown-provider errors, and a `toString` round-trip. Unit tests, lint, format-check and `tsc` all pass.

Verified end-to-end: with this change, `ALUMNIUM_MODEL=openai/xiaomi/mimo-v2.5` + `OPENAI_CUSTOM_URL=https://openrouter.ai/api/v1` starts the driver and reaches the model — the `400` is gone.

> Note: full OpenRouter usage then surfaces two further, unrelated response-shape issues (the cache schema expects `response_metadata.user` to be `null` rather than `undefined`; and a structured-output extraction path assumes a defined value). Those are out of scope for this parsing fix — happy to open a separate PR/issue if that path is of interest.
