### PR TITLE
Java: Enforce required model in /v1/sessions (align with TS API)

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/client/HttpClient.java
+++ b/packages/java/src/main/java/ai/alumnium/client/HttpClient.java
@@ -94,7 +94,16 @@ public final class HttpClient implements AutoCloseable {
         excludeAttributes == null ? List.of() : List.copyOf(excludeAttributes));
 
     JsonNode resp = postJson("/v1/sessions", body, Duration.ofSeconds(30));
-    this.model = Model.fromString(resp.path("model").asText(null));
+    String modelStr = resp.path("model").asText(null);
+    if (modelStr == null || modelStr.isBlank()) {
+      throw new IllegalStateException("Server '/v1/sessions' response missing required 'model'");
+    }
+    Model parsedModel = Model.fromString(modelStr);
+    if (parsedModel == null) {
+      throw new IllegalStateException(
+          "Invalid 'model' value '" + modelStr + "' in /v1/sessions response");
+    }
+    this.model = parsedModel;
     sessionId.set(resp.path("session_id").asText(null));
   }
 

--- a/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java
+++ b/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java
@@ -1,0 +1,120 @@
+package ai.alumnium.unit.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ai.alumnium.Model;
+import ai.alumnium.client.HttpClient;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests that HttpClient enforces presence of 'model' in /v1/sessions response. */
+public class HttpClientSessionModelTest {
+
+  private HttpServer server;
+  private String baseUrl;
+
+  @BeforeEach
+  void startServer() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.start();
+    baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+  }
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void constructsWhenModelPresent() {
+    // Arrange: stub POST /v1/sessions with model and session_id
+    String sessionId = "abc123";
+    server.createContext(
+        "/v1/sessions",
+        new JsonHandler(
+            200,
+            '{'
+                + "\"session_id\":\""
+                + sessionId
+                + "\","
+                + "\"model\":\"openai/gpt-5-nano-2025-08-07\","
+                + "\"platform\":\"chromium\""
+                + '}'));
+    server.createContext("/v1/sessions/" + sessionId, new EmptyHandler(204));
+
+    // Act
+    HttpClient client =
+        new HttpClient(baseUrl, null, "chromium", List.of(), false, (Set<String>) null);
+
+    // Assert
+    Model m = client.model();
+    assertThat(m).isNotNull();
+    assertThat(m.provider().value()).isEqualTo("openai");
+    assertThat(m.name()).isEqualTo("gpt-5-nano-2025-08-07");
+
+    // Cleanup
+    client.close();
+  }
+
+  @Test
+  void throwsWhenModelMissing() {
+    // Arrange: stub POST /v1/sessions missing 'model'
+    server.createContext(
+        "/v1/sessions",
+        new JsonHandler(
+            200, '{' + "\"session_id\":\"missing-model\"," + "\"platform\":\"chromium\"" + '}'));
+
+    // Act + Assert
+    assertThatThrownBy(
+            () -> new HttpClient(baseUrl, null, "chromium", List.of(), false, (Set<String>) null))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("missing required 'model'");
+  }
+
+  private static class JsonHandler implements HttpHandler {
+    private final int status;
+    private final String body;
+
+    JsonHandler(int status, String body) {
+      this.status = status;
+      this.body = body;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+      byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(status, bytes.length);
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(bytes);
+      }
+    }
+  }
+
+  private static class EmptyHandler implements HttpHandler {
+    private final int status;
+
+    EmptyHandler(int status) {
+      this.status = status;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+      exchange.sendResponseHeaders(status, -1);
+      exchange.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Aligns the Java client with the TypeScript API contract defined in [ApiModels.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/clients/ApiModels.ts:0:0-0:0), where [SessionResponse.model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3) is a required string. The Java [HttpClient](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/client/HttpClient.java:36:0-492:1) now validates that `/v1/sessions` returns a non-empty [model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3) field and fails fast with a clear error if the server violates the contract.

## Changes
- **HttpClient.java**: Added validation in the constructor to ensure `/v1/sessions` response includes a non-empty [model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3). Throws `IllegalStateException` with a clear message if missing or invalid.
- **Alumni.java**: No changes needed—logging remains unchanged since [model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3) is guaranteed after successful validation.
- **Tests**: Added [HttpClientSessionModelTest](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java:21:0-117:1) using JDK `HttpServer` to stub `/v1/sessions` responses:
  - [constructsWhenModelPresent](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java:40:2-65:3): Verifies successful construction when [model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3) is present.
  - [throwsWhenModelMissing](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java:67:2-82:3): Verifies constructor throws when [model](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/Alumni.java:107:2-109:3) is missing.

## Motivation
 `/v1/sessions` must always return a model name (see `packages/typescript/src/clients/ApiModels.ts#L24`). This change enforces that contract in the Java client, preventing subtle bugs if a non-compliant server is used.

## Testing
- Unit tests: [HttpClientSessionModelTest](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/test/java/ai/alumnium/unit/client/HttpClientSessionModelTest.java:21:0-117:1)