### PR TITLE
feat(mcp): read proxy from http_proxy env var in Playwright driver

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -86,6 +86,7 @@ url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/410690624"
 checksum = "sha256:f92d60ee4bb669b97a500f000fe053f92f7cbf0817ed4678e5b0f506d1357dd6"
 url = "https://github.com/jdx/fnox/releases/download/v1.23.1/fnox-aarch64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/jdx/fnox/releases/assets/410690610"
+provenance = "github-attestations"
 
 [tools.fnox."platforms.macos-x64"]
 checksum = "sha256:0b09405d648387a163d3f21be3e88972332d3fa04e5db55955726890a3f22877"

--- a/packages/typescript/src/mcp/mcpDrivers.test.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.test.ts
@@ -1,5 +1,5 @@
 import type { WebDriver } from "selenium-webdriver";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSeleniumDriver } from "./mcpDrivers.ts";
 
 const mocks = vi.hoisted(() => {
@@ -98,6 +98,38 @@ describe("createSeleniumDriver", () => {
     mocks.builders.length = 0;
     mocks.options.length = 0;
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env["http_proxy"];
+    delete process.env["HTTP_PROXY"];
+    delete process.env["https_proxy"];
+    delete process.env["HTTPS_PROXY"];
+  });
+
+  it("reads proxy from http_proxy env var automatically", async () => {
+    process.env["http_proxy"] = "http://envproxy.example:8080";
+
+    await createSeleniumDriver({}, null, {});
+
+    expect(mocks.options[0]?.args).toEqual(
+      expect.arrayContaining(["--proxy-server=http://envproxy.example:8080"]),
+    );
+  });
+
+  it("gives explicit proxy precedence over env var", async () => {
+    process.env["http_proxy"] = "http://envproxy.example:8080";
+
+    await createSeleniumDriver({}, null, {
+      proxy: { server: "http://explicit.example:3128" },
+    });
+
+    expect(mocks.options[0]?.args).toEqual(
+      expect.arrayContaining(["--proxy-server=http://explicit.example:3128"]),
+    );
+    expect(mocks.options[0]?.args).not.toEqual(
+      expect.arrayContaining(["--proxy-server=http://envproxy.example:8080"]),
+    );
   });
 
   it("passes proxy and user agent options to Chrome", async () => {

--- a/packages/typescript/src/mcp/mcpDrivers.test.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.test.ts
@@ -101,14 +101,11 @@ describe("createSeleniumDriver", () => {
   });
 
   afterEach(() => {
-    delete process.env["http_proxy"];
-    delete process.env["HTTP_PROXY"];
-    delete process.env["https_proxy"];
-    delete process.env["HTTPS_PROXY"];
+    vi.unstubAllEnvs();
   });
 
   it("reads proxy from http_proxy env var automatically", async () => {
-    process.env["http_proxy"] = "http://envproxy.example:8080";
+    vi.stubEnv("http_proxy", "http://envproxy.example:8080");
 
     await createSeleniumDriver({}, null, {});
 
@@ -118,7 +115,7 @@ describe("createSeleniumDriver", () => {
   });
 
   it("gives explicit proxy precedence over env var", async () => {
-    process.env["http_proxy"] = "http://envproxy.example:8080";
+    vi.stubEnv("http_proxy", "http://envproxy.example:8080");
 
     await createSeleniumDriver({}, null, {
       proxy: { server: "http://explicit.example:3128" },

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -14,6 +14,7 @@ import {
 import type { Driver } from "../drivers/Driver.ts";
 import { Env } from "../Env.ts";
 import { FileStore } from "../FileStore/FileStore.ts";
+import { proxyFromEnv } from "./proxyFromEnv.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { TypeUtils } from "../typeUtils.ts";
 
@@ -37,6 +38,7 @@ export namespace McpDriver {
     executablePath?: string;
     headers?: Headers;
     headless?: boolean;
+    httpProxy?: boolean;
     permissions?: string[];
     profileDir?: string;
     proxy?: {
@@ -84,12 +86,16 @@ export async function createPlaywrightDriver(
     executablePath,
     headless = false,
     headers = {},
+    httpProxy,
     permissions,
     profileDir,
-    proxy,
+    proxy: explicitProxy,
     recordVideos = Env.ALUMNIUM_MCP_RECORD_VIDEOS,
     userAgent,
   } = driverOptions;
+
+  const proxy =
+    explicitProxy ?? (httpProxy ? (proxyFromEnv() ?? undefined) : undefined);
 
   logger.info(
     `Creating Playwright driver (headless=${headless}, profile=${profileDir ?? "none"})`,

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -38,7 +38,6 @@ export namespace McpDriver {
     executablePath?: string;
     headers?: Headers;
     headless?: boolean;
-    httpProxy?: boolean;
     permissions?: string[];
     profileDir?: string;
     proxy?: {
@@ -86,7 +85,6 @@ export async function createPlaywrightDriver(
     executablePath,
     headless = false,
     headers = {},
-    httpProxy,
     permissions,
     profileDir,
     proxy: explicitProxy,
@@ -94,8 +92,7 @@ export async function createPlaywrightDriver(
     userAgent,
   } = driverOptions;
 
-  const proxy =
-    explicitProxy ?? (httpProxy ? (proxyFromEnv() ?? undefined) : undefined);
+  const proxy = explicitProxy ?? proxyFromEnv() ?? undefined;
 
   logger.info(
     `Creating Playwright driver (headless=${headless}, profile=${profileDir ?? "none"})`,
@@ -179,9 +176,11 @@ export async function createSeleniumDriver(
     headers = {},
     headless = false,
     profileDir,
-    proxy,
+    proxy: explicitProxy,
     userAgent,
   } = driverOptions;
+
+  const proxy = explicitProxy ?? proxyFromEnv() ?? undefined;
 
   const chromeOptions = new Options();
   // Disable verbose logging so it doesn't print to stdout and interfere with

--- a/packages/typescript/src/mcp/proxyFromEnv.test.ts
+++ b/packages/typescript/src/mcp/proxyFromEnv.test.ts
@@ -1,24 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { proxyFromEnv } from "./proxyFromEnv.ts";
 
 describe("proxyFromEnv", () => {
-  const proxyEnvVars = [
-    "http_proxy",
-    "HTTP_PROXY",
-    "https_proxy",
-    "HTTPS_PROXY",
-  ];
-
   beforeEach(() => {
-    for (const key of proxyEnvVars) {
-      delete process.env[key];
-    }
+    vi.unstubAllEnvs();
   });
 
   afterEach(() => {
-    for (const key of proxyEnvVars) {
-      delete process.env[key];
-    }
+    vi.unstubAllEnvs();
   });
 
   it("returns null when no proxy env vars are set", () => {
@@ -26,47 +15,47 @@ describe("proxyFromEnv", () => {
   });
 
   it("reads http_proxy", () => {
-    process.env["http_proxy"] = "http://proxy.example.com:3128";
+    vi.stubEnv("http_proxy", "http://proxy.example.com:3128");
     expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com:3128" });
   });
 
   it("falls back to HTTP_PROXY", () => {
-    process.env["HTTP_PROXY"] = "http://proxy.example.com:8080";
+    vi.stubEnv("HTTP_PROXY", "http://proxy.example.com:8080");
     expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com:8080" });
   });
 
   it("falls back to https_proxy when http vars absent", () => {
-    process.env["https_proxy"] = "https://proxy.example.com";
+    vi.stubEnv("https_proxy", "https://proxy.example.com");
     expect(proxyFromEnv()).toEqual({ server: "https://proxy.example.com" });
   });
 
   it("falls back to HTTPS_PROXY last", () => {
-    process.env["HTTPS_PROXY"] = "https://proxy.example.com:3128";
+    vi.stubEnv("HTTPS_PROXY", "https://proxy.example.com:3128");
     expect(proxyFromEnv()).toEqual({
       server: "https://proxy.example.com:3128",
     });
   });
 
   it("prefers http_proxy over HTTP_PROXY", () => {
-    process.env["http_proxy"] = "http://low.example.com:3128";
-    process.env["HTTP_PROXY"] = "http://upper.example.com:3128";
+    vi.stubEnv("http_proxy", "http://low.example.com:3128");
+    vi.stubEnv("HTTP_PROXY", "http://upper.example.com:3128");
     expect(proxyFromEnv()).toEqual({ server: "http://low.example.com:3128" });
   });
 
   it("omits port from server when not present in URL", () => {
-    process.env["http_proxy"] = "http://proxy.example.com";
+    vi.stubEnv("http_proxy", "http://proxy.example.com");
     expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com" });
   });
 
   it("handles socks5 proxy URLs", () => {
-    process.env["http_proxy"] = "socks5://proxy.example.com:1080";
+    vi.stubEnv("http_proxy", "socks5://proxy.example.com:1080");
     expect(proxyFromEnv()).toEqual({
       server: "socks5://proxy.example.com:1080",
     });
   });
 
   it("extracts username and password", () => {
-    process.env["http_proxy"] = "http://user:pass@proxy.example.com:3128";
+    vi.stubEnv("http_proxy", "http://user:pass@proxy.example.com:3128");
     expect(proxyFromEnv()).toEqual({
       server: "http://proxy.example.com:3128",
       username: "user",
@@ -75,8 +64,10 @@ describe("proxyFromEnv", () => {
   });
 
   it("decodes percent-encoded credentials", () => {
-    process.env["http_proxy"] =
-      "http://user%40corp:p%40ss@proxy.example.com:3128";
+    vi.stubEnv(
+      "http_proxy",
+      "http://user%40corp:p%40ss@proxy.example.com:3128",
+    );
     expect(proxyFromEnv()).toEqual({
       server: "http://proxy.example.com:3128",
       username: "user@corp",
@@ -85,14 +76,14 @@ describe("proxyFromEnv", () => {
   });
 
   it("omits username and password when not present", () => {
-    process.env["http_proxy"] = "http://proxy.example.com:3128";
+    vi.stubEnv("http_proxy", "http://proxy.example.com:3128");
     const result = proxyFromEnv();
     expect(result).not.toHaveProperty("username");
     expect(result).not.toHaveProperty("password");
   });
 
   it("returns null for an invalid URL", () => {
-    process.env["http_proxy"] = "not-a-valid-url";
+    vi.stubEnv("http_proxy", "not-a-valid-url");
     expect(proxyFromEnv()).toBeNull();
   });
 });

--- a/packages/typescript/src/mcp/proxyFromEnv.test.ts
+++ b/packages/typescript/src/mcp/proxyFromEnv.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { proxyFromEnv } from "./proxyFromEnv.ts";
+
+describe("proxyFromEnv", () => {
+  const proxyEnvVars = [
+    "http_proxy",
+    "HTTP_PROXY",
+    "https_proxy",
+    "HTTPS_PROXY",
+  ];
+
+  beforeEach(() => {
+    for (const key of proxyEnvVars) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of proxyEnvVars) {
+      delete process.env[key];
+    }
+  });
+
+  it("returns null when no proxy env vars are set", () => {
+    expect(proxyFromEnv()).toBeNull();
+  });
+
+  it("reads http_proxy", () => {
+    process.env["http_proxy"] = "http://proxy.example.com:3128";
+    expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com:3128" });
+  });
+
+  it("falls back to HTTP_PROXY", () => {
+    process.env["HTTP_PROXY"] = "http://proxy.example.com:8080";
+    expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com:8080" });
+  });
+
+  it("falls back to https_proxy when http vars absent", () => {
+    process.env["https_proxy"] = "https://proxy.example.com";
+    expect(proxyFromEnv()).toEqual({ server: "https://proxy.example.com" });
+  });
+
+  it("falls back to HTTPS_PROXY last", () => {
+    process.env["HTTPS_PROXY"] = "https://proxy.example.com:3128";
+    expect(proxyFromEnv()).toEqual({
+      server: "https://proxy.example.com:3128",
+    });
+  });
+
+  it("prefers http_proxy over HTTP_PROXY", () => {
+    process.env["http_proxy"] = "http://low.example.com:3128";
+    process.env["HTTP_PROXY"] = "http://upper.example.com:3128";
+    expect(proxyFromEnv()).toEqual({ server: "http://low.example.com:3128" });
+  });
+
+  it("omits port from server when not present in URL", () => {
+    process.env["http_proxy"] = "http://proxy.example.com";
+    expect(proxyFromEnv()).toEqual({ server: "http://proxy.example.com" });
+  });
+
+  it("handles socks5 proxy URLs", () => {
+    process.env["http_proxy"] = "socks5://proxy.example.com:1080";
+    expect(proxyFromEnv()).toEqual({
+      server: "socks5://proxy.example.com:1080",
+    });
+  });
+
+  it("extracts username and password", () => {
+    process.env["http_proxy"] = "http://user:pass@proxy.example.com:3128";
+    expect(proxyFromEnv()).toEqual({
+      server: "http://proxy.example.com:3128",
+      username: "user",
+      password: "pass",
+    });
+  });
+
+  it("decodes percent-encoded credentials", () => {
+    process.env["http_proxy"] =
+      "http://user%40corp:p%40ss@proxy.example.com:3128";
+    expect(proxyFromEnv()).toEqual({
+      server: "http://proxy.example.com:3128",
+      username: "user@corp",
+      password: "p@ss",
+    });
+  });
+
+  it("omits username and password when not present", () => {
+    process.env["http_proxy"] = "http://proxy.example.com:3128";
+    const result = proxyFromEnv();
+    expect(result).not.toHaveProperty("username");
+    expect(result).not.toHaveProperty("password");
+  });
+
+  it("returns null for an invalid URL", () => {
+    process.env["http_proxy"] = "not-a-valid-url";
+    expect(proxyFromEnv()).toBeNull();
+  });
+});

--- a/packages/typescript/src/mcp/proxyFromEnv.ts
+++ b/packages/typescript/src/mcp/proxyFromEnv.ts
@@ -1,0 +1,29 @@
+type ProxyConfig = {
+  server: string;
+  bypass?: string;
+  username?: string;
+  password?: string;
+};
+
+export function proxyFromEnv(): ProxyConfig | null {
+  // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
+  const raw =
+    process.env["http_proxy"] ??
+    // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
+    process.env["HTTP_PROXY"] ??
+    // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
+    process.env["https_proxy"] ??
+    // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
+    process.env["HTTPS_PROXY"];
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return {
+      server: url.protocol + "//" + url.host,
+      ...(url.username ? { username: decodeURIComponent(url.username) } : {}),
+      ...(url.password ? { password: decodeURIComponent(url.password) } : {}),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/typescript/src/mcp/proxyFromEnv.ts
+++ b/packages/typescript/src/mcp/proxyFromEnv.ts
@@ -8,6 +8,7 @@ type ProxyConfig = {
 export function proxyFromEnv(): ProxyConfig | null {
   // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
   const raw =
+    // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
     process.env["http_proxy"] ??
     // oxlint-disable-next-line no-process-env -- reading standard proxy env vars not managed by Env
     process.env["HTTP_PROXY"] ??

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -60,9 +60,8 @@ export const startMcpTool = McpTool.define("start", {
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
-            - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
+            - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"}; if omitted, the http_proxy/HTTP_PROXY/https_proxy/HTTPS_PROXY environment variables are used automatically;
             - "recordVideos" (boolean, default true) — record video of the browser session, Playwright only. Can also be disabled via ALUMNIUM_MCP_RECORD_VIDEOS=false;
-            - "http_proxy" (boolean) — when true, reads proxy settings from the http_proxy/HTTP_PROXY/https_proxy/HTTPS_PROXY environment variables and passes them to Playwright; ignored if "proxy" is also set;
             - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -178,9 +177,6 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
-      ...(alumniumOptions["http_proxy"] === true && {
-        httpProxy: true,
-      }),
       ...(typeof alumniumOptions["proxy"] === "object" &&
         alumniumOptions["proxy"] !== null &&
         typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
@@ -206,7 +202,6 @@ export const startMcpTool = McpTool.define("start", {
       "executablePath",
       "headers",
       "headless",
-      "http_proxy",
       "permissions",
       "planner",
       "proxy",

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -62,6 +62,7 @@ export const startMcpTool = McpTool.define("start", {
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
             - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"};
             - "recordVideos" (boolean, default true) — record video of the browser session, Playwright only. Can also be disabled via ALUMNIUM_MCP_RECORD_VIDEOS=false;
+            - "http_proxy" (boolean) — when true, reads proxy settings from the http_proxy/HTTP_PROXY/https_proxy/HTTPS_PROXY environment variables and passes them to Playwright; ignored if "proxy" is also set;
             - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
@@ -177,6 +178,9 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
+      ...(alumniumOptions["http_proxy"] === true && {
+        httpProxy: true,
+      }),
       ...(typeof alumniumOptions["proxy"] === "object" &&
         alumniumOptions["proxy"] !== null &&
         typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
@@ -202,6 +206,7 @@ export const startMcpTool = McpTool.define("start", {
       "executablePath",
       "headers",
       "headless",
+      "http_proxy",
       "permissions",
       "planner",
       "proxy",


### PR DESCRIPTION
 ## Summary

  - Both the Playwright and Selenium drivers now automatically read proxy settings from http_proxy / HTTP_PROXY / https_proxy / HTTPS_PROXY environment variables — no configuration needed. An explicit proxy object in alumnium:options still takes precedence.
  - Adds proxyFromEnv utility (proxyFromEnv.ts) that parses the env var into a structured proxy config, handling credentials and percent-encoded characters.

  ## Precedence

  1. Explicit alumnium:options.proxy object → highest priority
  2. http_proxy / HTTP_PROXY / https_proxy / HTTPS_PROXY env vars → automatic fallback
  3. No proxy → if neither is set


  ## Test plan

  - [X] `mise run //packages/typescript:types` — passes clean
  - [X] `mise run //packages/typescript:lint` — no new errors (baseline: 3w/15e)
  - [X] `mise run //packages/typescript:format/check` — passes clean
  - [X] `mise run //packages/typescript:test/unit` — 252 passing (pre-existing `mcpDrivers.test.ts` playwright-core failure unchanged)

