### PR TITLE
Add device/viewport emulation support to the Playwright driver

### DIFF
--- a/packages/typescript/src/mcp/mcpDrivers.test.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.test.ts
@@ -176,18 +176,53 @@ describe("createPlaywrightDriver", () => {
     });
   });
 
-  it("lets an explicit viewport override the device's viewport", async () => {
+  it("passes a device descriptor object through directly", async () => {
+    await createPlaywrightDriver({}, artifactsStore, {
+      device: {
+        deviceScaleFactor: 2,
+        hasTouch: true,
+        isMobile: true,
+        userAgent: "custom-descriptor-ua",
+        viewport: { width: 360, height: 800 },
+      },
+      recordVideos: false,
+    });
+
+    expect(playwrightMocks.newContextCalls[0]).toMatchObject({
+      deviceScaleFactor: 2,
+      hasTouch: true,
+      isMobile: true,
+      userAgent: "custom-descriptor-ua",
+      viewport: { width: 360, height: 800 },
+    });
+  });
+
+  it("ignores unrecognized fields on a device descriptor object", async () => {
+    await createPlaywrightDriver({}, artifactsStore, {
+      device: {
+        viewport: { width: 360, height: 800 },
+        // Fields real Playwright device JSON carries but that aren't emulation options.
+        defaultBrowserType: "webkit",
+        screen: { width: 360, height: 800 },
+      } as never,
+      recordVideos: false,
+    });
+
+    const options = playwrightMocks.newContextCalls[0];
+    expect(options?.viewport).toEqual({ width: 360, height: 800 });
+    expect(options).not.toHaveProperty("defaultBrowserType");
+    expect(options).not.toHaveProperty("screen");
+  });
+
+  it("lets an explicit userAgent override a named device's userAgent", async () => {
     await createPlaywrightDriver({}, artifactsStore, {
       device: "Pixel 7",
       recordVideos: false,
-      viewport: { width: 360, height: 800 },
+      userAgent: "custom-ua",
     });
 
-    expect(playwrightMocks.newContextCalls[0]?.viewport).toEqual({
-      width: 360,
-      height: 800,
-    });
-    // isMobile stays device-derived — only viewport was overridden explicitly.
+    expect(playwrightMocks.newContextCalls[0]?.userAgent).toBe("custom-ua");
+    // isMobile stays device-derived — only userAgent was overridden explicitly.
     expect(playwrightMocks.newContextCalls[0]?.isMobile).toBe(true);
   });
 

--- a/packages/typescript/src/mcp/mcpDrivers.test.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.test.ts
@@ -1,6 +1,8 @@
 import type { WebDriver } from "selenium-webdriver";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createSeleniumDriver } from "./mcpDrivers.ts";
+
+import { FileStore } from "../FileStore/FileStore.ts";
+import { createPlaywrightDriver, createSeleniumDriver } from "./mcpDrivers.ts";
 
 const mocks = vi.hoisted(() => {
   class MockOptions {
@@ -92,6 +94,135 @@ vi.mock("selenium-webdriver/chrome.js", () => ({
     }
   },
 }));
+
+const playwrightMocks = vi.hoisted(() => {
+  function makeContext() {
+    return {
+      addCookies: vi.fn(async () => undefined),
+      grantPermissions: vi.fn(async () => undefined),
+      newPage: vi.fn(async () => ({})),
+      pages: vi.fn(() => []),
+      tracing: { start: vi.fn(async () => undefined) },
+    };
+  }
+
+  const newContextCalls: Record<string, unknown>[] = [];
+  const launchPersistentContextCalls: Record<string, unknown>[] = [];
+
+  const newContext = vi.fn(async (options: Record<string, unknown>) => {
+    newContextCalls.push(options);
+    return makeContext();
+  });
+
+  const launchPersistentContext = vi.fn(
+    async (_profileDir: string, options: Record<string, unknown>) => {
+      launchPersistentContextCalls.push(options);
+      return makeContext();
+    },
+  );
+
+  return {
+    devices: {
+      "Pixel 7": {
+        deviceScaleFactor: 2.625,
+        hasTouch: true,
+        isMobile: true,
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 14; Pixel 7) Chrome/148 Mobile Safari/537.36",
+        viewport: { width: 412, height: 839 },
+      },
+    } as Record<string, unknown>,
+    launch: vi.fn(async () => ({ newContext })),
+    launchPersistentContext,
+    launchPersistentContextCalls,
+    newContext,
+    newContextCalls,
+  };
+});
+
+vi.mock("playwright-core", () => ({
+  chromium: {
+    launch: playwrightMocks.launch,
+    launchPersistentContext: playwrightMocks.launchPersistentContext,
+  },
+  devices: playwrightMocks.devices,
+}));
+
+vi.mock("../standalone/installPlaywrightBrowsers.ts", () => ({
+  ensurePlaywrightChromiumInstalled: vi.fn(async () => undefined),
+}));
+
+describe("createPlaywrightDriver", () => {
+  const artifactsStore = new FileStore("test-artifacts");
+
+  beforeEach(() => {
+    playwrightMocks.newContextCalls.length = 0;
+    playwrightMocks.launchPersistentContextCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("resolves a named device into viewport/userAgent/isMobile/deviceScaleFactor/hasTouch", async () => {
+    await createPlaywrightDriver({}, artifactsStore, {
+      device: "Pixel 7",
+      recordVideos: false,
+    });
+
+    expect(playwrightMocks.newContextCalls[0]).toMatchObject({
+      deviceScaleFactor: 2.625,
+      hasTouch: true,
+      isMobile: true,
+      userAgent: expect.stringContaining("Pixel 7"),
+      viewport: { width: 412, height: 839 },
+    });
+  });
+
+  it("lets an explicit viewport override the device's viewport", async () => {
+    await createPlaywrightDriver({}, artifactsStore, {
+      device: "Pixel 7",
+      recordVideos: false,
+      viewport: { width: 360, height: 800 },
+    });
+
+    expect(playwrightMocks.newContextCalls[0]?.viewport).toEqual({
+      width: 360,
+      height: 800,
+    });
+    // isMobile stays device-derived — only viewport was overridden explicitly.
+    expect(playwrightMocks.newContextCalls[0]?.isMobile).toBe(true);
+  });
+
+  it("throws a clear error for an unknown device name", async () => {
+    await expect(
+      createPlaywrightDriver({}, artifactsStore, {
+        device: "Pixle 7",
+        recordVideos: false,
+      }),
+    ).rejects.toThrow(/Unknown device/);
+  });
+
+  it("injects no viewport-related keys when neither device nor viewport is set", async () => {
+    await createPlaywrightDriver({}, artifactsStore, { recordVideos: false });
+
+    const options = playwrightMocks.newContextCalls[0];
+    expect(options).not.toHaveProperty("viewport");
+    expect(options).not.toHaveProperty("isMobile");
+    expect(options).not.toHaveProperty("deviceScaleFactor");
+    expect(options).not.toHaveProperty("hasTouch");
+  });
+
+  it("applies device options through a persistent context profile", async () => {
+    await createPlaywrightDriver({}, artifactsStore, {
+      device: "Pixel 7",
+      profileDir: "/tmp/profile",
+      recordVideos: false,
+    });
+
+    expect(playwrightMocks.launchPersistentContextCalls[0]).toMatchObject({
+      viewport: { width: 412, height: 839 },
+      isMobile: true,
+    });
+  });
+});
 
 describe("createSeleniumDriver", () => {
   beforeEach(() => {

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -3,20 +3,21 @@
  */
 
 import type { BrowserContext, Page } from "playwright-core";
-import { chromium } from "playwright-core";
+import { chromium, devices } from "playwright-core";
 import { Builder, type WebDriver } from "selenium-webdriver";
-import { ensurePlaywrightChromiumInstalled } from "../standalone/installPlaywrightBrowsers.ts";
 import { Options } from "selenium-webdriver/chrome.js";
 import {
   remote as remoteWebdriverio,
   type Browser as WebdriverIoBrowser,
 } from "webdriverio";
+
 import type { Driver } from "../drivers/Driver.ts";
 import { Env } from "../Env.ts";
 import { FileStore } from "../FileStore/FileStore.ts";
-import { proxyFromEnv } from "./proxyFromEnv.ts";
+import { ensurePlaywrightChromiumInstalled } from "../standalone/installPlaywrightBrowsers.ts";
 import { Logger } from "../telemetry/Logger.ts";
 import { TypeUtils } from "../typeUtils.ts";
+import { proxyFromEnv } from "./proxyFromEnv.ts";
 
 const logger = Logger.get(import.meta.url);
 
@@ -35,9 +36,14 @@ export namespace McpDriver {
 
   export interface DriverOptions {
     cookies?: Cookies;
+    /** Name of a Playwright device preset (e.g. `"Pixel 7"`), resolved via `playwright-core`'s `devices` catalog. */
+    device?: string;
+    deviceScaleFactor?: number;
     executablePath?: string;
+    hasTouch?: boolean;
     headers?: Headers;
     headless?: boolean;
+    isMobile?: boolean;
     permissions?: string[];
     profileDir?: string;
     proxy?: {
@@ -48,6 +54,7 @@ export namespace McpDriver {
     };
     recordVideos?: boolean;
     userAgent?: string;
+    viewport?: { width: number; height: number };
   }
 
   export interface SeleniumCdpConnection {
@@ -89,10 +96,12 @@ export async function createPlaywrightDriver(
     profileDir,
     proxy: explicitProxy,
     recordVideos = Env.ALUMNIUM_MCP_RECORD_VIDEOS,
-    userAgent,
   } = driverOptions;
 
   const proxy = explicitProxy ?? proxyFromEnv() ?? undefined;
+  // Resolves `device`/`viewport`/`isMobile`/`deviceScaleFactor`/`hasTouch`/`userAgent` — an
+  // explicitly-set field always overrides its device-derived counterpart. Empty when unset.
+  const deviceOptions = resolveDeviceOptions(driverOptions);
 
   logger.info(
     `Creating Playwright driver (headless=${headless}, profile=${profileDir ?? "none"})`,
@@ -111,11 +120,11 @@ export async function createPlaywrightDriver(
   if (profileDir) {
     context = await chromium.launchPersistentContext(profileDir, {
       headless,
+      ...deviceOptions,
       ...(videosDir ? { recordVideo: { dir: videosDir } } : {}),
       extraHTTPHeaders: headers,
       ...(executablePath ? { executablePath } : {}),
       ...(proxy ? { proxy } : {}),
-      ...(userAgent ? { userAgent } : {}),
     });
   } else {
     const browser = await chromium.launch({
@@ -124,9 +133,9 @@ export async function createPlaywrightDriver(
       ...(proxy ? { proxy } : {}),
     });
     context = await browser.newContext({
+      ...deviceOptions,
       ...(videosDir ? { recordVideo: { dir: videosDir } } : {}),
       extraHTTPHeaders: headers,
-      ...(userAgent ? { userAgent } : {}),
     });
   }
 
@@ -326,4 +335,49 @@ export async function createAppiumDriver(
 
   logger.debug(`Appium driver for ${platform} created successfully`);
   return driver;
+}
+
+/** Playwright `BrowserContextOptions` fields that describe a device/viewport emulation profile. */
+type DeviceOptions = Pick<
+  McpDriver.DriverOptions,
+  "deviceScaleFactor" | "hasTouch" | "isMobile" | "userAgent" | "viewport"
+>;
+
+/**
+ * Resolves `driverOptions.device` (a Playwright device-catalog name, e.g. `"Pixel 7"`) into its
+ * viewport/userAgent/isMobile/deviceScaleFactor/hasTouch fields, then lets any of those fields set
+ * explicitly on `driverOptions` override the device-derived value. Returns an empty object when
+ * neither `device` nor any raw field is set, so existing desktop-viewport behavior is unchanged.
+ */
+function resolveDeviceOptions(
+  driverOptions: McpDriver.DriverOptions,
+): DeviceOptions {
+  const { device, deviceScaleFactor, hasTouch, isMobile, userAgent, viewport } =
+    driverOptions;
+
+  let resolved: DeviceOptions = {};
+  if (device !== undefined) {
+    const descriptor = devices[device];
+    if (!descriptor) {
+      throw new Error(
+        `Unknown device "${device}". See Playwright's devices catalog for supported names.`,
+      );
+    }
+    resolved = {
+      deviceScaleFactor: descriptor.deviceScaleFactor,
+      hasTouch: descriptor.hasTouch,
+      isMobile: descriptor.isMobile,
+      userAgent: descriptor.userAgent,
+      viewport: descriptor.viewport,
+    };
+  }
+
+  return {
+    ...resolved,
+    ...(deviceScaleFactor !== undefined && { deviceScaleFactor }),
+    ...(hasTouch !== undefined && { hasTouch }),
+    ...(isMobile !== undefined && { isMobile }),
+    ...(userAgent !== undefined && { userAgent }),
+    ...(viewport !== undefined && { viewport }),
+  };
 }

--- a/packages/typescript/src/mcp/mcpDrivers.ts
+++ b/packages/typescript/src/mcp/mcpDrivers.ts
@@ -34,16 +34,26 @@ export namespace McpDriver {
     [key: string]: unknown;
   }
 
+  /** A device emulation profile: viewport, user agent, and touch/mobile/scale-factor flags. */
+  export interface DeviceDescriptor {
+    deviceScaleFactor?: number;
+    hasTouch?: boolean;
+    isMobile?: boolean;
+    userAgent?: string;
+    viewport?: { width: number; height: number };
+  }
+
   export interface DriverOptions {
     cookies?: Cookies;
-    /** Name of a Playwright device preset (e.g. `"Pixel 7"`), resolved via `playwright-core`'s `devices` catalog. */
-    device?: string;
-    deviceScaleFactor?: number;
+    /**
+     * Either the name of a Playwright device preset (e.g. `"Pixel 7"`), resolved via
+     * `playwright-core`'s `devices` catalog, or a custom `DeviceDescriptor` object (e.g. pasted
+     * directly from Playwright's own device list).
+     */
+    device?: string | DeviceDescriptor;
     executablePath?: string;
-    hasTouch?: boolean;
     headers?: Headers;
     headless?: boolean;
-    isMobile?: boolean;
     permissions?: string[];
     profileDir?: string;
     proxy?: {
@@ -54,7 +64,6 @@ export namespace McpDriver {
     };
     recordVideos?: boolean;
     userAgent?: string;
-    viewport?: { width: number; height: number };
   }
 
   export interface SeleniumCdpConnection {
@@ -99,8 +108,9 @@ export async function createPlaywrightDriver(
   } = driverOptions;
 
   const proxy = explicitProxy ?? proxyFromEnv() ?? undefined;
-  // Resolves `device`/`viewport`/`isMobile`/`deviceScaleFactor`/`hasTouch`/`userAgent` — an
-  // explicitly-set field always overrides its device-derived counterpart. Empty when unset.
+  // Resolves `device` (catalog name or descriptor object) into viewport/userAgent/isMobile/
+  // deviceScaleFactor/hasTouch; an explicit `userAgent` overrides the device-derived one. Empty
+  // when unset.
   const deviceOptions = resolveDeviceOptions(driverOptions);
 
   logger.info(
@@ -338,25 +348,22 @@ export async function createAppiumDriver(
 }
 
 /** Playwright `BrowserContextOptions` fields that describe a device/viewport emulation profile. */
-type DeviceOptions = Pick<
-  McpDriver.DriverOptions,
-  "deviceScaleFactor" | "hasTouch" | "isMobile" | "userAgent" | "viewport"
->;
+type DeviceOptions = McpDriver.DeviceDescriptor;
 
 /**
- * Resolves `driverOptions.device` (a Playwright device-catalog name, e.g. `"Pixel 7"`) into its
- * viewport/userAgent/isMobile/deviceScaleFactor/hasTouch fields, then lets any of those fields set
- * explicitly on `driverOptions` override the device-derived value. Returns an empty object when
- * neither `device` nor any raw field is set, so existing desktop-viewport behavior is unchanged.
+ * Resolves `driverOptions.device` into its viewport/userAgent/isMobile/deviceScaleFactor/hasTouch
+ * fields — either by looking up a Playwright device-catalog name (e.g. `"Pixel 7"`) or by using a
+ * `DeviceDescriptor` object directly — then lets an explicit `driverOptions.userAgent` override the
+ * device-derived one. Returns an empty object when `device` is unset, so existing desktop-viewport
+ * behavior is unchanged.
  */
 function resolveDeviceOptions(
   driverOptions: McpDriver.DriverOptions,
 ): DeviceOptions {
-  const { device, deviceScaleFactor, hasTouch, isMobile, userAgent, viewport } =
-    driverOptions;
+  const { device, userAgent } = driverOptions;
 
   let resolved: DeviceOptions = {};
-  if (device !== undefined) {
+  if (typeof device === "string") {
     const descriptor = devices[device];
     if (!descriptor) {
       throw new Error(
@@ -370,14 +377,43 @@ function resolveDeviceOptions(
       userAgent: descriptor.userAgent,
       viewport: descriptor.viewport,
     };
+  } else if (device !== undefined) {
+    resolved = sanitizeDeviceDescriptor(device);
   }
 
   return {
     ...resolved,
-    ...(deviceScaleFactor !== undefined && { deviceScaleFactor }),
-    ...(hasTouch !== undefined && { hasTouch }),
-    ...(isMobile !== undefined && { isMobile }),
     ...(userAgent !== undefined && { userAgent }),
-    ...(viewport !== undefined && { viewport }),
+  };
+}
+
+/**
+ * Picks only the recognized `DeviceDescriptor` fields off an arbitrary object, so a raw Playwright
+ * device descriptor (which also carries fields like `defaultBrowserType`/`screen`) can be passed
+ * in as `driverOptions.device` as-is.
+ */
+function sanitizeDeviceDescriptor(value: object): McpDriver.DeviceDescriptor {
+  const source = value as Record<string, unknown>;
+  const viewport = source["viewport"] as Record<string, unknown> | undefined;
+
+  return {
+    ...(typeof source["userAgent"] === "string" && {
+      userAgent: source["userAgent"],
+    }),
+    ...(typeof source["deviceScaleFactor"] === "number" && {
+      deviceScaleFactor: source["deviceScaleFactor"],
+    }),
+    ...(typeof source["isMobile"] === "boolean" && {
+      isMobile: source["isMobile"],
+    }),
+    ...(typeof source["hasTouch"] === "boolean" && {
+      hasTouch: source["hasTouch"],
+    }),
+    ...(typeof viewport === "object" &&
+      viewport !== null &&
+      typeof viewport["width"] === "number" &&
+      typeof viewport["height"] === "number" && {
+        viewport: { width: viewport["width"], height: viewport["height"] },
+      }),
   };
 }

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -1,7 +1,9 @@
-import { never } from "alwaysly";
 import fs from "node:fs";
 import path from "node:path";
+
+import { never } from "alwaysly";
 import z from "zod";
+
 import { Alumni } from "../../client/Alumni.ts";
 import { NativeClient } from "../../clients/NativeClient.ts";
 import { Driver } from "../../drivers/Driver.ts";
@@ -15,13 +17,13 @@ import { ScrollTool } from "../../tools/ScrollTool.ts";
 import { SwitchToNextTabTool } from "../../tools/SwitchToNextTabTool.ts";
 import { SwitchToPreviousTabTool } from "../../tools/SwitchToPreviousTabTool.ts";
 import { McpArtifactsStore } from "../McpArtifactsStore.ts";
+import { McpProfilesStore } from "../McpProfilesStore.ts";
+import { McpState } from "../McpState.ts";
 import {
   createAppiumDriver,
   createChromeDriver,
   type McpDriver,
 } from "../mcpDrivers.ts";
-import { McpProfilesStore } from "../McpProfilesStore.ts";
-import { McpState } from "../McpState.ts";
 import { McpTool } from "./McpTool.ts";
 
 const { tracer } = Telemetry.get(import.meta.url);
@@ -51,18 +53,23 @@ export const startMcpTool = McpTool.define("start", {
             - "baseUrl" (string) — URL to navigate to automatically after driver start, e.g. "https://example.com";
             - "changeAnalysis" (boolean, default true) — enable UI changes analysis agent;
             - "cookies" (array) — cookies to set, supported for Selenium and Playwright, e.g. [{"name": "session", "value": "abc123", "domain": ".example.com"}];
+            - "device" (string) — name of a Playwright device preset, e.g. "Pixel 7", Playwright only. Expands into viewport/userAgent/isMobile/deviceScaleFactor/hasTouch; any of those set explicitly below override the device's value;
+            - "deviceScaleFactor" (number) — device pixel ratio for the emulated viewport, Playwright only;
             - "excludeAttributes" (string[]) — accessibility attributes to exclude from the tree (e.g., ["src"]);
             - "executablePath" (string) — path to a custom Chrome executable;
             - "fullPageScreenshot" (boolean, default false) — capture full-page screenshots.
+            - "hasTouch" (boolean) — whether the viewport supports touch events, Playwright only;
             - "headers" (object) — extra HTTP headers for every request, supported for Selenium and Playwright, e.g. {"Authorization": "Bearer token"};
             - "headless" (boolean, default false) — run browser headless, supported for Selenium and Playwright;
+            - "isMobile" (boolean) — whether the viewport is a mobile viewport, Playwright only;
             - "newTabTimeout" (number, default 200) — ms to wait for new tab detection, Playwright only;
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
             - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"}; if omitted, the http_proxy/HTTP_PROXY/https_proxy/HTTPS_PROXY environment variables are used automatically;
             - "recordVideos" (boolean, default true) — record video of the browser session, Playwright only. Can also be disabled via ALUMNIUM_MCP_RECORD_VIDEOS=false;
-            - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
+            - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright;
+            - "viewport" (object) — emulated viewport size, Playwright only, e.g. {"width": 360, "height": 800}.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
         `
@@ -177,6 +184,31 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
+      ...(typeof alumniumOptions["device"] === "string" && {
+        device: alumniumOptions["device"],
+      }),
+      ...(typeof alumniumOptions["isMobile"] === "boolean" && {
+        isMobile: alumniumOptions["isMobile"],
+      }),
+      ...(typeof alumniumOptions["hasTouch"] === "boolean" && {
+        hasTouch: alumniumOptions["hasTouch"],
+      }),
+      ...(typeof alumniumOptions["deviceScaleFactor"] === "number" && {
+        deviceScaleFactor: alumniumOptions["deviceScaleFactor"],
+      }),
+      ...(typeof alumniumOptions["viewport"] === "object" &&
+        alumniumOptions["viewport"] !== null &&
+        typeof (alumniumOptions["viewport"] as Record<string, unknown>)[
+          "width"
+        ] === "number" &&
+        typeof (alumniumOptions["viewport"] as Record<string, unknown>)[
+          "height"
+        ] === "number" && {
+          viewport: alumniumOptions["viewport"] as {
+            width: number;
+            height: number;
+          },
+        }),
       ...(typeof alumniumOptions["proxy"] === "object" &&
         alumniumOptions["proxy"] !== null &&
         typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
@@ -198,15 +230,20 @@ export const startMcpTool = McpTool.define("start", {
       "baseUrl",
       "changeAnalysis",
       "cookies",
+      "device",
+      "deviceScaleFactor",
       "excludeAttributes",
       "executablePath",
+      "hasTouch",
       "headers",
       "headless",
+      "isMobile",
       "permissions",
       "planner",
       "proxy",
       "recordVideos",
       "userAgent",
+      "viewport",
     ]);
     const driverSettings: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(alumniumOptions)) {

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -29,6 +29,23 @@ import { McpTool } from "./McpTool.ts";
 const { tracer } = Telemetry.get(import.meta.url);
 
 /**
+ * Parses `alumnium:options.device` into either a Playwright device-catalog name (string) or a
+ * device-descriptor object (e.g. pasted directly from Playwright's own device list). Field-level
+ * validation of the object form happens downstream in `resolveDeviceOptions`.
+ */
+function parseDeviceOption(
+  value: unknown,
+): string | McpDriver.DeviceDescriptor | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  return value as McpDriver.DeviceDescriptor;
+}
+
+/**
  * Start a new driver instance.
  */
 export const startMcpTool = McpTool.define("start", {
@@ -53,23 +70,19 @@ export const startMcpTool = McpTool.define("start", {
             - "baseUrl" (string) — URL to navigate to automatically after driver start, e.g. "https://example.com";
             - "changeAnalysis" (boolean, default true) — enable UI changes analysis agent;
             - "cookies" (array) — cookies to set, supported for Selenium and Playwright, e.g. [{"name": "session", "value": "abc123", "domain": ".example.com"}];
-            - "device" (string) — name of a Playwright device preset, e.g. "Pixel 7", Playwright only. Expands into viewport/userAgent/isMobile/deviceScaleFactor/hasTouch; any of those set explicitly below override the device's value;
-            - "deviceScaleFactor" (number) — device pixel ratio for the emulated viewport, Playwright only;
+            - "device" (string or object) — Playwright device emulation, Playwright only. Either the name of a built-in device preset, e.g. "Pixel 7", or a custom device-descriptor object with any of viewport/userAgent/deviceScaleFactor/isMobile/hasTouch, e.g. {"viewport": {"width": 600, "height": 1024}, "userAgent": "...", "deviceScaleFactor": 1, "isMobile": true, "hasTouch": true} — you can paste this straight from Playwright's own device list; unrecognized fields (e.g. "defaultBrowserType", "screen") are ignored. "userAgent" set below overrides the device's;
             - "excludeAttributes" (string[]) — accessibility attributes to exclude from the tree (e.g., ["src"]);
             - "executablePath" (string) — path to a custom Chrome executable;
             - "fullPageScreenshot" (boolean, default false) — capture full-page screenshots.
-            - "hasTouch" (boolean) — whether the viewport supports touch events, Playwright only;
             - "headers" (object) — extra HTTP headers for every request, supported for Selenium and Playwright, e.g. {"Authorization": "Bearer token"};
             - "headless" (boolean, default false) — run browser headless, supported for Selenium and Playwright;
-            - "isMobile" (boolean) — whether the viewport is a mobile viewport, Playwright only;
             - "newTabTimeout" (number, default 200) — ms to wait for new tab detection, Playwright only;
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";
             - "proxy" (object) — HTTP/HTTPS/SOCKS5 proxy, supported for Selenium and Playwright, e.g. {"server": "http://myproxy.com:3128", "bypass": ".com, chromium.org", "username": "usr", "password": "pwd"}; if omitted, the http_proxy/HTTP_PROXY/https_proxy/HTTPS_PROXY environment variables are used automatically;
             - "recordVideos" (boolean, default true) — record video of the browser session, Playwright only. Can also be disabled via ALUMNIUM_MCP_RECORD_VIDEOS=false;
-            - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright;
-            - "viewport" (object) — emulated viewport size, Playwright only, e.g. {"width": 360, "height": 800}.
+            - "userAgent" (string) — custom User-Agent header sent with every request, supported for Selenium and Playwright.
 
           Example: '{"platformName": "chrome", "alumnium:options": {"headless": true, "executablePath": "/Applications/Arc.app/Contents/MacOS/Arc", "profile": "work"}}'.
         `
@@ -162,6 +175,8 @@ export const startMcpTool = McpTool.define("start", {
     const artifactsStore = new McpArtifactsStore(id);
     const profilesStore = new McpProfilesStore();
 
+    const device = parseDeviceOption(alumniumOptions["device"]);
+
     const driverOptions: McpDriver.DriverOptions = {
       ...(alumniumOptions["headers"] !== undefined && {
         headers: alumniumOptions["headers"] as McpDriver.Headers,
@@ -184,31 +199,7 @@ export const startMcpTool = McpTool.define("start", {
       ...(typeof alumniumOptions["userAgent"] === "string" && {
         userAgent: alumniumOptions["userAgent"],
       }),
-      ...(typeof alumniumOptions["device"] === "string" && {
-        device: alumniumOptions["device"],
-      }),
-      ...(typeof alumniumOptions["isMobile"] === "boolean" && {
-        isMobile: alumniumOptions["isMobile"],
-      }),
-      ...(typeof alumniumOptions["hasTouch"] === "boolean" && {
-        hasTouch: alumniumOptions["hasTouch"],
-      }),
-      ...(typeof alumniumOptions["deviceScaleFactor"] === "number" && {
-        deviceScaleFactor: alumniumOptions["deviceScaleFactor"],
-      }),
-      ...(typeof alumniumOptions["viewport"] === "object" &&
-        alumniumOptions["viewport"] !== null &&
-        typeof (alumniumOptions["viewport"] as Record<string, unknown>)[
-          "width"
-        ] === "number" &&
-        typeof (alumniumOptions["viewport"] as Record<string, unknown>)[
-          "height"
-        ] === "number" && {
-          viewport: alumniumOptions["viewport"] as {
-            width: number;
-            height: number;
-          },
-        }),
+      ...(device !== undefined && { device }),
       ...(typeof alumniumOptions["proxy"] === "object" &&
         alumniumOptions["proxy"] !== null &&
         typeof (alumniumOptions["proxy"] as Record<string, unknown>)[
@@ -231,19 +222,15 @@ export const startMcpTool = McpTool.define("start", {
       "changeAnalysis",
       "cookies",
       "device",
-      "deviceScaleFactor",
       "excludeAttributes",
       "executablePath",
-      "hasTouch",
       "headers",
       "headless",
-      "isMobile",
       "permissions",
       "planner",
       "proxy",
       "recordVideos",
       "userAgent",
-      "viewport",
     ]);
     const driverSettings: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(alumniumOptions)) {


### PR DESCRIPTION
Summary
- The Playwright driver had no way to launch a mobile-sized viewport: DriverOptions carried no viewport/device fields, and the only fallback for unrecognized alumnium:options keys assigned directly onto the driver object — which silently no-ops for viewport, since Playwright's Page only exposes it via setViewportSize(), not a settable property.
- Added Playwright device/viewport emulation via a single "device" option in alumnium:options, which accepts either:
  - a string — a Playwright device-catalog preset name (e.g. "Pixel 7"), resolved via playwright-core's devices catalog, or
  - an object — a custom device descriptor (viewport, userAgent, deviceScaleFactor, isMobile, hasTouch) that can be pasted directly from Playwright's own device list; unrecognized fields (e.g. defaultBrowserType, screen) are silently ignored, since engine switching (webkit/firefox) is out of scope — the driver stays chromium-only.
- userAgent remains a separate top-level option (also used standalone by the Selenium driver) and, when set, overrides the device-derived user agent.
- Wired the resolved device options into both newContext() and launchPersistentContext(). Omitting device keeps today's desktop-viewport behavior unchanged.
- Documented the new device/userAgent behavior in the start MCP tool's alumnium:options capabilities schema.

Test plan
- [ ] Unit tests in mcpDrivers.test.ts cover: resolving a named device string into all 5 fields; passing a device descriptor object through directly; ignoring unrecognized fields on a device object; an explicit userAgent overriding a named device's userAgent; unknown device names throwing a clear error; no viewport-related keys injected when device is unset; and device options applied through a persistent context profile.
- [ ] mise //packages/typescript:test/unit — 259 tests passing
- [ ] mise //packages/typescript:types — clean
- [ ] mise //packages/typescript:lint — clean (pre-existing unrelated warnings only)



Mark the relevant options.

- [ ] Bug fix
- [X] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

