### PR TITLE
feat(mcp): support Selenium proxy and user agent options

### DIFF
--- a/packages/typescript/src/mcp/mcpDrivers.test.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.test.ts
@@ -1,0 +1,125 @@
+import type { WebDriver } from "selenium-webdriver";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSeleniumDriver } from "./mcpDrivers.ts";
+
+const mocks = vi.hoisted(() => {
+  class MockOptions {
+    args: string[] = [];
+    excludedSwitches: string[] = [];
+    binaryPath: string | undefined;
+    capabilities: Record<string, unknown> = {};
+
+    addArguments(...args: string[]) {
+      this.args.push(...args);
+      return this;
+    }
+
+    excludeSwitches(...switches: string[]) {
+      this.excludedSwitches.push(...switches);
+      return this;
+    }
+
+    setBinaryPath(path: string) {
+      this.binaryPath = path;
+      return this;
+    }
+
+    set(key: string, value: unknown) {
+      this.capabilities[key] = value;
+      return this;
+    }
+
+    addExtensions(...extensions: (string | Buffer)[]) {
+      this.capabilities.extensions = extensions;
+      return this;
+    }
+  }
+
+  class MockBuilder {
+    browser: string | undefined;
+    chromeOptions: MockOptions | undefined;
+    serverUrl: string | undefined;
+
+    forBrowser(browser: string) {
+      this.browser = browser;
+      return this;
+    }
+
+    setChromeOptions(options: MockOptions) {
+      this.chromeOptions = options;
+      return this;
+    }
+
+    usingServer(serverUrl: string) {
+      this.serverUrl = serverUrl;
+      return this;
+    }
+
+    async build() {
+      return mockDriver;
+    }
+  }
+
+  const cdpSend = vi.fn(async () => null);
+  const mockDriver = {
+    createCDPConnection: vi.fn(async () => ({ send: cdpSend })),
+  };
+
+  return {
+    builders: [] as MockBuilder[],
+    cdpSend,
+    driver: mockDriver,
+    MockBuilder,
+    MockOptions,
+    options: [] as MockOptions[],
+  };
+});
+
+vi.mock("selenium-webdriver", () => ({
+  Builder: class extends mocks.MockBuilder {
+    constructor() {
+      super();
+      mocks.builders.push(this);
+    }
+  },
+}));
+
+vi.mock("selenium-webdriver/chrome.js", () => ({
+  Options: class extends mocks.MockOptions {
+    constructor() {
+      super();
+      mocks.options.push(this);
+    }
+  },
+}));
+
+describe("createSeleniumDriver", () => {
+  beforeEach(() => {
+    mocks.builders.length = 0;
+    mocks.options.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("passes proxy and user agent options to Chrome", async () => {
+    const driver = await createSeleniumDriver({}, null, {
+      proxy: {
+        server: "http://proxy.example:3128",
+        bypass: ".internal,localhost",
+      },
+      userAgent: "Alumnium Test Agent",
+    });
+
+    expect(driver).toBe(mocks.driver as unknown as WebDriver);
+    expect(mocks.options).toHaveLength(1);
+    expect(mocks.options[0]?.args).toEqual(
+      expect.arrayContaining([
+        "--disable-logging",
+        "--log-level=3",
+        "--proxy-server=http://proxy.example:3128",
+        "--proxy-bypass-list=.internal,localhost",
+        "--user-agent=Alumnium Test Agent",
+      ]),
+    );
+    expect(mocks.builders[0]?.chromeOptions).toBe(mocks.options[0]);
+  });
+});

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -169,6 +169,8 @@ export async function createSeleniumDriver(
     headers = {},
     headless = false,
     profileDir,
+    proxy,
+    userAgent,
   } = driverOptions;
 
   const chromeOptions = new Options();
@@ -191,6 +193,17 @@ export async function createSeleniumDriver(
 
   if (headless) {
     chromeOptions.addArguments("--headless=new");
+  }
+
+  if (proxy) {
+    chromeOptions.addArguments(`--proxy-server=${proxy.server}`);
+    if (proxy.bypass) {
+      chromeOptions.addArguments(`--proxy-bypass-list=${proxy.bypass}`);
+    }
+  }
+
+  if (userAgent) {
+    chromeOptions.addArguments(`--user-agent=${userAgent}`);
   }
 
   // Apply all capabilities to options.

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -60,8 +60,8 @@ export const startMcpTool = McpTool.define("start", {
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
-            - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, Playwright only, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
-            - "userAgent" (string) — custom User-Agent header sent with every request, Playwright only.
+            - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
+            - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
         `


### PR DESCRIPTION
## Summary
- pass `alumnium:options.proxy` through to Selenium Chrome using Chrome proxy arguments
- pass `alumnium:options.userAgent` through to Selenium Chrome using a Chrome user-agent argument
- update the MCP start-tool option description and add focused coverage for the Selenium driver factory

Closes #383
Closes #394

## Validation
- `npx vitest --project unit run src/mcp/mcpDrivers.test.ts` from `packages/typescript`
- `npx oxlint packages/typescript/src/mcp/mcpDrivers.ts packages/typescript/src/mcp/mcpDrivers.test.ts packages/typescript/src/mcp/tools/startMcpTool.ts`
- `npx oxfmt --check packages/typescript/src/mcp/mcpDrivers.ts packages/typescript/src/mcp/mcpDrivers.test.ts packages/typescript/src/mcp/tools/startMcpTool.ts`

## Note
- `npx tsc -p packages/typescript/tsconfig.json --noEmit` and `npx tsgo --build packages/typescript/tsconfig.json` currently fail in this local npm-based setup at `packages/typescript/src/server/serverApp.ts:58` (`unknown` not assignable to `CreateSessionProps`), outside this PR's changed files. The recommended local `bun`/`mise` tools are not installed in this Windows environment, so I used npm with no-save installs for the focused checks above.