### PR TITLE
fix: santize a11y tree before parsing

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -30,10 +30,6 @@ MISE_EXPERIMENTAL = true # Enable monorepo root support
 OPENCODE_CONFIG_DIR = "./.agents"
 FORCE_COLOR = "1" # Force colors, i.e., for `bun --filter test`
 
-# Default model envs
-ALUMNIUM_MODEL = "${ALUMNIUM_MODEL:-azure_openai}"
-AZURE_OPENAI_API_VERSION = "2025-03-01-preview"
-
 # Default tracing envs. To enable set ALUMNIUM_TRACE=true.
 OTEL_SERVICE_NAME = "alumnium"
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318"

--- a/packages/typescript/src/Xml.test.ts
+++ b/packages/typescript/src/Xml.test.ts
@@ -1,0 +1,70 @@
+import { Element, Text } from "domhandler";
+import { describe, expect, it } from "vitest";
+import { Xml } from "./Xml.ts";
+
+function el(
+  tag: string,
+  attrs: Record<string, string>,
+  children: Xml.AnyElement[] = [],
+): Element {
+  const e = new Element(tag, attrs);
+  e.children = children as any;
+  return e;
+}
+
+function text(data: string): Text {
+  return new Text(data);
+}
+
+describe("Xml.format", () => {
+  it("preserves unicode text content without encoding", () => {
+    const xml = Xml.format([el("root", {}, [text("1701–1870")])]);
+    expect(xml).toContain("1701–1870");
+    expect(xml).not.toContain("&#x2013;");
+  });
+
+  it("escapes < and & in text nodes", () => {
+    const xml = Xml.format([el("root", {}, [text("<< Back & done")])]);
+    expect(xml).toContain("&lt;&lt; Back &amp; done");
+  });
+
+  it("escapes control characters in attribute values", () => {
+    const xml = Xml.format([el("root", { name: "hello\nworld" })]);
+    expect(xml).toContain('name="hello&#xA;world"');
+    expect(xml).not.toContain("hello\nworld");
+  });
+
+  it("escapes < and & in attribute values", () => {
+    const xml = Xml.format([el("root", { label: "a < b & c" })]);
+    expect(xml).toContain('label="a &lt; b &amp; c"');
+  });
+
+  it("escapes double-quotes in attribute values", () => {
+    const xml = Xml.format([el("root", { name: 'say "hi"' })]);
+    expect(xml).toContain('name="say &quot;hi&quot;"');
+  });
+
+  it("does not escape apostrophes in text nodes", () => {
+    const xml = Xml.format([el("root", {}, [text("We're happy")])]);
+    expect(xml).toContain("We're happy");
+    expect(xml).not.toContain("&apos;");
+  });
+
+  it("produces parseable XML when text contains angle brackets", () => {
+    const xml = Xml.format([el("root", {}, [text("<< Back")])]);
+    expect(() => Xml.parseRootChildren(xml)).not.toThrow();
+  });
+
+  it("produces parseable XML when attribute contains a newline", () => {
+    const xml = Xml.format([el("root", { name: "line1\nline2" })]);
+    expect(() => Xml.parseRootChildren(xml)).not.toThrow();
+  });
+
+  it("formats nested elements", () => {
+    const xml = Xml.format([
+      el("root", { id: "1" }, [el("button", { name: "OK" })]),
+    ]);
+    expect(xml).toContain('<root id="1">');
+    expect(xml).toContain('<button name="OK"/>');
+  });
+});

--- a/packages/typescript/src/Xml.ts
+++ b/packages/typescript/src/Xml.ts
@@ -57,19 +57,18 @@ export abstract class Xml {
   static format(els: Xml.AnyElement[]): string {
     let xml = "";
     for (const element of els) {
-      xml += xmlFormat(
-        render(element, {
-          xmlMode: true,
-          encodeEntities: false, // Skip encoding unicode text content, e.g., `1701–1870` -> `1701&#x2013;1870`.
-          emptyAttrs: true, // Preserve empty attributes as-is, e.g., `value=""`.
-          selfClosingTags: true,
-        }),
-        {
-          indentation: "  ",
-          forceSelfClosingEmptyTag: true,
-          lineSeparator: "\n",
-        },
-      );
+      Xml.#sanitizeElement(element);
+      const rendered = render(element, {
+        xmlMode: true,
+        encodeEntities: false, // Skip encoding unicode text content, e.g., `1701–1870` -> `1701&#x2013;1870`.
+        emptyAttrs: true, // Preserve empty attributes as-is, e.g., `value=""`.
+        selfClosingTags: true,
+      });
+      xml += xmlFormat(rendered, {
+        indentation: "  ",
+        forceSelfClosingEmptyTag: true,
+        lineSeparator: "\n",
+      });
     }
     return xml;
   }
@@ -93,5 +92,38 @@ export abstract class Xml {
       return node;
     }
     return null;
+  }
+
+  static #sanitizeElement(node: Xml.AnyElement): void {
+    if (isText(node)) {
+      node.data = Xml.#sanitizeText(node.data);
+    } else if (isTag(node)) {
+      for (const [k, v] of Object.entries(node.attribs)) {
+        node.attribs[k] = Xml.#sanitizeAttr(v);
+      }
+      for (const child of node.children) {
+        if (isText(child) || isTag(child)) Xml.#sanitizeElement(child);
+      }
+    }
+  }
+
+  // In text nodes only <, > and & must be escaped.
+  static #sanitizeText(s: string): string {
+    return s.replace(/[<>&\x00-\x08\x0B\x0C\x0E-\x1F]/g, (c) => {
+      if (c === "<") return "&lt;";
+      if (c === ">") return "&gt;";
+      if (c === "&") return "&amp;";
+      return `&#x${c.charCodeAt(0).toString(16).toUpperCase()};`;
+    });
+  }
+
+  // In double-quoted attribute values <, &, " and control chars must be escaped.
+  static #sanitizeAttr(s: string): string {
+    return s.replace(/[<>&"\x00-\x08\x0B\x0C\x0E-\x1F\n\r\t]/g, (c) => {
+      if (c === "<") return "&lt;";
+      if (c === "&") return "&amp;";
+      if (c === '"') return "&quot;";
+      return `&#x${c.charCodeAt(0).toString(16).toUpperCase()};`;
+    });
   }
 }


### PR DESCRIPTION
Prior to the fix, XML parsing would fail if accessibility tree contains `\n` in attribute value or `<>` in node text.