### PR TITLE
fix(cache): don't response-cache the actor's action selection

### DIFF
--- a/packages/typescript/src/server/cache/ResponseCache.test.ts
+++ b/packages/typescript/src/server/cache/ResponseCache.test.ts
@@ -96,6 +96,31 @@ describe("ResponseCache", () => {
     const result = await cache.lookup(prompt1, llmKey);
     expect(result).toBeNull();
   });
+
+  it("does not cache actor action selection so retries re-sample", async () => {
+    const { sessionContext, llmContext, cacheStore, prompt1, llmKey } =
+      await setup();
+    const cache = new ResponseCache(sessionContext, cacheStore, llmContext);
+
+    // Re-key prompt1 with ACTOR metadata (the action-selecting agent).
+    llmContext.clearPromptsMeta([prompt1]);
+    llmContext.assignPromptsMeta([prompt1], {
+      kind: "actor",
+      goal: "fill the field" as never,
+      step: "type into the field" as never,
+      treeXml: "<xml></xml>",
+    });
+
+    const generations = createGenerations("an action");
+    await cache.update(prompt1, llmKey, generations);
+
+    // Actor generations are intentionally NOT frozen: a stochastic model
+    // (e.g. gpt-5-nano, unable to run at temperature 0) would otherwise have a
+    // single wrong/no-op draw replayed on every retry until the tree changes.
+    // Skipping the cache here makes each actor invocation re-sample.
+    const result = await cache.lookup(prompt1, llmKey);
+    expect(result).toBeNull();
+  });
 });
 
 async function setup() {

--- a/packages/typescript/src/server/cache/ResponseCache.ts
+++ b/packages/typescript/src/server/cache/ResponseCache.ts
@@ -153,6 +153,28 @@ export class ResponseCache extends ServerCache {
         return;
       }
 
+      // Never freeze the actor's stochastic action selection. The actor picks a
+      // mutating action (click/type/execute-javascript/...) from a model that
+      // may be unable to run at temperature 0 (e.g. gpt-5-nano, whose
+      // temperature parameter is rejected, so it samples). The response cache
+      // keys on the exact (prompt = goal + step + accessibility tree), so a
+      // single bad sample - a no-op, a ClickTool where TypeTool was needed, or
+      // a script with mangled quotes/newlines - gets frozen for that page state
+      // and replayed on every retry. The action then never succeeds until the
+      // tree changes (form reload -> new element ids busts the key), which is
+      // the only known workaround. Skipping the actor here makes each actor
+      // invocation re-sample, so a retry can escape a bad draw. Read agents
+      // (planner/locator/area/retriever) still cache normally; the per-element
+      // ElementsCache is a separate layer and is unaffected.
+      if (agentMeta.kind === "actor") {
+        span.event("cache.update.skip", {
+          ...this.#spanAttrs(),
+          "agent.kind": agentMeta.kind,
+          "cache.update.skip.reason": "actor_no_freeze",
+        });
+        return;
+      }
+
       const { requestHash } = this.#initiate(agentMeta, prompt, llmKey);
 
       const storedGenerations = generations.map(Lchain.toStored);


### PR DESCRIPTION
## Problem

The actor agent selects a *mutating* action (click / type / execute-javascript / …) per step. With models that can't run at temperature 0 — notably `gpt-5-nano` (the OpenAI default for the MCP server), whose `temperature` parameter is rejected so it **samples** — the actor occasionally emits a wrong tool (a `ClickTool` where a `TypeTool` was needed), a no-op (no tool call at all), or a faithful-but-corrupted argument (mangled quotes, a dropped `\n`).

`ResponseCache` keys the LLM generation on the exact prompt = (goal + step + accessibility tree, element ids included). So a single bad sample is **written to cache and replayed verbatim on every retry** of the same (goal, step, tree). The action then *never* succeeds on retry — the only escape is changing the prompt, i.e. reloading the page so the element ids change and the cache key no longer matches. This turns a *rare* bad draw into a *permanent* stuck state and makes "just retry" useless.

## Fix

Skip caching the **actor**'s action selection in `ResponseCache.update` (`agentMeta.kind === "actor"`), so each actor invocation re-samples and a retry can escape a bad draw. Read agents (planner / locator / area / retriever) still cache normally; the separate per-element `ElementsCache` layer is unaffected.

## Verification

Against a real, large, already-populated accessibility tree (a multiline textarea on a busy form):

- **Pre-fix:** 8 identical actor invocations → all 8 replayed one frozen no-op draw; only the first was a real API call, the other 7 were instant cache hits (~6 s total). This is the "retries don't work" experience.
- **Post-fix:** the same 8 invocations re-sample → a mix incl. the correct action, recovering by the 2nd invocation (8 real API calls, ~65 s). The wall-clock difference (1 frozen-and-replayed call vs 8 fresh calls) independently confirms the mechanism.

Adds a `ResponseCache` regression test asserting actor-kind generations are not written to cache. `vitest run --project unit` green.

## Note

This is the load-bearing half of a two-part issue. The other half is the actor's per-call mis-selection rate itself (raising `reasoning.effort` and prompt / tool-description hardening were both measured *ineffective* on the dominant populated-field no-op). The cache fix is what makes the failure retry-recoverable rather than permanent.
