### PR TITLE
feat(playwright): OOPIF frames support

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public final class PlaywrightDriver extends BaseDriver {
   private Page page;
   private CDPSession client;
   private final List<Page> pages = new ArrayList<>();
+  private final Set<Frame> oopifFrames = new HashSet<>();
   public boolean autoswitchToNewTab = true;
   public boolean fullPageScreenshot = Config.FULL_PAGE_SCREENSHOT;
   public final Set<Class<? extends BaseTool>> supportedTools =
@@ -60,9 +62,8 @@ public final class PlaywrightDriver extends BaseDriver {
 
   public PlaywrightDriver(Page page) {
     this.page = page;
-    this.client = page.context().newCDPSession(page);
     setupPageTracking(page);
-    enableTargetAutoAttach();
+    initCDPSession();
   }
 
   @Override
@@ -84,38 +85,31 @@ public final class PlaywrightDriver extends BaseDriver {
     Map<String, Object> frameTree = (Map<String, Object>) frameTreeResp.get("frameTree");
     List<String> frameIds = collectFrameIds(frameTree);
     String mainFrameId = frameIdOf(frameTree);
-    LOG.debug("Found {} frames", frameIds.size());
 
-    Map<String, Integer> frameToIframeMap = new HashMap<>();
-    buildFrameHierarchy(frameTree, mainFrameId, frameToIframeMap);
+    Map<String, Frame> frameIdToFrame = buildPlaywrightFrameMap(frameTreeResp);
+    List<String> oopifFrameIds =
+        frameIdToFrame.entrySet().stream()
+            .filter(e -> oopifFrames.contains(e.getValue()))
+            .map(Map.Entry::getKey)
+            .toList();
+    LOG.debug("Found {} same-process frames, {} OOPIFs", frameIds.size(), oopifFrameIds.size());
 
-    Map<String, Frame> frameIdToFrame = new HashMap<>();
-    for (Frame f : page.frames()) {
-      String cdpFrameId = findCdpFrameIdByUrl(frameTree, f.url());
-      if (cdpFrameId != null) {
-        frameIdToFrame.put(cdpFrameId, f);
-      }
-    }
+    Map<String, Integer> frameToIframeMap =
+        buildFrameOwnerMap(frameTree, mainFrameId, oopifFrameIds);
 
     List<Map<String, Object>> allNodes = new ArrayList<>();
+    int frameIndex = 0;
+
     for (String frameId : frameIds) {
-      try {
-        Map<String, Object> resp =
-            sendCdp("Accessibility.getFullAXTree", Map.of("frameId", frameId));
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> nodes =
-            (List<Map<String, Object>>) resp.getOrDefault("nodes", List.of());
-        Frame pwFrame = frameIdToFrame.getOrDefault(frameId, page.mainFrame());
-        for (Map<String, Object> node : nodes) {
-          node.put("_frame", pwFrame);
-          if (node.get("parentId") == null && frameToIframeMap.containsKey(frameId)) {
-            node.put("_parent_iframe_backend_node_id", frameToIframeMap.get(frameId));
-          }
-          allNodes.add(node);
-        }
-      } catch (RuntimeException e) {
-        LOG.debug("Frame {} failed", frameId, e);
-      }
+      Frame pwFrame = frameIdToFrame.getOrDefault(frameId, page.mainFrame());
+      List<Map<String, Object>> nodes = getFrameNodes(frameId);
+      mergeFrameNodes(nodes, frameId, frameToIframeMap, pwFrame, frameIndex++, allNodes);
+    }
+
+    for (String oopifFrameId : oopifFrameIds) {
+      Frame pwFrame = frameIdToFrame.get(oopifFrameId);
+      List<Map<String, Object>> nodes = getOopifNodes(oopifFrameId, pwFrame);
+      mergeFrameNodes(nodes, oopifFrameId, frameToIframeMap, pwFrame, frameIndex++, allNodes);
     }
 
     Map<String, Object> cdpResponse = new LinkedHashMap<>();
@@ -229,21 +223,31 @@ public final class PlaywrightDriver extends BaseDriver {
     if (backendNodeId == null) {
       throw new IllegalStateException("Element " + id + " has no backendNodeId");
     }
-    sendCdp("DOM.enable", null);
-    sendCdp("DOM.getFlattenedDocument", null);
-    Map<String, Object> pushed =
-        sendCdp(
-            "DOM.pushNodesByBackendIdsToFrontend",
-            Map.of("backendNodeIds", List.of(backendNodeId)));
-    @SuppressWarnings("unchecked")
-    List<Number> nodeIds = (List<Number>) pushed.get("nodeIds");
-    if (nodeIds == null || nodeIds.isEmpty()) {
-      throw new IllegalStateException("CDP did not return a node id for " + backendNodeId);
+
+    boolean isOopif = frame != page.mainFrame() && oopifFrames.contains(frame);
+    CDPSession session = isOopif ? page.context().newCDPSession(frame) : client;
+    try {
+      sendCdpOn(session, "DOM.enable", null);
+      sendCdpOn(session, "DOM.getFlattenedDocument", null);
+      Map<String, Object> pushed =
+          sendCdpOn(
+              session,
+              "DOM.pushNodesByBackendIdsToFrontend",
+              Map.of("backendNodeIds", List.of(backendNodeId)));
+      @SuppressWarnings("unchecked")
+      List<Number> nodeIds = (List<Number>) pushed.get("nodeIds");
+      if (nodeIds == null || nodeIds.isEmpty()) {
+        throw new IllegalStateException("CDP did not return a node id for " + backendNodeId);
+      }
+      Number nodeId = nodeIds.get(0);
+      sendCdpOn(
+          session,
+          "DOM.setAttributeValue",
+          Map.of("nodeId", nodeId, "name", "data-alumnium-id", "value", backendNodeId.toString()));
+    } finally {
+      if (isOopif) session.detach();
     }
-    Number nodeId = nodeIds.get(0);
-    sendCdp(
-        "DOM.setAttributeValue",
-        Map.of("nodeId", nodeId, "name", "data-alumnium-id", "value", backendNodeId.toString()));
+
     return frame.locator("css=[data-alumnium-id='" + backendNodeId + "']");
   }
 
@@ -257,10 +261,9 @@ public final class PlaywrightDriver extends BaseDriver {
     page.waitForTimeout(100);
     if (pages.size() <= 1) return;
     int idx = pages.indexOf(page);
-    Page next = pages.get((idx + 1) % pages.size());
-    this.page = next;
-    this.client = next.context().newCDPSession(next);
-    next.waitForLoadState();
+    this.page = pages.get((idx + 1) % pages.size());
+    initCDPSession();
+    page.waitForLoadState();
   }
 
   @Override
@@ -268,10 +271,9 @@ public final class PlaywrightDriver extends BaseDriver {
     page.waitForTimeout(100);
     if (pages.size() <= 1) return;
     int idx = pages.indexOf(page);
-    Page prev = pages.get((idx - 1 + pages.size()) % pages.size());
-    this.page = prev;
-    this.client = prev.context().newCDPSession(prev);
-    prev.waitForLoadState();
+    this.page = pages.get((idx - 1 + pages.size()) % pages.size());
+    initCDPSession();
+    page.waitForLoadState();
   }
 
   @Override
@@ -282,7 +284,62 @@ public final class PlaywrightDriver extends BaseDriver {
   // endregion
   // region Internals
 
+  private void initCDPSession() {
+    oopifFrames.clear();
+    this.client = page.context().newCDPSession(page);
+    enableTargetAutoAttach();
+  }
+
+  private void mergeFrameNodes(
+      List<Map<String, Object>> nodes,
+      String frameId,
+      Map<String, Integer> frameToIframeMap,
+      Frame pwFrame,
+      int frameIndex,
+      List<Map<String, Object>> allNodes) {
+    String prefix = "f" + frameIndex + ":";
+    for (Map<String, Object> node : nodes) {
+      Object nid = node.get("nodeId");
+      if (nid != null) node.put("nodeId", prefix + nid);
+      Object pid = node.get("parentId");
+      if (pid != null) node.put("parentId", prefix + pid);
+      @SuppressWarnings("unchecked")
+      List<Object> childIds = (List<Object>) node.get("childIds");
+      if (childIds != null) {
+        List<Object> prefixed = new ArrayList<>(childIds.size());
+        for (Object cid : childIds) prefixed.add(prefix + cid);
+        node.put("childIds", prefixed);
+      }
+      node.put("_frame", pwFrame);
+      if (node.get("parentId") == null && frameToIframeMap.containsKey(frameId)) {
+        node.put("_parent_iframe_backend_node_id", frameToIframeMap.get(frameId));
+      }
+      allNodes.add(node);
+    }
+  }
+
+  private List<Map<String, Object>> getOopifNodes(String frameId, Frame pwFrame) {
+    try {
+      CDPSession frameSession = page.context().newCDPSession(pwFrame);
+      Map<String, Object> resp = sendCdpOn(frameSession, "Accessibility.getFullAXTree", null);
+      frameSession.detach();
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> nodes =
+          (List<Map<String, Object>>) resp.getOrDefault("nodes", List.of());
+      LOG.debug("  -> OOPIF {}: {} nodes", frameId, nodes.size());
+      return nodes;
+    } catch (RuntimeException e) {
+      LOG.debug("  -> OOPIF {}: failed", frameId, e);
+      return List.of();
+    }
+  }
+
   private Map<String, Object> sendCdp(String method, Map<String, Object> params) {
+    return sendCdpOn(client, method, params);
+  }
+
+  private Map<String, Object> sendCdpOn(
+      CDPSession session, String method, Map<String, Object> params) {
     JsonObject paramsJson;
     if (params == null || params.isEmpty()) {
       paramsJson = new JsonObject();
@@ -294,7 +351,7 @@ public final class PlaywrightDriver extends BaseDriver {
         throw new IllegalStateException("Failed to encode CDP params for " + method, e);
       }
     }
-    JsonObject resp = client.send(method, paramsJson);
+    JsonObject resp = session.send(method, paramsJson);
     if (resp == null) return Map.of();
     try {
       JsonNode parsed = MAPPER.readTree(resp.toString());
@@ -386,7 +443,7 @@ public final class PlaywrightDriver extends BaseDriver {
         attachPageListeners(newPage);
       }
       this.page = newPage;
-      this.client = newPage.context().newCDPSession(newPage);
+      initCDPSession();
     }
   }
 
@@ -409,16 +466,66 @@ public final class PlaywrightDriver extends BaseDriver {
     return out;
   }
 
-  private void buildFrameHierarchy(
-      Map<String, Object> frameInfo, String mainFrameId, Map<String, Integer> frameToIframeMap) {
+  private Map<String, Frame> buildPlaywrightFrameMap(Map<String, Object> frameTreeResp) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> frameTree = (Map<String, Object>) frameTreeResp.get("frameTree");
+    Map<String, Frame> map = new HashMap<>();
+    for (Frame f : page.frames()) {
+      String cdpFrameId = findCdpFrameIdByUrl(frameTree, f.url());
+      if (cdpFrameId != null) map.put(cdpFrameId, f);
+    }
+
+    oopifFrames.clear();
+    for (Frame pwFrame : page.frames()) {
+      if (pwFrame == page.mainFrame()) continue;
+      if (map.containsValue(pwFrame)) continue;
+      try {
+        CDPSession frameSession = page.context().newCDPSession(pwFrame);
+        Map<String, Object> ft = sendCdpOn(frameSession, "Page.getFrameTree", null);
+        frameSession.detach();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> ftTree = (Map<String, Object>) ft.get("frameTree");
+        String rootFrameId = frameIdOf(ftTree);
+        map.put(rootFrameId, pwFrame);
+        oopifFrames.add(pwFrame);
+        LOG.debug("Mapped OOPIF {}... to Playwright frame", rootFrameId);
+      } catch (RuntimeException e) {
+        LOG.debug("Could not detect OOPIF frame", e);
+      }
+    }
+    return map;
+  }
+
+  private Map<String, Integer> buildFrameOwnerMap(
+      Map<String, Object> frameInfo, String mainFrameId, List<String> oopifFrameIds) {
+    Map<String, Integer> map = new HashMap<>();
+    sendCdp("DOM.enable", null);
+    walkFrameOwners(frameInfo, mainFrameId, map);
+    for (String oopifFrameId : oopifFrameIds) {
+      try {
+        Map<String, Object> owner = sendCdp("DOM.getFrameOwner", Map.of("frameId", oopifFrameId));
+        Object backend = owner.get("backendNodeId");
+        if (backend instanceof Number n) {
+          map.put(oopifFrameId, n.intValue());
+          LOG.debug("OOPIF {}... owned by iframe backendNodeId={}", oopifFrameId, n.intValue());
+        }
+      } catch (RuntimeException e) {
+        LOG.debug("Could not get frame owner for OOPIF {}", oopifFrameId, e);
+      }
+    }
+    return map;
+  }
+
+  private void walkFrameOwners(
+      Map<String, Object> frameInfo, String mainFrameId, Map<String, Integer> map) {
     String id = frameIdOf(frameInfo);
     if (!id.equals(mainFrameId)) {
       try {
-        sendCdp("DOM.enable", null);
         Map<String, Object> owner = sendCdp("DOM.getFrameOwner", Map.of("frameId", id));
         Object backend = owner.get("backendNodeId");
         if (backend instanceof Number n) {
-          frameToIframeMap.put(id, n.intValue());
+          map.put(id, n.intValue());
+          LOG.debug("Frame {}... owned by iframe backendNodeId={}", id, n.intValue());
         }
       } catch (RuntimeException e) {
         LOG.debug("Could not get frame owner for {}", id, e);
@@ -427,9 +534,21 @@ public final class PlaywrightDriver extends BaseDriver {
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> children = (List<Map<String, Object>>) frameInfo.get("childFrames");
     if (children != null) {
-      for (Map<String, Object> child : children) {
-        buildFrameHierarchy(child, mainFrameId, frameToIframeMap);
-      }
+      for (Map<String, Object> child : children) walkFrameOwners(child, mainFrameId, map);
+    }
+  }
+
+  private List<Map<String, Object>> getFrameNodes(String frameId) {
+    try {
+      Map<String, Object> resp = sendCdp("Accessibility.getFullAXTree", Map.of("frameId", frameId));
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> nodes =
+          (List<Map<String, Object>>) resp.getOrDefault("nodes", List.of());
+      LOG.debug("  -> Frame {}: {} nodes", frameId, nodes.size());
+      return nodes;
+    } catch (RuntimeException e) {
+      LOG.debug("  -> Frame {}: failed", frameId, e);
+      return List.of();
     }
   }
 

--- a/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/FramesTest.java
@@ -21,14 +21,16 @@ public class FramesTest extends BaseTest {
         List.of("LEFT", "MIDDLE", "RIGHT", "BOTTOM"), al.get("text from all frames"));
   }
 
+  @DisabledIfEnvironmentVariable(named = "ALUMNIUM_DRIVER", matches = "selenium")
   @Test
   void testCrossOriginIframe() {
     navigate(CROSS_ORIGIN_IFRAME_URL);
 
     al.check("button 'Main Page Button' is present");
-    al.act("click button 'Click Me Inside Iframe'");
-    al.check("text 'Button Clicked!' is present");
-    al.act("click link 'Iframe Link'");
-    al.check("text 'Link Clicked!' is present");
+    al.check("'Password' field is present");
+    al.act("type 'testuser' in the text input field");
+    al.check("Text input contains 'testuser'");
+    al.act("click Submit button");
+    al.check("'Form submitted' message is present");
   }
 }

--- a/packages/python/examples/pytest/frames_test.py
+++ b/packages/python/examples/pytest/frames_test.py
@@ -15,14 +15,15 @@ def test_nested_frames(al, navigate):
 
 
 @mark.xfail(
-    "appium" in getenv("ALUMNIUM_DRIVER", "selenium"),
-    reason="Frames support is only implemented for Playwright and Selenium currently",
+    "playwright" != getenv("ALUMNIUM_DRIVER", "selenium"),
+    reason="Frames support is only implemented for Playwright currently",
 )
 def test_cross_origin_iframe(al, navigate):
     navigate("cross_origin_iframe.html")
 
     al.check("button 'Main Page Button' is present")
-    al.do("click button 'Click Me Inside Iframe'")
-    al.check("text 'Button Clicked!' is present")
-    al.do("click link 'Iframe Link'")
-    al.check("text 'Link Clicked!' is present")
+    al.check("'Password' field is present")
+    al.do("type 'testuser' in the text input field")
+    al.check("Text input contains 'testuser'")
+    al.do("click Submit button")
+    al.check("'Form submitted' message is present")

--- a/packages/python/examples/support/pages/cross_origin_iframe.html
+++ b/packages/python/examples/support/pages/cross_origin_iframe.html
@@ -1,19 +1,18 @@
 <!doctype html>
 <html>
   <head>
-    <title>Cross-Origin Iframe Test</title>
+    <title>Cross-Origin Test</title>
   </head>
   <body>
     <h1>Main Page</h1>
-    <p>This is the main page content.</p>
+    <p>This page embeds a real cross-origin iframe.</p>
     <button id="main-button">Main Page Button</button>
 
     <h2>Cross-Origin Iframe Below:</h2>
-    <!-- Use data: URI to create cross-origin iframe -->
     <iframe
-      src="data:text/html,%3C!DOCTYPE%20html%3E%0A%3Chtml%3E%0A%3Chead%3E%0A%20%20%3Ctitle%3ECross-Origin%20Content%3C%2Ftitle%3E%0A%3C%2Fhead%3E%0A%3Cbody%3E%0A%20%20%3Ch1%3ECross-Origin%20Iframe%20Content%3C%2Fh1%3E%0A%20%20%3Cbutton%20id%3D%22iframe-button%22%3EClick%20Me%20Inside%20Iframe%3C%2Fbutton%3E%0A%20%20%3Ca%20href%3D%22%23%22%20id%3D%22iframe-link%22%3EIframe%20Link%3C%2Fa%3E%0A%20%20%3Cp%20id%3D%22result%22%3E%3C%2Fp%3E%0A%20%20%3Cscript%3E%0A%20%20%20%20document.getElementById%28%27iframe-button%27%29.addEventListener%28%27click%27%2C%20function%28%29%20%7B%0A%20%20%20%20%20%20document.getElementById%28%27result%27%29.textContent%20%3D%20%27Button%20Clicked%21%27%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%20%20document.getElementById%28%27iframe-link%27%29.addEventListener%28%27click%27%2C%20function%28e%29%20%7B%0A%20%20%20%20%20%20e.preventDefault%28%29%3B%0A%20%20%20%20%20%20document.getElementById%28%27result%27%29.textContent%20%3D%20%27Link%20Clicked%21%27%3B%0A%20%20%20%20%7D%29%3B%0A%20%20%3C%2Fscript%3E%0A%3C%2Fbody%3E%0A%3C%2Fhtml%3E"
+      src="https://bonigarcia.dev/selenium-webdriver-java/web-form.html"
       width="800"
-      height="400"
+      height="600"
       style="border: 2px solid blue"
     >
     </iframe>

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -36,7 +36,8 @@ class PlaywrightAsyncDriver(BaseDriver):
             TypeTool,
             UploadTool,
         }
-        self._run_async(self._enable_target_auto_attach())
+        self.oopif_frames: set[Frame] = set()
+        self._run_async(self._init_cdp_session())
         self._run_async(self._setup_page_tracking(page))
 
     @property
@@ -51,45 +52,32 @@ class PlaywrightAsyncDriver(BaseDriver):
     async def _accessibility_tree(self) -> ChromiumAccessibilityTree:
         await self._wait_for_page_to_load()
 
-        # Get frame tree to enumerate all frames (same approach as Selenium)
         frame_tree = await self._send_cdp_command("Page.getFrameTree")
         frame_ids = self._get_all_frame_ids(frame_tree["frameTree"])
         main_frame_id = frame_tree["frameTree"]["frame"]["id"]
-        logger.debug(f"Found {len(frame_ids)} frames")
 
-        # Build mapping: frameId -> backendNodeId of the iframe element containing the frame
-        frame_to_iframe_map: dict[str, int] = {}
-        await self._build_frame_hierarchy(frame_tree["frameTree"], main_frame_id, frame_to_iframe_map)
+        frame_id_to_playwright_frame = await self._build_playwright_frame_map(frame_tree)
+        oopif_frame_ids = [fid for fid, f in frame_id_to_playwright_frame.items() if f in self.oopif_frames]
+        logger.debug(f"Found {len(frame_ids)} same-process frames, {len(oopif_frame_ids)} OOPIFs")
 
-        # Build mapping: frameId -> Playwright Frame object (for element finding)
-        frame_id_to_playwright_frame: dict[str, Frame] = {}
-        for frame in self.page.frames:
-            cdp_frame_id = self._find_cdp_frame_id_by_url(frame_tree, frame.url)
-            if cdp_frame_id:
-                frame_id_to_playwright_frame[cdp_frame_id] = frame
+        frame_to_iframe_map = await self._build_frame_owner_map(
+            frame_tree["frameTree"], main_frame_id, oopif_frame_ids
+        )
 
-        # Aggregate accessibility nodes from all frames
         all_nodes: list[dict] = []
+        frame_index = 0
+
         for frame_id in frame_ids:
-            try:
-                response = await self._send_cdp_command(
-                    "Accessibility.getFullAXTree",
-                    {"frameId": frame_id},
-                )
-                nodes = response.get("nodes", [])
-                logger.debug(f"  -> Frame {frame_id[:20]}...: {len(nodes)} nodes")
+            playwright_frame = frame_id_to_playwright_frame.get(frame_id, self.page.main_frame)
+            nodes = await self._get_frame_nodes(frame_id)
+            self._merge_frame_nodes(nodes, frame_id, frame_to_iframe_map, playwright_frame, frame_index, all_nodes)
+            frame_index += 1
 
-                # Get Playwright frame reference
-                playwright_frame = frame_id_to_playwright_frame.get(frame_id, self.page.main_frame)
-
-                for node in nodes:
-                    node["_frame"] = playwright_frame
-                    # Tag root nodes with their parent iframe's backendNodeId (for tree inlining)
-                    if node.get("parentId") is None and frame_id in frame_to_iframe_map:
-                        node["_parent_iframe_backend_node_id"] = frame_to_iframe_map[frame_id]
-                    all_nodes.append(node)
-            except Exception as e:
-                logger.debug(f"  -> Frame {frame_id[:20]}...: failed ({e})")
+        for oopif_frame_id in oopif_frame_ids:
+            pw_frame = frame_id_to_playwright_frame[oopif_frame_id]
+            nodes = await self._get_oopif_nodes(oopif_frame_id, pw_frame)
+            self._merge_frame_nodes(nodes, oopif_frame_id, frame_to_iframe_map, pw_frame, frame_index, all_nodes)
+            frame_index += 1
 
         return ChromiumAccessibilityTree({"nodes": all_nodes})
 
@@ -215,24 +203,34 @@ class PlaywrightAsyncDriver(BaseDriver):
         if backend_node_id is None:
             raise ValueError(f"Element {id} has no backendNodeId")
 
-        # Beware!
-        await self._send_cdp_command("DOM.enable")
-        await self._send_cdp_command("DOM.getFlattenedDocument")
-        node_ids = await self._send_cdp_command(
-            "DOM.pushNodesByBackendIdsToFrontend",
-            {
-                "backendNodeIds": [backend_node_id],
-            },
-        )
-        node_id = node_ids["nodeIds"][0]
-        await self._send_cdp_command(
-            "DOM.setAttributeValue",
-            {
-                "nodeId": node_id,
-                "name": "data-alumnium-id",
-                "value": str(backend_node_id),
-            },
-        )
+        is_oopif = frame != self.page.main_frame and frame in self.oopif_frames
+        if is_oopif:
+            session = await self.page.context.new_cdp_session(frame)
+        else:
+            if self.client is None:
+                self.client = await self.page.context.new_cdp_session(self.page)
+            session = self.client
+        try:
+            # Beware!
+            await session.send("DOM.enable")
+            await session.send("DOM.getFlattenedDocument")
+            node_ids = await session.send(
+                "DOM.pushNodesByBackendIdsToFrontend",
+                {"backendNodeIds": [backend_node_id]},
+            )
+            node_id = node_ids["nodeIds"][0]
+            await session.send(
+                "DOM.setAttributeValue",
+                {
+                    "nodeId": node_id,
+                    "name": "data-alumnium-id",
+                    "value": str(backend_node_id),
+                },
+            )
+        finally:
+            if is_oopif:
+                await session.detach()
+
         # TODO: We need to remove the attribute after we are done with the element,
         # but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
         return frame.locator(f"css=[data-alumnium-id='{backend_node_id}']")
@@ -267,7 +265,6 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     @asynccontextmanager
     async def _autoswitch_to_new_tab(self):
-        # If auto-switch is disabled, just yield without waiting for new pages
         if not self.autoswitch_to_new_tab:
             yield
             return
@@ -282,16 +279,19 @@ class PlaywrightAsyncDriver(BaseDriver):
         title = await page.title()
         logger.debug(f"Auto-switching to new tab {title} ({page.url})")
         self.page = page
-        self.client = await self.page.context.new_cdp_session(self.page)
+        await self._init_cdp_session()
 
     async def _send_cdp_command(self, method: str, params: dict | None = None):
         if self.client is None:
             self.client = await self.page.context.new_cdp_session(self.page)
-
         return await self.client.send(method, params or {})
 
+    async def _init_cdp_session(self):
+        self.oopif_frames.clear()
+        self.client = await self.page.context.new_cdp_session(self.page)
+        await self._enable_target_auto_attach()
+
     async def _enable_target_auto_attach(self):
-        """Enable auto-attach to OOPIF targets for cross-origin iframe support."""
         try:
             await self._send_cdp_command(
                 "Target.setAutoAttach",
@@ -301,74 +301,146 @@ class PlaywrightAsyncDriver(BaseDriver):
                     "flatten": True,
                 },
             )
-            logger.debug("Enabled Target.setAutoAttach for OOPIF support")
         except Exception as e:
             logger.debug(f"Could not enable Target.setAutoAttach: {e}")
 
+    async def _build_playwright_frame_map(self, frame_tree: dict) -> dict[str, Frame]:
+        frame_map: dict[str, Frame] = {}
+
+        for frame in self.page.frames:
+            cdp_frame_id = self._find_cdp_frame_id_by_url(frame_tree, frame.url)
+            if cdp_frame_id:
+                frame_map[cdp_frame_id] = frame
+
+        self.oopif_frames.clear()
+        for pw_frame in self.page.frames:
+            if pw_frame == self.page.main_frame:
+                continue
+            if pw_frame in frame_map.values():
+                continue
+            try:
+                frame_session = await self.page.context.new_cdp_session(pw_frame)
+                ft = await frame_session.send("Page.getFrameTree")
+                await frame_session.detach()
+                root_frame_id = ft["frameTree"]["frame"]["id"]
+                frame_map[root_frame_id] = pw_frame
+                self.oopif_frames.add(pw_frame)
+                logger.debug(f"Mapped OOPIF {root_frame_id[:20]}... to Playwright frame")
+            except Exception as e:
+                logger.debug(f"Could not detect OOPIF frame: {e}")
+
+        return frame_map
+
+    async def _build_frame_owner_map(
+        self,
+        frame_info: dict,
+        main_frame_id: str,
+        oopif_frame_ids: list[str],
+    ) -> dict[str, int]:
+        frame_to_iframe_map: dict[str, int] = {}
+        await self._send_cdp_command("DOM.enable")
+
+        async def walk(fi: dict):
+            frame_id = fi["frame"]["id"]
+            if frame_id != main_frame_id:
+                try:
+                    owner_info = await self._send_cdp_command("DOM.getFrameOwner", {"frameId": frame_id})
+                    frame_to_iframe_map[frame_id] = owner_info["backendNodeId"]
+                    logger.debug(
+                        f"Frame {frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}"
+                    )
+                except Exception as e:
+                    logger.debug(f"Could not get frame owner for {frame_id[:20]}...: {e}")
+            for child in fi.get("childFrames", []):
+                await walk(child)
+
+        await walk(frame_info)
+
+        for oopif_frame_id in oopif_frame_ids:
+            try:
+                owner_info = await self._send_cdp_command("DOM.getFrameOwner", {"frameId": oopif_frame_id})
+                frame_to_iframe_map[oopif_frame_id] = owner_info["backendNodeId"]
+                logger.debug(
+                    f"OOPIF {oopif_frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}"
+                )
+            except Exception as e:
+                logger.debug(f"Could not get frame owner for OOPIF {oopif_frame_id[:20]}...: {e}")
+
+        return frame_to_iframe_map
+
+    async def _get_frame_nodes(self, frame_id: str) -> list[dict]:
+        try:
+            response = await self._send_cdp_command("Accessibility.getFullAXTree", {"frameId": frame_id})
+            nodes = response.get("nodes", [])
+            logger.debug(f"  -> Frame {frame_id[:20]}...: {len(nodes)} nodes")
+            return nodes
+        except Exception as e:
+            logger.debug(f"  -> Frame {frame_id[:20]}...: failed ({e})")
+            return []
+
+    async def _get_oopif_nodes(self, frame_id: str, playwright_frame: Frame) -> list[dict]:
+        try:
+            frame_session = await self.page.context.new_cdp_session(playwright_frame)
+            response = await frame_session.send("Accessibility.getFullAXTree", {})
+            await frame_session.detach()
+            nodes = response.get("nodes", [])
+            logger.debug(f"  -> OOPIF {frame_id[:20]}...: {len(nodes)} nodes")
+            return nodes
+        except Exception as e:
+            logger.debug(f"  -> OOPIF {frame_id[:20]}...: failed ({e})")
+            return []
+
+    def _merge_frame_nodes(
+        self,
+        nodes: list[dict],
+        frame_id: str,
+        frame_to_iframe_map: dict[str, int],
+        playwright_frame: Frame,
+        frame_index: int,
+        all_nodes: list[dict],
+    ):
+        prefix = f"f{frame_index}:"
+        for node in nodes:
+            if node.get("nodeId") is not None:
+                node["nodeId"] = prefix + str(node["nodeId"])
+            if node.get("parentId") is not None:
+                node["parentId"] = prefix + str(node["parentId"])
+            if node.get("childIds") is not None:
+                node["childIds"] = [prefix + str(cid) for cid in node["childIds"]]
+            node["_frame"] = playwright_frame
+            if node.get("parentId") is None and frame_id in frame_to_iframe_map:
+                node["_parent_iframe_backend_node_id"] = frame_to_iframe_map[frame_id]
+            all_nodes.append(node)
+
     async def _setup_page_tracking(self, initial_page: Page):
-        """Set up tracking for all pages in the context."""
         self._pages: list[Page] = [initial_page]
         self._attach_page_listeners(initial_page)
 
     def _attach_page_listeners(self, page: Page):
-        """Attach popup and close listeners to a page."""
-        # Use sync handler to avoid deadlock - async handler would block via _run_async
         page.on("popup", self._on_popup_sync)
         page.on("close", self._on_page_close)
 
     def _on_popup_sync(self, popup: Page):
-        """Handle new popup/tab opened from a page (sync to avoid deadlock)."""
         logger.debug(f"New popup opened: {popup.url}")
         self._pages.append(popup)
-        self._attach_page_listeners(popup)  # Chain: new page also listens for popups
+        self._attach_page_listeners(popup)
 
     def _on_page_close(self, popup: Page):
-        """Handle page closed."""
         if popup in self._pages:
             logger.debug(f"Page closed: {popup.url}")
             self._pages.remove(popup)
 
     def _get_all_frame_ids(self, frame_info: dict) -> list[str]:
-        """Recursively collect all frame IDs from CDP frame tree."""
         frame_ids = [frame_info["frame"]["id"]]
         for child in frame_info.get("childFrames", []):
             frame_ids.extend(self._get_all_frame_ids(child))
         return frame_ids
 
-    async def _build_frame_hierarchy(
-        self,
-        frame_info: dict,
-        main_frame_id: str,
-        frame_to_iframe_map: dict[str, int],
-    ):
-        """Build frame hierarchy maps recursively."""
-        frame_id = frame_info["frame"]["id"]
-
-        if frame_id != main_frame_id:
-            # Get the iframe element that owns this frame
-            await self._send_cdp_command("DOM.enable")
-            try:
-                owner_info = await self._send_cdp_command(
-                    "DOM.getFrameOwner",
-                    {"frameId": frame_id},
-                )
-                frame_to_iframe_map[frame_id] = owner_info["backendNodeId"]
-                logger.debug(f"Frame {frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}")
-            except Exception as e:
-                logger.debug(f"Could not get frame owner for {frame_id[:20]}...: {e}")
-
-        # Process children
-        for child in frame_info.get("childFrames", []):
-            await self._build_frame_hierarchy(child, main_frame_id, frame_to_iframe_map)
-
     def _find_cdp_frame_id_by_url(self, cdp_frame_tree: dict, target_url: str) -> str | None:
-        """Find CDP frameId by matching URL in CDP frame tree."""
-
         def search_frame(frame_info: dict) -> str | None:
             frame = frame_info["frame"]
             if frame["url"] == target_url:
                 return frame["id"]
-
             for child in frame_info.get("childFrames", []):
                 result = search_frame(child)
                 if result:
@@ -381,35 +453,27 @@ class PlaywrightAsyncDriver(BaseDriver):
         self._run_async(self._switch_to_next_tab())
 
     async def _switch_to_next_tab(self):
-        # Brief wait to allow popup handlers to complete
         await self.page.wait_for_timeout(100)
         if len(self._pages) <= 1:
-            return  # Only one tab, nothing to switch
+            return
 
         current_index = self._pages.index(self.page)
-        next_index = (current_index + 1) % len(self._pages)  # Wrap to first
-
-        self.page = self._pages[next_index]
-        self.client = None  # Reset CDP client for new page
+        self.page = self._pages[(current_index + 1) % len(self._pages)]
+        await self._init_cdp_session()
         await self.page.wait_for_load_state()
-        logger.debug(f"Switched to next tab: {self.page.url}")
 
     def switch_to_previous_tab(self):
         self._run_async(self._switch_to_previous_tab())
 
     async def _switch_to_previous_tab(self):
-        # Brief wait to allow popup handlers to complete
         await self.page.wait_for_timeout(100)
         if len(self._pages) <= 1:
-            return  # Only one tab, nothing to switch
+            return
 
         current_index = self._pages.index(self.page)
-        prev_index = (current_index - 1) % len(self._pages)  # Wrap to last
-
-        self.page = self._pages[prev_index]
-        self.client = None  # Reset CDP client for new page
+        self.page = self._pages[(current_index - 1) % len(self._pages)]
+        await self._init_cdp_session()
         await self.page.wait_for_load_state()
-        logger.debug(f"Switched to previous tab: {self.page.url}")
 
     def _run_async(self, coro):
         future = run_coroutine_threadsafe(coro, self.loop)

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -35,7 +35,6 @@ class PlaywrightDriver(BaseDriver):
         )
 
     def __init__(self, page: Page):
-        self.client = page.context.new_cdp_session(page)
         self.page = page
         self.autoswitch_to_new_tab = True
         self.full_page_screenshot = FULL_PAGE_SCREENSHOT
@@ -47,7 +46,8 @@ class PlaywrightDriver(BaseDriver):
             TypeTool,
             UploadTool,
         }
-        self._enable_target_auto_attach()
+        self.oopif_frames: set[Frame] = set()
+        self._init_cdp_session()
         self._setup_page_tracking(page)
 
     @property
@@ -58,45 +58,34 @@ class PlaywrightDriver(BaseDriver):
     def accessibility_tree(self) -> ChromiumAccessibilityTree:
         self._wait_for_page_to_load()
 
-        # Get frame tree to enumerate all frames (same approach as Selenium)
         frame_tree = self._send_cdp_command("Page.getFrameTree")
         frame_ids = self._get_all_frame_ids(frame_tree["frameTree"])
         main_frame_id = frame_tree["frameTree"]["frame"]["id"]
-        logger.debug(f"Found {len(frame_ids)} frames")
 
-        # Build mapping: frameId -> backendNodeId of the iframe element containing the frame
-        frame_to_iframe_map: dict[str, int] = {}
-        self._build_frame_hierarchy(frame_tree["frameTree"], main_frame_id, frame_to_iframe_map)
+        frame_id_to_playwright_frame = self._build_playwright_frame_map(frame_tree)
+        oopif_frame_ids = []
+        for frame_id, frame in frame_id_to_playwright_frame.items():
+            if frame in self.oopif_frames:
+                oopif_frame_ids.append(frame_id)
 
-        # Build mapping: frameId -> Playwright Frame object (for element finding)
-        frame_id_to_playwright_frame: dict[str, Frame] = {}
-        for frame in self.page.frames:
-            cdp_frame_id = self._find_cdp_frame_id_by_url(frame_tree, frame.url)
-            if cdp_frame_id:
-                frame_id_to_playwright_frame[cdp_frame_id] = frame
+        logger.debug(f"Found {len(frame_ids)} same-process frames, {len(oopif_frame_ids)} OOPIFs")
 
-        # Aggregate accessibility nodes from all frames
+        frame_to_iframe_map = self._build_frame_owner_map(frame_tree["frameTree"], main_frame_id, oopif_frame_ids)
+
         all_nodes: list[dict] = []
+        frame_index = 0
+
         for frame_id in frame_ids:
-            try:
-                response = self._send_cdp_command(
-                    "Accessibility.getFullAXTree",
-                    {"frameId": frame_id},
-                )
-                nodes = response.get("nodes", [])
-                logger.debug(f"  -> Frame {frame_id[:20]}...: {len(nodes)} nodes")
+            playwright_frame = frame_id_to_playwright_frame.get(frame_id, self.page.main_frame)
+            nodes = self._get_frame_nodes(frame_id)
+            self._merge_frame_nodes(nodes, frame_id, frame_to_iframe_map, playwright_frame, frame_index, all_nodes)
+            frame_index += 1
 
-                # Get Playwright frame reference
-                playwright_frame = frame_id_to_playwright_frame.get(frame_id, self.page.main_frame)
-
-                for node in nodes:
-                    node["_frame"] = playwright_frame
-                    # Tag root nodes with their parent iframe's backendNodeId (for tree inlining)
-                    if node.get("parentId") is None and frame_id in frame_to_iframe_map:
-                        node["_parent_iframe_backend_node_id"] = frame_to_iframe_map[frame_id]
-                    all_nodes.append(node)
-            except Exception as e:
-                logger.debug(f"  -> Frame {frame_id[:20]}...: failed ({e})")
+        for oopif_frame_id in oopif_frame_ids:
+            pw_frame = frame_id_to_playwright_frame[oopif_frame_id]
+            nodes = self._get_oopif_nodes(oopif_frame_id, pw_frame)
+            self._merge_frame_nodes(nodes, oopif_frame_id, frame_to_iframe_map, pw_frame, frame_index, all_nodes)
+            frame_index += 1
 
         return ChromiumAccessibilityTree({"nodes": all_nodes})
 
@@ -176,24 +165,29 @@ class PlaywrightDriver(BaseDriver):
         if backend_node_id is None:
             raise ValueError(f"Element {id} has no backendNodeId")
 
-        # Beware!
-        self._send_cdp_command("DOM.enable")
-        self._send_cdp_command("DOM.getFlattenedDocument")
-        node_ids = self._send_cdp_command(
-            "DOM.pushNodesByBackendIdsToFrontend",
-            {
-                "backendNodeIds": [backend_node_id],
-            },
-        )
-        node_id = node_ids["nodeIds"][0]
-        self._send_cdp_command(
-            "DOM.setAttributeValue",
-            {
-                "nodeId": node_id,
-                "name": "data-alumnium-id",
-                "value": str(backend_node_id),
-            },
-        )
+        is_oopif = frame != self.page.main_frame and frame in self.oopif_frames
+        session = self.page.context.new_cdp_session(frame) if is_oopif else self.client
+        try:
+            # Beware!
+            session.send("DOM.enable")
+            session.send("DOM.getFlattenedDocument")
+            node_ids = session.send(
+                "DOM.pushNodesByBackendIdsToFrontend",
+                {"backendNodeIds": [backend_node_id]},
+            )
+            node_id = node_ids["nodeIds"][0]
+            session.send(
+                "DOM.setAttributeValue",
+                {
+                    "nodeId": node_id,
+                    "name": "data-alumnium-id",
+                    "value": str(backend_node_id),
+                },
+            )
+        finally:
+            if is_oopif:
+                session.detach()
+
         # TODO: We need to remove the attribute after we are done with the element,
         # but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
         return frame.locator(f"css=[data-alumnium-id='{backend_node_id}']")
@@ -235,13 +229,17 @@ class PlaywrightDriver(BaseDriver):
         page = new_page_info.value
         logger.debug(f"Auto-switching to new tab {page.title()} ({page.url})")
         self.page = page
-        self.client = page.context.new_cdp_session(page)
+        self._init_cdp_session()
 
     def _send_cdp_command(self, method: str, params: dict | None = None):
         return self.client.send(method, params or {})
 
+    def _init_cdp_session(self):
+        self.oopif_frames.clear()
+        self.client = self.page.context.new_cdp_session(self.page)
+        self._enable_target_auto_attach()
+
     def _enable_target_auto_attach(self):
-        """Enable auto-attach to OOPIF targets for cross-origin iframe support."""
         try:
             self._send_cdp_command(
                 "Target.setAutoAttach",
@@ -251,68 +249,144 @@ class PlaywrightDriver(BaseDriver):
                     "flatten": True,
                 },
             )
-            logger.debug("Enabled Target.setAutoAttach for OOPIF support")
         except Exception as e:
             logger.debug(f"Could not enable Target.setAutoAttach: {e}")
 
+    def _merge_frame_nodes(
+        self,
+        nodes: list[dict],
+        frame_id: str,
+        frame_to_iframe_map: dict[str, int],
+        playwright_frame: Frame,
+        frame_index: int,
+        all_nodes: list[dict],
+    ):
+        prefix = f"f{frame_index}:"
+        for node in nodes:
+            if node.get("nodeId") is not None:
+                node["nodeId"] = prefix + str(node["nodeId"])
+            if node.get("parentId") is not None:
+                node["parentId"] = prefix + str(node["parentId"])
+            if node.get("childIds") is not None:
+                node["childIds"] = [prefix + str(cid) for cid in node["childIds"]]
+            node["_frame"] = playwright_frame
+            if node.get("parentId") is None and frame_id in frame_to_iframe_map:
+                node["_parent_iframe_backend_node_id"] = frame_to_iframe_map[frame_id]
+            all_nodes.append(node)
+
+    def _get_oopif_nodes(self, frame_id: str, playwright_frame: Frame) -> list[dict]:
+        try:
+            frame_session = self.page.context.new_cdp_session(playwright_frame)
+            response = frame_session.send("Accessibility.getFullAXTree", {})
+            frame_session.detach()
+            nodes = response.get("nodes", [])
+            logger.debug(f"  -> OOPIF {frame_id[:20]}...: {len(nodes)} nodes")
+            return nodes
+        except Exception as e:
+            logger.debug(f"  -> OOPIF {frame_id[:20]}...: failed ({e})")
+            return []
+
+    def _build_playwright_frame_map(self, frame_tree: dict) -> dict[str, Frame]:
+        frame_map: dict[str, Frame] = {}
+
+        for frame in self.page.frames:
+            cdp_frame_id = self._find_cdp_frame_id_by_url(frame_tree, frame.url)
+            if cdp_frame_id:
+                frame_map[cdp_frame_id] = frame
+
+        # OOPIFs are absent from Page.getFrameTree — open a per-frame CDP session
+        # and compare root frame ids.
+        self.oopif_frames.clear()
+        for playwright_frame in self.page.frames:
+            if playwright_frame == self.page.main_frame:
+                continue
+            if playwright_frame in frame_map.values():
+                continue
+            try:
+                frame_session = self.page.context.new_cdp_session(playwright_frame)
+                frame_tree = frame_session.send("Page.getFrameTree")
+                frame_session.detach()
+                root_frame_id = frame_tree["frameTree"]["frame"]["id"]
+                frame_map[root_frame_id] = playwright_frame
+                self.oopif_frames.add(playwright_frame)
+                logger.debug(f"Mapped OOPIF {root_frame_id[:20]}... to Playwright frame")
+            except Exception as e:
+                logger.debug(f"Could not detect OOPIF frame: {e}")
+
+        return frame_map
+
+    def _build_frame_owner_map(
+        self,
+        frame_info: dict,
+        main_frame_id: str,
+        oopif_frame_ids: list[str],
+    ) -> dict[str, int]:
+        frame_to_iframe_map: dict[str, int] = {}
+        self._send_cdp_command("DOM.enable")
+
+        def walk(fi: dict):
+            frame_id = fi["frame"]["id"]
+            if frame_id != main_frame_id:
+                try:
+                    owner_info = self._send_cdp_command("DOM.getFrameOwner", {"frameId": frame_id})
+                    frame_to_iframe_map[frame_id] = owner_info["backendNodeId"]
+                    logger.debug(
+                        f"Frame {frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}"
+                    )
+                except Exception as e:
+                    logger.debug(f"Could not get frame owner for {frame_id[:20]}...: {e}")
+            for child in fi.get("childFrames", []):
+                walk(child)
+
+        walk(frame_info)
+
+        for oopif_frame_id in oopif_frame_ids:
+            try:
+                owner_info = self._send_cdp_command("DOM.getFrameOwner", {"frameId": oopif_frame_id})
+                frame_to_iframe_map[oopif_frame_id] = owner_info["backendNodeId"]
+                logger.debug(
+                    f"OOPIF {oopif_frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}"
+                )
+            except Exception as e:
+                logger.debug(f"Could not get frame owner for OOPIF {oopif_frame_id[:20]}...: {e}")
+
+        return frame_to_iframe_map
+
+    def _get_frame_nodes(self, frame_id: str) -> list[dict]:
+        try:
+            response = self._send_cdp_command("Accessibility.getFullAXTree", {"frameId": frame_id})
+            nodes = response.get("nodes", [])
+            logger.debug(f"  -> Frame {frame_id[:20]}...: {len(nodes)} nodes")
+            return nodes
+        except Exception as e:
+            logger.debug(f"  -> Frame {frame_id[:20]}...: failed ({e})")
+            return []
+
     def _setup_page_tracking(self, initial_page: Page):
-        """Set up tracking for all pages in the context."""
         self._pages: list[Page] = [initial_page]
         self._attach_page_listeners(initial_page)
 
     def _attach_page_listeners(self, page: Page):
-        """Attach popup and close listeners to a page."""
         page.on("popup", self._on_popup)
         page.on("close", self._on_page_close)
 
     def _on_popup(self, popup: Page):
-        """Handle new popup/tab opened from a page."""
         logger.debug(f"New popup opened: {popup.url}")
         self._pages.append(popup)
-        self._attach_page_listeners(popup)  # Chain: new page also listens for popups
+        self._attach_page_listeners(popup)
 
     def _on_page_close(self, popup: Page):
-        """Handle page closed."""
         if popup in self._pages:
             logger.debug(f"Page closed: {popup.url}")
             self._pages.remove(popup)
 
     def _get_all_frame_ids(self, frame_info: dict) -> list[str]:
-        """Recursively collect all frame IDs from CDP frame tree."""
         frame_ids = [frame_info["frame"]["id"]]
         for child in frame_info.get("childFrames", []):
             frame_ids.extend(self._get_all_frame_ids(child))
         return frame_ids
 
-    def _build_frame_hierarchy(
-        self,
-        frame_info: dict,
-        main_frame_id: str,
-        frame_to_iframe_map: dict[str, int],
-    ):
-        """Build frame hierarchy maps recursively."""
-        frame_id = frame_info["frame"]["id"]
-
-        if frame_id != main_frame_id:
-            # Get the iframe element that owns this frame
-            self._send_cdp_command("DOM.enable")
-            try:
-                owner_info = self._send_cdp_command(
-                    "DOM.getFrameOwner",
-                    {"frameId": frame_id},
-                )
-                frame_to_iframe_map[frame_id] = owner_info["backendNodeId"]
-                logger.debug(f"Frame {frame_id[:20]}... owned by iframe backendNodeId={owner_info['backendNodeId']}")
-            except Exception as e:
-                logger.debug(f"Could not get frame owner for {frame_id[:20]}...: {e}")
-
-        # Process children
-        for child in frame_info.get("childFrames", []):
-            self._build_frame_hierarchy(child, main_frame_id, frame_to_iframe_map)
-
     def _find_cdp_frame_id_by_url(self, cdp_frame_tree: dict, target_url: str) -> str | None:
-        """Find CDP frameId by matching URL in CDP frame tree."""
-
         def search_frame(frame_info: dict) -> str | None:
             frame = frame_info["frame"]
             if frame["url"] == target_url:
@@ -333,10 +407,8 @@ class PlaywrightDriver(BaseDriver):
             return  # Only one tab, nothing to switch
 
         current_index = self._pages.index(self.page)
-        next_index = (current_index + 1) % len(self._pages)  # Wrap to first
-
-        self.page = self._pages[next_index]
-        self.client = self.page.context.new_cdp_session(self.page)
+        self.page = self._pages[(current_index + 1) % len(self._pages)]
+        self._init_cdp_session()
         self.page.wait_for_load_state()
 
     def switch_to_previous_tab(self):
@@ -346,8 +418,6 @@ class PlaywrightDriver(BaseDriver):
             return  # Only one tab, nothing to switch
 
         current_index = self._pages.index(self.page)
-        prev_index = (current_index - 1) % len(self._pages)  # Wrap to last
-
-        self.page = self._pages[prev_index]
-        self.client = self.page.context.new_cdp_session(self.page)
+        self.page = self._pages[(current_index - 1) % len(self._pages)]
+        self._init_cdp_session()
         self.page.wait_for_load_state()

--- a/packages/typescript/src/accessibility/ChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/accessibility/ChromiumAccessibilityTree.ts
@@ -193,8 +193,12 @@ export class ChromiumAccessibilityTree extends BaseAccessibilityTree {
 
     // Inline iframe content: if this element is an iframe, add its child trees
     const backendNodeId = node.backendDOMNodeId;
-    if (backendNodeId && iframeChildren[backendNodeId]) {
-      for (const childRoot of iframeChildren[backendNodeId]) {
+    const iframeRoots = backendNodeId
+      ? iframeChildren[backendNodeId]
+      : undefined;
+    if (backendNodeId && iframeRoots) {
+      delete iframeChildren[backendNodeId];
+      for (const childRoot of iframeRoots) {
         const childElem = this.#nodeToXml(
           childRoot,
           nodeLookup,

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -66,6 +66,10 @@ export class PlaywrightDriver extends BaseDriver {
   private client!: CDPSession;
   page: Page;
   private _pages: Page[] = [];
+  // frameId → url for OOPIF frames tracked via Target.attachedToTarget events
+  private oopifFrameIds: Map<string, string> = new Map();
+  // Playwright Frame objects that correspond to OOPIFs (populated during getAccessibilityTree)
+  private oopifFrames: Set<Frame> = new Set();
   public platform: Driver.Platform = "chromium";
   public supportedTools: Set<ToolClass> = new Set([
     ClickTool,
@@ -111,6 +115,8 @@ export class PlaywrightDriver extends BaseDriver {
   }
 
   private async initCDPSession(): Promise<void> {
+    this.oopifFrameIds.clear();
+    this.oopifFrames.clear();
     this.client = await this.page.context().newCDPSession(this.page);
     await this.enableTargetAutoAttach();
   }
@@ -122,6 +128,52 @@ export class PlaywrightDriver extends BaseDriver {
         waitForDebuggerOnStart: false,
         flatten: true,
       });
+
+      // Track OOPIF frames: they arrive as attached targets of type "iframe"
+      // but are absent from Page.getFrameTree because they run in a separate
+      // renderer process. The URL is often empty at attach time; it gets
+      // updated via Page.frameNavigated events.
+      this.client.on(
+        "Target.attachedToTarget",
+        (event: {
+          targetInfo: { type: string; targetId: string; url: string };
+          sessionId: string;
+        }) => {
+          if (event.targetInfo.type === "iframe") {
+            logger.debug(
+              `OOPIF attached: frameId=${event.targetInfo.targetId} url=${event.targetInfo.url || "(empty)"}`,
+            );
+            this.oopifFrameIds.set(
+              event.targetInfo.targetId,
+              event.targetInfo.url,
+            );
+          }
+        },
+      );
+
+      this.client.on(
+        "Target.detachedFromTarget",
+        (event: { targetId?: string }) => {
+          if (event.targetId && this.oopifFrameIds.has(event.targetId)) {
+            logger.debug(`OOPIF detached: frameId=${event.targetId}`);
+            this.oopifFrameIds.delete(event.targetId);
+          }
+        },
+      );
+
+      // Update URLs as OOPIF frames navigate (the initial attach URL is often empty)
+      this.client.on(
+        "Page.frameNavigated",
+        (event: { frame: { id: string; url: string }; type: string }) => {
+          if (this.oopifFrameIds.has(event.frame.id)) {
+            logger.debug(
+              `OOPIF navigated: frameId=${event.frame.id} url=${event.frame.url}`,
+            );
+            this.oopifFrameIds.set(event.frame.id, event.frame.url);
+          }
+        },
+      );
+
       logger.debug("Enabled Target.setAutoAttach for OOPIF support");
     } catch (error) {
       logger.debug(
@@ -134,63 +186,51 @@ export class PlaywrightDriver extends BaseDriver {
   async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
     await this.waitForPageToLoad();
 
-    // Get frame tree to enumerate all frames (same approach as Selenium)
     const frameTree = (await this.client.send(
       "Page.getFrameTree",
     )) as CDPFrameTree;
     const frameIds = this.getAllFrameIds(frameTree.frameTree);
     const mainFrameId = frameTree.frameTree.frame.id;
-    logger.debug(`Found ${frameIds.length} frames`);
-
-    // Build mapping: frameId -> backendNodeId of the iframe element containing the frame
-    const frameToIframeMap: Map<string, number> = new Map();
-    await this.buildFrameHierarchy(
-      frameTree.frameTree,
-      mainFrameId,
-      frameToIframeMap,
+    logger.debug(
+      `Found ${frameIds.length} same-process frames, ${this.oopifFrameIds.size} OOPIFs`,
     );
 
-    // Build mapping: frameId -> Playwright Frame object (for element finding)
-    const frameIdToPlaywrightFrame: Map<string, Frame> = new Map();
-    for (const frame of this.page.frames()) {
-      const cdpFrameId = this.findCdpFrameIdByUrl(frameTree, frame.url());
-      if (cdpFrameId) {
-        frameIdToPlaywrightFrame.set(cdpFrameId, frame);
-      }
+    const frameToIframeMap = await this.buildFrameOwnerMap(
+      frameTree.frameTree,
+      mainFrameId,
+    );
+    const frameIdToPlaywrightFrame =
+      await this.buildPlaywrightFrameMap(frameTree);
+
+    const allNodes: CDPNode[] = [];
+    let frameIndex = 0;
+
+    for (const frameId of frameIds) {
+      const playwrightFrame =
+        frameIdToPlaywrightFrame.get(frameId) ?? this.page.mainFrame();
+      const nodes = await this.getFrameNodes(frameId, playwrightFrame);
+      this.mergeFrameNodes(
+        nodes,
+        frameId,
+        frameToIframeMap,
+        playwrightFrame,
+        frameIndex++,
+        allNodes,
+      );
     }
 
-    // Aggregate accessibility nodes from all frames
-    const allNodes: CDPNode[] = [];
-    for (const frameId of frameIds) {
-      try {
-        const response = (await this.client.send(
-          "Accessibility.getFullAXTree",
-          {
-            frameId,
-          },
-        )) as { nodes: CDPNode[] };
-        const nodes = response.nodes || [];
-        logger.debug(
-          `  -> Frame ${frameId.slice(0, 20)}...: ${nodes.length} nodes`,
-        );
-
-        // Get Playwright frame reference
-        const playwrightFrame =
-          frameIdToPlaywrightFrame.get(frameId) || this.page.mainFrame();
-
-        for (const node of nodes) {
-          node._frame = playwrightFrame;
-          // Tag root nodes with their parent iframe's backendNodeId (for tree inlining)
-          if (node.parentId === undefined && frameToIframeMap.has(frameId)) {
-            node._parent_iframe_backend_node_id = frameToIframeMap.get(frameId);
-          }
-          allNodes.push(node);
-        }
-      } catch (error) {
-        logger.debug(
-          `  -> Frame ${frameId.slice(0, 20)}...: failed (${error instanceof Error ? error.message : String(error)})`,
-        );
-      }
+    for (const oopifFrameId of this.oopifFrameIds.keys()) {
+      const playwrightFrame = frameIdToPlaywrightFrame.get(oopifFrameId);
+      if (!playwrightFrame) continue;
+      const nodes = await this.getOopifNodes(oopifFrameId, playwrightFrame);
+      this.mergeFrameNodes(
+        nodes,
+        oopifFrameId,
+        frameToIframeMap,
+        playwrightFrame,
+        frameIndex++,
+        allNodes,
+      );
     }
 
     return new ChromiumAccessibilityTree({ nodes: allNodes });
@@ -320,25 +360,155 @@ export class PlaywrightDriver extends BaseDriver {
 
     const backendNodeId = accessibilityElement.backendNodeId!;
 
+    // OOPIF elements live in a separate renderer process — the main CDP session
+    // cannot resolve their backendNodeIds. Use a per-frame session instead.
+    const isOopif = frame !== this.page.mainFrame() && this.isOopifFrame(frame);
+    const session = isOopif
+      ? await this.page.context().newCDPSession(frame)
+      : this.client;
+
     // Beware!
-    await this.client.send("DOM.enable");
-    await this.client.send("DOM.getFlattenedDocument");
-    const nodeIds = await this.client.send(
-      "DOM.pushNodesByBackendIdsToFrontend",
-      {
-        backendNodeIds: [backendNodeId],
-      },
-    );
+    await session.send("DOM.enable");
+    await session.send("DOM.getFlattenedDocument");
+    const nodeIds = await session.send("DOM.pushNodesByBackendIdsToFrontend", {
+      backendNodeIds: [backendNodeId],
+    });
     const nodeId = nodeIds.nodeIds[0];
     ensure(nodeId);
-    await this.client.send("DOM.setAttributeValue", {
+    await session.send("DOM.setAttributeValue", {
       nodeId,
       name: "data-alumnium-id",
       value: String(backendNodeId),
     });
+
+    if (isOopif) await session.detach();
+
     // TODO: We need to remove the attribute after we are done with the element,
     // but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
     return frame.locator(`css=[data-alumnium-id='${backendNodeId}']`);
+  }
+
+  private isOopifFrame(frame: Frame): boolean {
+    return this.oopifFrames.has(frame);
+  }
+
+  // Build frameId -> backendNodeId map for all non-main frames so nodes can be
+  // stitched back to their parent <iframe> element in the merged tree.
+  private async buildFrameOwnerMap(
+    frameInfo: CDPFrameInfo,
+    mainFrameId: string,
+  ): Promise<Map<string, number>> {
+    const map: Map<string, number> = new Map();
+    await this.client.send("DOM.enable");
+
+    const walk = async (fi: CDPFrameInfo) => {
+      if (fi.frame.id !== mainFrameId) {
+        try {
+          const owner = await this.client.send("DOM.getFrameOwner", {
+            frameId: fi.frame.id,
+          });
+          map.set(fi.frame.id, owner.backendNodeId);
+          logger.debug(
+            `Frame ${fi.frame.id.slice(0, 20)}... owned by iframe backendNodeId=${owner.backendNodeId}`,
+          );
+        } catch (error) {
+          logger.debug(
+            `Could not get frame owner for ${fi.frame.id.slice(0, 20)}...: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+      for (const child of fi.childFrames || []) await walk(child);
+    };
+    await walk(frameInfo);
+
+    // OOPIFs: their <iframe> element lives in the main DOM, so the main session resolves it fine.
+    for (const oopifFrameId of this.oopifFrameIds.keys()) {
+      try {
+        const owner = await this.client.send("DOM.getFrameOwner", {
+          frameId: oopifFrameId,
+        });
+        map.set(oopifFrameId, owner.backendNodeId);
+        logger.debug(
+          `OOPIF ${oopifFrameId.slice(0, 20)}... owned by iframe backendNodeId=${owner.backendNodeId}`,
+        );
+      } catch (error) {
+        logger.debug(
+          `Could not get frame owner for OOPIF ${oopifFrameId.slice(0, 20)}...: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    return map;
+  }
+
+  // Build frameId -> Playwright Frame map for same-origin and OOPIF frames.
+  private async buildPlaywrightFrameMap(
+    frameTree: CDPFrameTree,
+  ): Promise<Map<string, Frame>> {
+    const map: Map<string, Frame> = new Map();
+
+    for (const frame of this.page.frames()) {
+      const cdpFrameId = this.findCdpFrameIdByUrl(frameTree, frame.url());
+      if (cdpFrameId) map.set(cdpFrameId, frame);
+    }
+
+    // OOPIFs are absent from Page.getFrameTree, so URL matching won't work.
+    // Open a per-frame CDP session and compare root frame ids.
+    const unmappedOopifs = new Set(
+      [...this.oopifFrameIds.keys()].filter((id) => !map.has(id)),
+    );
+    if (unmappedOopifs.size > 0) {
+      for (const playwrightFrame of this.page.frames()) {
+        if (playwrightFrame === this.page.mainFrame()) continue;
+        if ([...map.values()].includes(playwrightFrame)) continue;
+
+        try {
+          const frameSession = await this.page
+            .context()
+            .newCDPSession(playwrightFrame);
+          const ft = (await frameSession.send(
+            "Page.getFrameTree",
+          )) as CDPFrameTree;
+          await frameSession.detach();
+
+          const rootFrameId = ft.frameTree.frame.id;
+          if (unmappedOopifs.has(rootFrameId)) {
+            map.set(rootFrameId, playwrightFrame);
+            this.oopifFrames.add(playwrightFrame);
+            unmappedOopifs.delete(rootFrameId);
+            logger.debug(
+              `Mapped OOPIF ${rootFrameId.slice(0, 20)}... to Playwright frame`,
+            );
+          }
+        } catch {
+          // frame may have been destroyed
+        }
+      }
+    }
+
+    return map;
+  }
+
+  // Namespace and append a frame's nodes into allNodes to prevent id collisions.
+  private mergeFrameNodes(
+    nodes: CDPNode[],
+    frameId: string,
+    frameToIframeMap: Map<string, number>,
+    playwrightFrame: Frame,
+    frameIndex: number,
+    allNodes: CDPNode[],
+  ): void {
+    const prefix = `f${frameIndex}:`;
+    for (const node of nodes) {
+      node.nodeId = prefix + node.nodeId;
+      if (node.parentId != null) node.parentId = prefix + node.parentId;
+      if (node.childIds) node.childIds = node.childIds.map((id) => prefix + id);
+      node._frame = playwrightFrame;
+      if (node.parentId === undefined && frameToIframeMap.has(frameId)) {
+        node._parent_iframe_backend_node_id = frameToIframeMap.get(frameId);
+      }
+      allNodes.push(node);
+    }
   }
 
   @span("driver.execute_script", spanAttrs)
@@ -452,35 +622,6 @@ export class PlaywrightDriver extends BaseDriver {
     return frameIds;
   }
 
-  private async buildFrameHierarchy(
-    frameInfo: CDPFrameInfo,
-    mainFrameId: string,
-    frameToIframeMap: Map<string, number>,
-  ): Promise<void> {
-    const frameId = frameInfo.frame.id;
-
-    if (frameId !== mainFrameId) {
-      await this.client.send("DOM.enable");
-      try {
-        const ownerInfo = await this.client.send("DOM.getFrameOwner", {
-          frameId,
-        });
-        frameToIframeMap.set(frameId, ownerInfo.backendNodeId);
-        logger.debug(
-          `Frame ${frameId.slice(0, 20)}... owned by iframe backendNodeId=${ownerInfo.backendNodeId}`,
-        );
-      } catch (error) {
-        logger.debug(
-          `Could not get frame owner for ${frameId.slice(0, 20)}...: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
-    for (const child of frameInfo.childFrames || []) {
-      await this.buildFrameHierarchy(child, mainFrameId, frameToIframeMap);
-    }
-  }
-
   private findCdpFrameIdByUrl(
     cdpFrameTree: CDPFrameTree,
     targetUrl: string,
@@ -498,6 +639,55 @@ export class PlaywrightDriver extends BaseDriver {
     };
 
     return searchFrame(cdpFrameTree.frameTree);
+  }
+
+  private async getFrameNodes(
+    frameId: string,
+    playwrightFrame: Frame,
+  ): Promise<CDPNode[]> {
+    try {
+      const response = (await this.client.send("Accessibility.getFullAXTree", {
+        frameId,
+      })) as { nodes: CDPNode[] };
+      const nodes = response.nodes || [];
+      logger.debug(
+        `  -> Frame ${frameId.slice(0, 20)}...: ${nodes.length} nodes`,
+      );
+      return nodes;
+    } catch (error) {
+      logger.debug(
+        `  -> Frame ${frameId.slice(0, 20)}...: failed (${error instanceof Error ? error.message : String(error)})`,
+      );
+      return [];
+    }
+  }
+
+  private async getOopifNodes(
+    frameId: string,
+    playwrightFrame: Frame,
+  ): Promise<CDPNode[]> {
+    try {
+      // OOPIFs run in a separate renderer process — open a per-frame CDP session
+      // scoped to that target, then call getFullAXTree without a frameId parameter.
+      const frameSession = await this.page
+        .context()
+        .newCDPSession(playwrightFrame);
+      const response = (await frameSession.send(
+        "Accessibility.getFullAXTree",
+        {},
+      )) as { nodes: CDPNode[] };
+      const nodes = response.nodes || [];
+      logger.debug(
+        `  -> OOPIF ${frameId.slice(0, 20)}...: got ${nodes.length} nodes`,
+      );
+      await frameSession.detach();
+      return nodes;
+    } catch (oopifError) {
+      logger.debug(
+        `  -> OOPIF ${frameId.slice(0, 20)}...: failed (${oopifError instanceof Error ? oopifError.message : String(oopifError)})`,
+      );
+      return [];
+    }
   }
 }
 

--- a/packages/typescript/tests/system/frames.test.ts
+++ b/packages/typescript/tests/system/frames.test.ts
@@ -26,21 +26,22 @@ describe("Frames", () => {
     expect(texts).toEqual(["LEFT", "MIDDLE", "RIGHT", "BOTTOM"]);
   });
 
-  it("cross origin iframe", async ({ expect, setup }) => {
-    const { al, $ } = await setup();
+  it("cross origin iframe", async ({ expect, setup, skip }) => {
+    const { al, $, driverId } = await setup();
+    const assert = expect.assert;
+
+    if (driverId !== "playwright")
+      skip("Frames support is only implemented for Playwright currently");
 
     await $.navigate("cross_origin_iframe.html");
 
-    await al.check("button 'Main Page Button' is present", {
-      assert: expect.assert,
-    });
-    await al.do("click button 'Click Me Inside Iframe'");
-    await al.check("text 'Button Clicked!' is present", {
-      assert: expect.assert,
-    });
-    await al.do("click link 'Iframe Link'");
-    await al.check("text 'Link Clicked!' is present", {
-      assert: expect.assert,
-    });
+    await al.check("'Main Page Button' is present", { assert });
+    await al.check("'Password' field is present", { assert });
+
+    await al.do("type 'testuser' in the text input field");
+    await al.check("Text input contains 'testuser'", { assert });
+
+    await al.do("click Submit button");
+    await al.check("'Form submitted' message is present", { assert });
   });
 });


### PR DESCRIPTION
Improves cross-origin frames support to properly handle out-of-process iframes (OOPIFs). Previously, they would be represented as empty `frame` inside the accessibility tree. The core challenge is that cross-origin iframes run in a separate Chrome renderer process and are absent from `Page.getFrameTree`, making them invisible to the main CDP session. Now, at `accessibilityTree()` call time, each driver now scans `page.frames()` for any Playwright frame not URL-matched in the same-process CDP frame tree. For each such frame, a per-frame CDP session is opened to call `Page.getFrameTree` and retrieve its root `frameId`, identifying it as an OOPIF. The `DOM.getFrameOwner` CDP command (via the main session) resolves the `<iframe>` element's `backendNodeId` so the OOPIF's root node can be stitched back into the merged tree. All frame nodes are merged into a single flat list with `nodeId/parentId/childIds` prefixed by frame index to prevent collisions across frames. When resolving an OOPIF element in `findElement`, a fresh per-frame CDP session is used instead of the main session, since the main session cannot reach `backendNodeIds` in a different renderer process.