### PR TITLE
feat(mcp): add HTTP proxy support for Playwright driver

### DIFF
--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -39,6 +39,7 @@ export namespace McpDriver {
     headless?: boolean;
     permissions?: string[];
     profileDir?: string;
+    proxy?: { server: string };
     userAgent?: string;
   }
 
@@ -79,6 +80,7 @@ export async function createPlaywrightDriver(
     headers = {},
     permissions,
     profileDir,
+    proxy,
     userAgent,
   } = driverOptions;
 
@@ -100,16 +102,19 @@ export async function createPlaywrightDriver(
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
+      ...(proxy ? { proxy } : {}),
       ...(userAgent ? { userAgent } : {}),
     });
   } else {
     const browser = await chromium.launch({
       headless,
       ...(executablePath ? { executablePath } : {}),
+      ...(proxy ? { proxy } : {}),
     });
     context = await browser.newContext({
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
+      ...(proxy ? { proxy } : {}),
       ...(userAgent ? { userAgent } : {}),
     });
   }

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -39,7 +39,12 @@ export namespace McpDriver {
     headless?: boolean;
     permissions?: string[];
     profileDir?: string;
-    proxy?: { server: string; bypass?: string; username?: string; password?: string };
+    proxy?: {
+      server: string;
+      bypass?: string;
+      username?: string;
+      password?: string;
+    };
     userAgent?: string;
   }
 

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -39,7 +39,7 @@ export namespace McpDriver {
     headless?: boolean;
     permissions?: string[];
     profileDir?: string;
-    proxy?: string;
+    proxy?: { server: string; bypass?: string; username?: string; password?: string };
     userAgent?: string;
   }
 
@@ -102,14 +102,14 @@ export async function createPlaywrightDriver(
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
-      ...(proxy ? { args: [`--proxy-server=${proxy}`] } : {}),
+      ...(proxy ? { proxy } : {}),
       ...(userAgent ? { userAgent } : {}),
     });
   } else {
     const browser = await chromium.launch({
       headless,
       ...(executablePath ? { executablePath } : {}),
-      ...(proxy ? { args: [`--proxy-server=${proxy}`] } : {}),
+      ...(proxy ? { proxy } : {}),
     });
     context = await browser.newContext({
       recordVideo: { dir: videosDir },

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -39,7 +39,7 @@ export namespace McpDriver {
     headless?: boolean;
     permissions?: string[];
     profileDir?: string;
-    proxy?: { server: string };
+    proxy?: string;
     userAgent?: string;
   }
 
@@ -102,19 +102,18 @@ export async function createPlaywrightDriver(
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
-      ...(proxy ? { proxy } : {}),
+      ...(proxy ? { args: [`--proxy-server=${proxy}`] } : {}),
       ...(userAgent ? { userAgent } : {}),
     });
   } else {
     const browser = await chromium.launch({
       headless,
       ...(executablePath ? { executablePath } : {}),
-      ...(proxy ? { proxy } : {}),
+      ...(proxy ? { args: [`--proxy-server=${proxy}`] } : {}),
     });
     context = await browser.newContext({
       recordVideo: { dir: videosDir },
       extraHTTPHeaders: headers,
-      ...(proxy ? { proxy } : {}),
       ...(userAgent ? { userAgent } : {}),
     });
   }

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -60,7 +60,7 @@ export const startMcpTool = McpTool.define("start", {
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
-            - "proxy" (string) — HTTP/HTTPS proxy server URL, Playwright only, e.g. "http://proxy.example.com:8080";
+            - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, Playwright only, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
             - "userAgent" (string) — custom User-Agent header sent with every request, Playwright only.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -176,9 +176,18 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
-      ...(typeof alumniumOptions["proxy"] === "string" && {
-        proxy: alumniumOptions["proxy"],
-      }),
+      ...(typeof alumniumOptions["proxy"] === "object" &&
+        alumniumOptions["proxy"] !== null &&
+        typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
+          "server"
+        ] === "string" && {
+          proxy: alumniumOptions["proxy"] as {
+            server: string;
+            bypass?: string;
+            username?: string;
+            password?: string;
+          },
+        }),
     };
 
     const alumniumOptionsNonDriverKeys = new Set([

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -60,7 +60,7 @@ export const startMcpTool = McpTool.define("start", {
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
-            - "proxy" (object) — HTTP/HTTPS proxy server, Playwright only, e.g. {"server": "http://proxy.example.com:8080"};
+            - "proxy" (string) — HTTP/HTTPS proxy server URL, Playwright only, e.g. "http://proxy.example.com:8080";
             - "userAgent" (string) — custom User-Agent header sent with every request, Playwright only.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -176,13 +176,9 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
-      ...(typeof alumniumOptions["proxy"] === "object" &&
-        alumniumOptions["proxy"] !== null &&
-        typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
-          "server"
-        ] === "string" && {
-          proxy: alumniumOptions["proxy"] as { server: string },
-        }),
+      ...(typeof alumniumOptions["proxy"] === "string" && {
+        proxy: alumniumOptions["proxy"],
+      }),
     };
 
     const alumniumOptionsNonDriverKeys = new Set([

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -60,6 +60,7 @@ export const startMcpTool = McpTool.define("start", {
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
+            - "proxy" (object) — HTTP/HTTPS proxy server, Playwright only, e.g. {"server": "http://proxy.example.com:8080"};
             - "userAgent" (string) — custom User-Agent header sent with every request, Playwright only.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -175,6 +176,13 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
+      ...(typeof alumniumOptions["proxy"] === "object" &&
+        alumniumOptions["proxy"] !== null &&
+        typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
+          "server"
+        ] === "string" && {
+          proxy: alumniumOptions["proxy"] as { server: string },
+        }),
     };
 
     const alumniumOptionsNonDriverKeys = new Set([
@@ -187,6 +195,7 @@ export const startMcpTool = McpTool.define("start", {
       "headless",
       "permissions",
       "planner",
+      "proxy",
       "userAgent",
     ]);
     const driverSettings: Record<string, unknown> = {};


### PR DESCRIPTION
## feat(mcp): add HTTP proxy support for Playwright driver

  - Added proxy?: { server, bypass?, username?, password? } to McpDriver.DriverOptions, matching Playwright's full native proxy spec (HTTP, HTTPS, SOCKS5)
  - Passed proxy to chromium.launch() and launchPersistentContext() in createPlaywrightDriver
  - Exposed proxy as an alumnium:options key in the MCP start tool with runtime type validation (server must be a string) and schema docs
  - Added "proxy" to alumniumOptionsNonDriverKeys to prevent it from leaking into raw driver settings

## Motivation

**Chromium ignores `HTTP_PROXY` env vars.** This is a known Chromium design
decision — it only uses a proxy if explicitly passed as `--proxy-server=<url>`
on the command line.



## Type of Change

Mark the relevant options.

- [ ] Bug fix
- [X] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)


## Checklist

Please verify the following before submitting:

- [ ] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated relevant documentation
- [ ] I have written or updated necessary tests
- [ ] I have tested the changes locally
- [ ] The changes follow the project's coding style and structure
- [ ] I have not included any sensitive or credential-related information
- [ ] I have ensured these changes maintain or improve accessibility (for UI changes)
- [ ] I have considered security implications of these changes

## Additional Notes

Anything else the reviewer should be aware of?
For example: limitations, discussions to follow up on, or next steps.
