### PR TITLE
fix: expand Key enum and fix PressKeyTool undefined crash (#400)

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/driver/AppiumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/AppiumDriver.java
@@ -110,9 +110,14 @@ public final class AppiumDriver extends BaseDriver {
     ensureNativeContext();
     CharSequence code =
         switch (key) {
+          case ARROW_DOWN -> org.openqa.selenium.Keys.ARROW_DOWN;
+          case ARROW_LEFT -> org.openqa.selenium.Keys.ARROW_LEFT;
+          case ARROW_RIGHT -> org.openqa.selenium.Keys.ARROW_RIGHT;
+          case ARROW_UP -> org.openqa.selenium.Keys.ARROW_UP;
           case BACKSPACE -> org.openqa.selenium.Keys.BACK_SPACE;
           case ENTER -> org.openqa.selenium.Keys.ENTER;
           case ESCAPE -> org.openqa.selenium.Keys.ESCAPE;
+          case F5 -> org.openqa.selenium.Keys.F5;
           case TAB -> org.openqa.selenium.Keys.TAB;
         };
     new Actions(driver).sendKeys(code).perform();

--- a/packages/java/src/main/java/ai/alumnium/driver/Key.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/Key.java
@@ -5,9 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 /** Keyboard keys recognized by the server for {@code PressKey} tool calls. */
 public enum Key {
+  ARROW_DOWN("ArrowDown"),
+  ARROW_LEFT("ArrowLeft"),
+  ARROW_RIGHT("ArrowRight"),
+  ARROW_UP("ArrowUp"),
   BACKSPACE("Backspace"),
   ENTER("Enter"),
   ESCAPE("Escape"),
+  F5("F5"),
   TAB("Tab");
 
   private final String value;

--- a/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
@@ -171,9 +171,14 @@ public final class SeleniumDriver extends BaseDriver {
         () -> {
           CharSequence keyStroke =
               switch (key) {
+                case ARROW_DOWN -> org.openqa.selenium.Keys.ARROW_DOWN;
+                case ARROW_LEFT -> org.openqa.selenium.Keys.ARROW_LEFT;
+                case ARROW_RIGHT -> org.openqa.selenium.Keys.ARROW_RIGHT;
+                case ARROW_UP -> org.openqa.selenium.Keys.ARROW_UP;
                 case BACKSPACE -> org.openqa.selenium.Keys.BACK_SPACE;
                 case ENTER -> org.openqa.selenium.Keys.ENTER;
                 case ESCAPE -> org.openqa.selenium.Keys.ESCAPE;
+                case F5 -> org.openqa.selenium.Keys.F5;
                 case TAB -> org.openqa.selenium.Keys.TAB;
               };
           new Actions(driver).sendKeys(keyStroke).perform();

--- a/packages/python/src/alumnium/drivers/appium_driver.py
+++ b/packages/python/src/alumnium/drivers/appium_driver.py
@@ -74,12 +74,22 @@ class AppiumDriver(BaseDriver):
     def press_key(self, key: Key) -> None:
         self._ensure_native_app_context()
         keys = []
-        if key == Key.BACKSPACE:
+        if key == Key.ARROW_DOWN:
+            keys.append(Keys.ARROW_DOWN)
+        elif key == Key.ARROW_LEFT:
+            keys.append(Keys.ARROW_LEFT)
+        elif key == Key.ARROW_RIGHT:
+            keys.append(Keys.ARROW_RIGHT)
+        elif key == Key.ARROW_UP:
+            keys.append(Keys.ARROW_UP)
+        elif key == Key.BACKSPACE:
             keys.append(Keys.BACKSPACE)
         elif key == Key.ENTER:
             keys.append(Keys.ENTER)
         elif key == Key.ESCAPE:
             keys.append(Keys.ESCAPE)
+        elif key == Key.F5:
+            keys.append(Keys.F5)
         elif key == Key.TAB:
             keys.append(Keys.TAB)
 

--- a/packages/python/src/alumnium/drivers/keys.py
+++ b/packages/python/src/alumnium/drivers/keys.py
@@ -2,7 +2,12 @@ from enum import Enum
 
 
 class Key(str, Enum):
+    ARROW_DOWN = "ArrowDown"
+    ARROW_LEFT = "ArrowLeft"
+    ARROW_RIGHT = "ArrowRight"
+    ARROW_UP = "ArrowUp"
     BACKSPACE = "Backspace"
     ENTER = "Enter"
     ESCAPE = "Escape"
+    F5 = "F5"
     TAB = "Tab"

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -159,12 +159,22 @@ class SeleniumDriver(BaseDriver):
     @_autoswitch_to_new_tab
     def press_key(self, key: Key):
         keys = []
-        if key == Key.BACKSPACE:
+        if key == Key.ARROW_DOWN:
+            keys.append(Keys.ARROW_DOWN)
+        elif key == Key.ARROW_LEFT:
+            keys.append(Keys.ARROW_LEFT)
+        elif key == Key.ARROW_RIGHT:
+            keys.append(Keys.ARROW_RIGHT)
+        elif key == Key.ARROW_UP:
+            keys.append(Keys.ARROW_UP)
+        elif key == Key.BACKSPACE:
             keys.append(Keys.BACKSPACE)
         elif key == Key.ENTER:
             keys.append(Keys.ENTER)
         elif key == Key.ESCAPE:
             keys.append(Keys.ESCAPE)
+        elif key == Key.F5:
+            keys.append(Keys.F5)
         elif key == Key.TAB:
             keys.append(Keys.TAB)
 

--- a/packages/python/tests/tools/test_tool_to_schema_converter.py
+++ b/packages/python/tests/tools/test_tool_to_schema_converter.py
@@ -39,9 +39,14 @@ def test_convert_tool_with_enum():
                     "key": {
                         "type": "string",
                         "enum": [
+                            "ArrowDown",
+                            "ArrowLeft",
+                            "ArrowRight",
+                            "ArrowUp",
                             "Backspace",
                             "Enter",
                             "Escape",
+                            "F5",
                             "Tab",
                         ],
                         "description": "Key to press.",

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -98,9 +98,14 @@ export class AppiumDriver extends BaseDriver {
   async pressKey(key: Keys.Key): Promise<void> {
     await this.ensureNativeAppContext();
     const keyMap: Record<Keys.Key, string> = {
+      ArrowDown: SeleniumKey.ARROW_DOWN,
+      ArrowLeft: SeleniumKey.ARROW_LEFT,
+      ArrowRight: SeleniumKey.ARROW_RIGHT,
+      ArrowUp: SeleniumKey.ARROW_UP,
       Backspace: SeleniumKey.BACK_SPACE,
       Enter: SeleniumKey.ENTER,
       Escape: SeleniumKey.ESCAPE,
+      F5: SeleniumKey.F5,
       Tab: SeleniumKey.TAB,
     };
 

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -275,9 +275,7 @@ export class PlaywrightDriver extends BaseDriver {
 
   @span("driver.press_key", spanAttrs)
   async pressKey(key: Keys.Key): Promise<void> {
-    await this.autoswitchToNewTabAction(() =>
-      this.page.keyboard.press(key),
-    );
+    await this.autoswitchToNewTabAction(() => this.page.keyboard.press(key));
   }
 
   @span("driver.quit", spanAttrs)

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -275,15 +275,8 @@ export class PlaywrightDriver extends BaseDriver {
 
   @span("driver.press_key", spanAttrs)
   async pressKey(key: Keys.Key): Promise<void> {
-    const keyMap: Record<Keys.Key, string> = {
-      Backspace: "Backspace",
-      Enter: "Enter",
-      Escape: "Escape",
-      Tab: "Tab",
-    };
-
     await this.autoswitchToNewTabAction(() =>
-      this.page.keyboard.press(keyMap[key]),
+      this.page.keyboard.press(key),
     );
   }
 

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -217,9 +217,14 @@ export class SeleniumDriver extends BaseDriver {
   pressKey(key: Keys.Key): Promise<void> {
     return this.#autoswitchToNewTab(async () => {
       const keyMap: Record<Keys.Key, string> = {
+        ArrowDown: SeleniumKey.ARROW_DOWN,
+        ArrowLeft: SeleniumKey.ARROW_LEFT,
+        ArrowRight: SeleniumKey.ARROW_RIGHT,
+        ArrowUp: SeleniumKey.ARROW_UP,
         Backspace: SeleniumKey.BACK_SPACE,
         Enter: SeleniumKey.ENTER,
         Escape: SeleniumKey.ESCAPE,
+        F5: SeleniumKey.F5,
         Tab: SeleniumKey.TAB,
       };
 

--- a/packages/typescript/src/drivers/keys.ts
+++ b/packages/typescript/src/drivers/keys.ts
@@ -3,5 +3,15 @@ export namespace Keys {
 }
 
 export abstract class Keys {
-  static enum = ["Backspace", "Enter", "Escape", "Tab"] as const;
+  static enum = [
+    "ArrowDown",
+    "ArrowLeft",
+    "ArrowRight",
+    "ArrowUp",
+    "Backspace",
+    "Enter",
+    "Escape",
+    "F5",
+    "Tab",
+  ] as const;
 }

--- a/packages/typescript/src/tools/toolToSchemaConverter.test.ts
+++ b/packages/typescript/src/tools/toolToSchemaConverter.test.ts
@@ -44,7 +44,7 @@ describe(convertToolsToSchemas, () => {
           properties: {
             key: {
               type: "string",
-              enum: ["Backspace", "Enter", "Escape", "Tab"],
+              enum: ["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp", "Backspace", "Enter", "Escape", "F5", "Tab"],
               description: "Key to press.",
             },
           },

--- a/packages/typescript/src/tools/toolToSchemaConverter.test.ts
+++ b/packages/typescript/src/tools/toolToSchemaConverter.test.ts
@@ -44,7 +44,17 @@ describe(convertToolsToSchemas, () => {
           properties: {
             key: {
               type: "string",
-              enum: ["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp", "Backspace", "Enter", "Escape", "F5", "Tab"],
+              enum: [
+                "ArrowDown",
+                "ArrowLeft",
+                "ArrowRight",
+                "ArrowUp",
+                "Backspace",
+                "Enter",
+                "Escape",
+                "F5",
+                "Tab",
+              ],
               description: "Key to press.",
             },
           },


### PR DESCRIPTION
## Summary

Fixes #400 — [PressKeyTool](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/tools/PressKeyTool.ts:5:0-27:1) crashes with `keyboard.press: key: expected string, got undefined` when the LLM passes a key not in the keyMap (e.g. F5 for page reload).

## Root Cause

In [PlaywrightDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/PlaywrightDriver.ts:0:0-0:0), [pressKey()](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/AppiumDriver.ts:97:2-122:3) used a `keyMap` lookup that only covered 4 keys (`Backspace`, `Enter`, `Escape`, `Tab`). If the LLM emitted any other key, `keyMap[key]` returned `undefined`, which was passed directly to Playwright's `page.keyboard.press()`, causing a crash.

## Changes

- **[keys.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/keys.ts:0:0-0:0)**: Expanded `Keys.enum` with `ArrowDown`, `ArrowLeft`, `ArrowRight`, `ArrowUp`, `F5`
- **[PlaywrightDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/PlaywrightDriver.ts:0:0-0:0)**: Removed the unnecessary `keyMap` indirection — Playwright key names already match `Keys.enum` values, so `key` is passed directly. This eliminates the `undefined` crash.
- **[SeleniumDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/SeleniumDriver.ts:0:0-0:0)** / **[AppiumDriver.ts](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/typescript/src/drivers/AppiumDriver.ts:0:0-0:0)**: Expanded `keyMap` with Selenium key constants for the new keys. The `Record<Keys.Key, string>` type ensures compile-time exhaustiveness.
- **Python** ([keys.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/drivers/keys.py:0:0-0:0), [selenium_driver.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/drivers/selenium_driver.py:0:0-0:0), [appium_driver.py](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/drivers/appium_driver.py:0:0-0:0)): Expanded [Key](cci:2://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/drivers/keys.py:3:0-12:15) enum and [press_key](cci:1://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/python/src/alumnium/drivers/appium_driver.py:73:4-95:60) mappings to match
- **Java** ([Key.java](cci:7://file:///Users/satyasivasundarsalagrama/open-source/alumnium/packages/java/src/main/java/ai/alumnium/driver/Key.java:0:0-0:0)): Expanded enum to match

## Verification

- `bun types` passes
- Existing tests pass

Closes #400