### PR TITLE
feat: make video recording optional in MCP (#339)

### DIFF
--- a/packages/typescript/src/Env.ts
+++ b/packages/typescript/src/Env.ts
@@ -128,6 +128,10 @@ export const Env = {
     );
   },
 
+  get ALUMNIUM_MCP_RECORD_VIDEOS() {
+    return envVar("ALUMNIUM_MCP_RECORD_VIDEOS", z.stringbool().default(true));
+  },
+
   get ALUMNIUM_MCP_ARTIFACTS_DIR() {
     return envVar("ALUMNIUM_MCP_ARTIFACTS_DIR", pathString().optional());
   },

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -45,6 +45,7 @@ export namespace McpDriver {
       username?: string;
       password?: string;
     };
+    recordVideos?: boolean;
     userAgent?: string;
   }
 
@@ -86,6 +87,7 @@ export async function createPlaywrightDriver(
     permissions,
     profileDir,
     proxy,
+    recordVideos = Env.ALUMNIUM_MCP_RECORD_VIDEOS,
     userAgent,
   } = driverOptions;
 
@@ -98,13 +100,15 @@ export async function createPlaywrightDriver(
   }
 
   await ensurePlaywrightChromiumInstalled();
-  const videosDir = await artifactsStore.ensureDir("videos");
+  const videosDir = recordVideos
+    ? await artifactsStore.ensureDir("videos")
+    : undefined;
 
   let context: BrowserContext;
   if (profileDir) {
     context = await chromium.launchPersistentContext(profileDir, {
       headless,
-      recordVideo: { dir: videosDir },
+      ...(videosDir ? { recordVideo: { dir: videosDir } } : {}),
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
       ...(proxy ? { proxy } : {}),
@@ -117,7 +121,7 @@ export async function createPlaywrightDriver(
       ...(proxy ? { proxy } : {}),
     });
     context = await browser.newContext({
-      recordVideo: { dir: videosDir },
+      ...(videosDir ? { recordVideo: { dir: videosDir } } : {}),
       extraHTTPHeaders: headers,
       ...(userAgent ? { userAgent } : {}),
     });

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -61,6 +61,7 @@ export const startMcpTool = McpTool.define("start", {
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
             - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
+            - "recordVideos" (boolean, default true) — record video of the browser session, Playwright only. Can also be disabled via ALUMNIUM_MCP_RECORD_VIDEOS=false;
             - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -188,6 +189,9 @@ export const startMcpTool = McpTool.define("start", {
             password?: string;
           },
         }),
+      ...(typeof alumniumOptions["recordVideos"] === "boolean" && {
+        recordVideos: alumniumOptions["recordVideos"],
+      }),
     };
 
     const alumniumOptionsNonDriverKeys = new Set([
@@ -201,6 +205,7 @@ export const startMcpTool = McpTool.define("start", {
       "permissions",
       "planner",
       "proxy",
+      "recordVideos",
       "userAgent",
     ]);
     const driverSettings: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Makes video recording optional in the MCP Playwright driver. Previously, video recording was always enabled when starting a Playwright driver via MCP. This change adds an environment variable and a capability option to disable it.

## Changes

- **[Env.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/Env.ts:0:0-0:0)**: Added [ALUMNIUM_MCP_RECORD_VIDEOS](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/Env.ts:130:2-132:3) environment variable (default: `true`)
- **[mcpDrivers.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/mcp/mcpDrivers.ts:0:0-0:0)**: 
  - Added `recordVideos?: boolean` to [McpDriver.DriverOptions](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/mcp/mcpDrivers.ts:34:2-49:3) interface
  - Modified [createPlaywrightDriver](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/mcp/mcpDrivers.ts:73:0-155:1) to conditionally pass `recordVideo` based on the option or env var
- **[startMcpTool.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/mcp/tools/startMcpTool.ts:0:0-0:0)**:
  - Read `recordVideos` from `alumnium:options` capability
  - Pass through to driver options
  - Updated input schema documentation

## Usage

**Disable via environment variable:**
```bash
export ALUMNIUM_MCP_RECORD_VIDEOS=false