### PR TITLE
Fix Java Area.get() missing null/noop check

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/Area.java
+++ b/packages/java/src/main/java/ai/alumnium/Area.java
@@ -3,6 +3,7 @@ package ai.alumnium;
 import ai.alumnium.Alumni.CheckOptions;
 import ai.alumnium.Alumni.GetOptions;
 import ai.alumnium.accessibility.BaseAccessibilityTree;
+import ai.alumnium.client.Data;
 import ai.alumnium.client.FindElementResult;
 import ai.alumnium.client.HttpClient;
 import ai.alumnium.client.HttpClient.ActionResult;
@@ -170,7 +171,11 @@ public class Area {
                   vision ? this.driver.screenshot() : null,
                   this.driver.app());
 
-          return result.result().toObject();
+          Data value = result.result();
+          if (value == null || value.isNoop()) {
+            return new Data.StringData(result.explanation());
+          }
+          return value.toObject();
         });
   }
 


### PR DESCRIPTION
# Fix Java `Area.get()` missing null/noop check

## Summary

When the server cannot extract the requested data, it returns a `NOOP` result. Java's `Area.get()` was returning `null` instead of the server's explanation string, while other implementations already handle this case correctly.

## The Bug

`Area.get()` was calling `result.result().toObject()` directly:

```java
return result.result().toObject();
```

When the server returns a `NOOP` result, `result.result()` is `Data.NoopData.INSTANCE`, and `toObject()` returns `null`. As a result, callers receive `null` instead of the explanation provided by the server.

## The Fix

Added a null/`NOOP` check before calling `toObject()`. If the result is `null` or represents a `NOOP`, the method now returns the explanation wrapped in `Data.StringData`.

### Before

```java
return result.result().toObject();
```

### After

```java
Data value = result.result();

if (value == null || value.isNoop()) {
    return new Data.StringData(result.explanation());
}

return value.toObject();
```

## Files Changed

| File | Change |
|------|--------|
| `packages/java/src/main/java/ai/alumnium/Area.java` | Added a null/`NOOP` guard in `get()` and return `new Data.StringData(result.explanation())` instead of `null`. |

## Test Plan

- Verified that existing tests continue to pass.
-  Manually verified that when the server returns a `NOOP` result, `Area.get()` returns the explanation wrapped in `Data.StringData` instead of `null`.

## Result

- Prevents `null` from being returned for `NOOP` responses.
- Returns a meaningful explanation to the caller.
- Preserves existing behavior for successful extraction requests.
- Improves consistency with the behavior of other language implementations.