### PR TITLE
fix: cache accessibility trees in `do`

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/Alumni.java
+++ b/packages/java/src/main/java/ai/alumnium/Alumni.java
@@ -138,6 +138,7 @@ public final class Alumni implements AutoCloseable {
     return Retry.execute(
         () -> {
           boolean vision = opts != null && opts.vision();
+          driver.resetAccessibilityTree();
           HttpClient.RetrieveResult result =
               client.retrieve(
                   "Is the following true or false - " + statement,
@@ -162,6 +163,7 @@ public final class Alumni implements AutoCloseable {
     return Retry.execute(
         () -> {
           boolean vision = opts != null && opts.vision();
+          driver.resetAccessibilityTree();
           HttpClient.RetrieveResult result =
               client.retrieve(
                   data,
@@ -187,6 +189,7 @@ public final class Alumni implements AutoCloseable {
   public Object find(String description) {
     return Retry.execute(
         () -> {
+          driver.resetAccessibilityTree();
           FindElementResult response =
               client.findElement(description, driver.accessibilityTree().toStr(), driver.app());
           int id = response.id();
@@ -206,6 +209,7 @@ public final class Alumni implements AutoCloseable {
    *     use.
    */
   public Area area(String description) {
+    driver.resetAccessibilityTree();
     FindElementResult response =
         client.findArea(description, driver.accessibilityTree().toStr(), driver.app());
     int id = response.id();
@@ -259,6 +263,8 @@ public final class Alumni implements AutoCloseable {
     return Retry.execute(
         () -> {
           String app = driver.app();
+          // Start from a fresh snapshot; it stays cached until the next step resets it.
+          driver.resetAccessibilityTree();
           BaseAccessibilityTree initial = driver.accessibilityTree();
           String beforeTree = changeAnalysis ? initial.toStr() : null;
           String beforeUrl = changeAnalysis ? driver.url() : null;
@@ -270,7 +276,11 @@ public final class Alumni implements AutoCloseable {
           List<String> steps = plan.steps();
           for (int idx = 0; idx < steps.size(); idx++) {
             String step = steps.get(idx);
-            BaseAccessibilityTree tree = idx == 0 ? initial : driver.accessibilityTree();
+            // Use the initial tree for the first step, a fresh tree afterwards.
+            if (idx > 0) {
+              driver.resetAccessibilityTree();
+            }
+            BaseAccessibilityTree tree = driver.accessibilityTree();
             HttpClient.ActionResult action = client.executeAction(goal, step, tree.toStr(), app);
 
             if (explanation.equals(goal)) {
@@ -287,6 +297,7 @@ public final class Alumni implements AutoCloseable {
           String changes = "";
           if (changeAnalysis && !executedSteps.isEmpty()) {
             try {
+              driver.resetAccessibilityTree();
               changes =
                   client.analyzeChanges(
                       beforeTree, beforeUrl, driver.accessibilityTree().toStr(), driver.url(), app);

--- a/packages/java/src/main/java/ai/alumnium/Area.java
+++ b/packages/java/src/main/java/ai/alumnium/Area.java
@@ -64,15 +64,6 @@ public class Area {
   }
 
   /**
-   * Scope the accessibility tree to the area. Used for all client requests.
-   *
-   * @return the scoped accessibility tree
-   */
-  private BaseAccessibilityTree scopedTree() {
-    return driver.accessibilityTree().scopeToArea(id);
-  }
-
-  /**
    * Act on the area.
    *
    * @param goal the goal to act on
@@ -81,13 +72,15 @@ public class Area {
   public DoResult act(String goal) {
     return Retry.execute(
         () -> {
-          PlanResult response = client.planActions(goal, scopedTree().toStr(), driver.app());
+          driver.setAccessibilityTree(accessibilityTree);
+
+          PlanResult response = client.planActions(goal, accessibilityTree.toStr(), driver.app());
           String explanation = response.explanation();
           List<String> steps = response.steps();
           List<DoStep> executedSteps = new ArrayList<>();
           for (String step : steps) {
             ActionResult actionResult =
-                client.executeAction(goal, step, scopedTree().toStr(), driver.app());
+                client.executeAction(goal, step, accessibilityTree.toStr(), driver.app());
 
             if (explanation.equals(goal)) {
               explanation = actionResult.explanation();
@@ -127,11 +120,11 @@ public class Area {
           HttpClient.RetrieveResult result =
               client.retrieve(
                   "Is the following true or false - " + statement,
-                  scopedTree().toStr(),
-                  this.driver.title(),
-                  this.driver.url(),
-                  vision ? this.driver.screenshot() : null,
-                  this.driver.app());
+                  accessibilityTree.toStr(),
+                  driver.title(),
+                  driver.url(),
+                  vision ? driver.screenshot() : null,
+                  driver.app());
 
           if (!Boolean.TRUE.equals(result.result().boxedValue())) {
             throw new AssertionError(result.explanation());
@@ -164,11 +157,11 @@ public class Area {
           HttpClient.RetrieveResult result =
               client.retrieve(
                   data,
-                  scopedTree().toStr(),
-                  this.driver.title(),
-                  this.driver.url(),
-                  vision ? this.driver.screenshot() : null,
-                  this.driver.app());
+                  accessibilityTree.toStr(),
+                  driver.title(),
+                  driver.url(),
+                  vision ? driver.screenshot() : null,
+                  driver.app());
 
           return result.result().toObject();
         });
@@ -183,9 +176,10 @@ public class Area {
   public Object find(String description) {
     return Retry.execute(
         () -> {
+          driver.setAccessibilityTree(accessibilityTree);
           FindElementResult response =
-              client.findElement(description, scopedTree().toStr(), this.driver.app());
-          return this.driver.findElement(response.id());
+              client.findElement(description, accessibilityTree.toStr(), driver.app());
+          return driver.findElement(response.id());
         });
   }
 }

--- a/packages/java/src/main/java/ai/alumnium/driver/AppiumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/AppiumDriver.java
@@ -67,7 +67,7 @@ public final class AppiumDriver extends BaseDriver {
   }
 
   @Override
-  public BaseAccessibilityTree accessibilityTree() {
+  protected BaseAccessibilityTree fetchAccessibilityTree() {
     ensureNativeContext();
     sleep(delay);
     if (doubleFetchPageSource) {

--- a/packages/java/src/main/java/ai/alumnium/driver/BaseDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/BaseDriver.java
@@ -18,8 +18,20 @@ public abstract sealed class BaseDriver permits SeleniumDriver, PlaywrightDriver
 
   public abstract String platform();
 
-  /** Full accessibility tree snapshot for the current view. */
-  public abstract BaseAccessibilityTree accessibilityTree();
+  protected abstract BaseAccessibilityTree fetchAccessibilityTree();
+
+  private BaseAccessibilityTree cachedAccessibilityTree;
+
+  public BaseAccessibilityTree accessibilityTree() {
+    if (cachedAccessibilityTree == null) {
+      cachedAccessibilityTree = fetchAccessibilityTree();
+    }
+    return cachedAccessibilityTree;
+  }
+
+  public void resetAccessibilityTree() {
+    cachedAccessibilityTree = null;
+  }
 
   public abstract Set<Class<? extends BaseTool>> supportedTools();
 

--- a/packages/java/src/main/java/ai/alumnium/driver/BaseDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/BaseDriver.java
@@ -24,9 +24,13 @@ public abstract sealed class BaseDriver permits SeleniumDriver, PlaywrightDriver
 
   public BaseAccessibilityTree accessibilityTree() {
     if (cachedAccessibilityTree == null) {
-      cachedAccessibilityTree = fetchAccessibilityTree();
+      setAccessibilityTree(fetchAccessibilityTree());
     }
     return cachedAccessibilityTree;
+  }
+
+  public void setAccessibilityTree(BaseAccessibilityTree tree) {
+    cachedAccessibilityTree = tree;
   }
 
   public void resetAccessibilityTree() {

--- a/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
@@ -77,7 +77,7 @@ public final class PlaywrightDriver extends BaseDriver {
   }
 
   @Override
-  public ChromiumAccessibilityTree accessibilityTree() {
+  protected ChromiumAccessibilityTree fetchAccessibilityTree() {
     waitForPageToLoad();
 
     Map<String, Object> frameTreeResp = sendCdp("Page.getFrameTree", null);

--- a/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
@@ -75,7 +75,7 @@ public final class SeleniumDriver extends BaseDriver {
   }
 
   @Override
-  public ChromiumAccessibilityTree accessibilityTree() {
+  protected ChromiumAccessibilityTree fetchAccessibilityTree() {
     driver.switchTo().defaultContent();
     waitForPageToLoad();
 

--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -94,6 +94,7 @@ class Alumni:
             DoResult containing the explanation and executed steps with their actions.
         """
         app = self.driver.app
+        self.driver.reset_accessibility_tree()
         initial_accessibility_tree = self.driver.accessibility_tree
         before_tree = initial_accessibility_tree.to_str() if self.change_analysis else None
         before_url = self.driver.url if self.change_analysis else None
@@ -101,8 +102,10 @@ class Alumni:
 
         executed_steps = []
         for idx, step in enumerate(steps):
-            # If the step is the first step, use the initial accessibility tree.
-            accessibility_tree = initial_accessibility_tree if idx == 0 else self.driver.accessibility_tree
+            # Use the initial tree for the first step, a fresh tree afterwards.
+            if idx > 0:
+                self.driver.reset_accessibility_tree()
+            accessibility_tree = self.driver.accessibility_tree
             actor_explanation, actions = self.client.execute_action(goal, step, accessibility_tree.to_str(), app=app)
 
             # When planner is off, explanation is just the goal — replace with actor's reasoning.
@@ -121,6 +124,7 @@ class Alumni:
             try:
                 assert before_tree is not None
                 assert before_url is not None
+                self.driver.reset_accessibility_tree()
                 changes = self.client.analyze_changes(
                     before_accessibility_tree=before_tree,
                     before_url=before_url,
@@ -147,6 +151,7 @@ class Alumni:
         Raises:
             AssertionError: If the verification fails.
         """
+        self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             f"Is the following true or false - {statement}",
             self.driver.accessibility_tree.to_str(),
@@ -170,6 +175,7 @@ class Alumni:
         Returns:
             The extracted data. If data cannot be extracted, returns the explanation string.
         """
+        self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             data,
             self.driver.accessibility_tree.to_str(),
@@ -191,6 +197,7 @@ class Alumni:
         Returns:
             Native driver element (Selenium WebElement, Playwright Locator, or Appium WebElement).
         """
+        self.driver.reset_accessibility_tree()
         response = self.client.find_element(description, self.driver.accessibility_tree.to_str(), app=self.driver.app)
         return self.driver.find_element(response["id"])
 
@@ -208,6 +215,7 @@ class Alumni:
         Returns:
             Area: An instance of the Area class that represents the area of the accessibility tree to use.
         """
+        self.driver.reset_accessibility_tree()
         accessibility_tree = self.driver.accessibility_tree
         response = self.client.find_area(description, accessibility_tree.to_str(), app=self.driver.app)
         return Area(

--- a/packages/python/src/alumnium/area.py
+++ b/packages/python/src/alumnium/area.py
@@ -41,6 +41,8 @@ class Area:
         Returns:
             DoResult containing the explanation and executed steps with their actions.
         """
+        self.driver.set_accessibility_tree(self.accessibility_tree)
+
         explanation, steps = self.client.plan_actions(goal, self.accessibility_tree.to_str(), app=self.driver.app)
 
         executed_steps = []
@@ -121,5 +123,6 @@ class Area:
         Returns:
             Native driver element (Selenium WebElement, Playwright Locator, or Appium WebElement).
         """
+        self.driver.set_accessibility_tree(self.accessibility_tree)
         response = self.client.find_element(description, self.accessibility_tree.to_str(), app=self.driver.app)
         return self.driver.find_element(response["id"])

--- a/packages/python/src/alumnium/drivers/appium_driver.py
+++ b/packages/python/src/alumnium/drivers/appium_driver.py
@@ -40,8 +40,7 @@ class AppiumDriver(BaseDriver):
         else:
             self.platform = "xcuitest"
 
-    @property
-    def accessibility_tree(self) -> XCUITestAccessibilityTree | UIAutomator2AccessibilityTree:
+    def _fetch_accessibility_tree(self) -> XCUITestAccessibilityTree | UIAutomator2AccessibilityTree:
         self._ensure_native_app_context()
         sleep(self.delay)
         # Hacky workaround for cloud providers reporting stale page source.

--- a/packages/python/src/alumnium/drivers/base_driver.py
+++ b/packages/python/src/alumnium/drivers/base_driver.py
@@ -11,8 +11,11 @@ class BaseDriver(ABC):
         cached = getattr(self, "_cached_accessibility_tree", None)
         if cached is None:
             cached = self._fetch_accessibility_tree()
-            self._cached_accessibility_tree = cached
+            self.set_accessibility_tree(cached)
         return cached
+
+    def set_accessibility_tree(self, tree: BaseAccessibilityTree):
+        self._cached_accessibility_tree = tree
 
     def reset_accessibility_tree(self):
         self._cached_accessibility_tree = None

--- a/packages/python/src/alumnium/drivers/base_driver.py
+++ b/packages/python/src/alumnium/drivers/base_driver.py
@@ -7,8 +7,18 @@ from .keys import Key
 
 class BaseDriver(ABC):
     @property
-    @abstractmethod
     def accessibility_tree(self) -> BaseAccessibilityTree:
+        cached = getattr(self, "_cached_accessibility_tree", None)
+        if cached is None:
+            cached = self._fetch_accessibility_tree()
+            self._cached_accessibility_tree = cached
+        return cached
+
+    def reset_accessibility_tree(self):
+        self._cached_accessibility_tree = None
+
+    @abstractmethod
+    def _fetch_accessibility_tree(self) -> BaseAccessibilityTree:
         pass
 
     @abstractmethod

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -44,9 +44,15 @@ class PlaywrightAsyncDriver(BaseDriver):
     def platform(self) -> str:
         return "chromium"
 
-    @property
-    def accessibility_tree(self) -> ChromiumAccessibilityTree:
+    def _fetch_accessibility_tree(self) -> ChromiumAccessibilityTree:
         return self._run_async(self._accessibility_tree)
+
+    async def _cached_or_fetched_accessibility_tree(self) -> ChromiumAccessibilityTree:
+        cached = getattr(self, "_cached_accessibility_tree", None)
+        if cached is None:
+            cached = await self._accessibility_tree
+            self._cached_accessibility_tree = cached
+        return cached
 
     @property
     async def _accessibility_tree(self) -> ChromiumAccessibilityTree:
@@ -195,7 +201,7 @@ class PlaywrightAsyncDriver(BaseDriver):
         return self._run_async(self._find_element(id))
 
     async def _find_element(self, id: int) -> Locator:
-        accessibility_tree = await self._accessibility_tree
+        accessibility_tree = await self._cached_or_fetched_accessibility_tree()
         accessibility_element = accessibility_tree.element_by_id(id)
         frame = accessibility_element.frame or self.page.main_frame
 

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -54,8 +54,7 @@ class PlaywrightDriver(BaseDriver):
     def platform(self) -> str:
         return "chromium"
 
-    @property
-    def accessibility_tree(self) -> ChromiumAccessibilityTree:
+    def _fetch_accessibility_tree(self) -> ChromiumAccessibilityTree:
         self._wait_for_page_to_load()
 
         frame_tree = self._send_cdp_command("Page.getFrameTree")

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -53,8 +53,7 @@ class SeleniumDriver(BaseDriver):
     def platform(self) -> str:
         return "chromium"
 
-    @property
-    def accessibility_tree(self) -> ChromiumAccessibilityTree:
+    def _fetch_accessibility_tree(self) -> ChromiumAccessibilityTree:
         # Switch to default content to ensure we're at the top level for frame enumeration
         self.driver.switch_to.default_content()
         self._wait_for_page_to_load()

--- a/packages/typescript/src/client/Alumni.ts
+++ b/packages/typescript/src/client/Alumni.ts
@@ -150,6 +150,7 @@ export class Alumni {
     return retry(async () => {
       const app = await this.driver.app();
 
+      this.driver.resetAccessibilityTree();
       const initialAccessibilityTree = await this.driver.getAccessibilityTree();
       const beforeTree = this.changeAnalysis
         ? initialAccessibilityTree.toStr()
@@ -167,11 +168,9 @@ export class Alumni {
         const step = steps[idx];
         always(step);
 
-        // Use initial tree for first step, fresh tree for subsequent steps
-        const accessibilityTree =
-          idx === 0
-            ? initialAccessibilityTree
-            : await this.driver.getAccessibilityTree();
+        // Use initial tree for first step, fresh tree for subsequent steps.
+        if (idx > 0) this.driver.resetAccessibilityTree();
+        const accessibilityTree = await this.driver.getAccessibilityTree();
         const { explanation: actorExplanation, actions } =
           await this.client.executeAction({
             goal,
@@ -200,6 +199,7 @@ export class Alumni {
 
       let changes = "";
       if (this.changeAnalysis && executedSteps.length > 0) {
+        this.driver.resetAccessibilityTree();
         changes = await this.client.analyzeChanges({
           beforeAccessibilityTree: beforeTree!,
           beforeUrl: beforeUrl!,
@@ -231,6 +231,7 @@ export class Alumni {
       const screenshot = options.vision
         ? await this.driver.screenshot()
         : undefined;
+      this.driver.resetAccessibilityTree();
       const accessibilityTree = await this.driver.getAccessibilityTree();
       const [explanation, value] = await this.client.retrieve({
         statement: `Is the following true or false - ${statement}`,
@@ -263,6 +264,7 @@ export class Alumni {
       const screenshot = options.vision
         ? await this.driver.screenshot()
         : undefined;
+      this.driver.resetAccessibilityTree();
       const accessibilityTree = await this.driver.getAccessibilityTree();
       const [explanation, value] = await this.client.retrieve({
         statement: data,
@@ -280,6 +282,7 @@ export class Alumni {
   @span("alumni.find", spanAttrs)
   async find(description: string): Promise<Element | undefined> {
     return retry(async () => {
+      this.driver.resetAccessibilityTree();
       const accessibilityTree = await this.driver.getAccessibilityTree();
       const response = await this.client.findElement({
         description,
@@ -293,6 +296,7 @@ export class Alumni {
 
   @span("alumni.area", spanAttrs)
   async area(description: string): Promise<Area> {
+    this.driver.resetAccessibilityTree();
     const accessibilityTree = await this.driver.getAccessibilityTree();
     const response = await this.client.findArea({
       description,

--- a/packages/typescript/src/client/Area.ts
+++ b/packages/typescript/src/client/Area.ts
@@ -41,6 +41,7 @@ export class Area {
   async do(goal: string): Promise<DoResult> {
     return retry(async () => {
       const app = await this.driver.app();
+      this.driver.setAccessibilityTree(this.accessibilityTree);
 
       const { explanation, steps } = await this.client.planActions({
         goal,
@@ -139,6 +140,7 @@ export class Area {
   @span("alumni.find", spanAttrs)
   async find(description: string): Promise<Element | undefined> {
     return retry(async () => {
+      this.driver.setAccessibilityTree(this.accessibilityTree);
       const response = await this.client.findElement({
         description,
         accessibilityTree: this.accessibilityTree.toStr(),

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -53,7 +53,7 @@ export class AppiumDriver extends BaseDriver {
   }
 
   @span("driver.get_accessibility_tree", spanAttrs)
-  async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
+  protected async fetchAccessibilityTree(): Promise<BaseAccessibilityTree> {
     await this.ensureNativeAppContext();
     if (this.delay > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.delay * 1000));

--- a/packages/typescript/src/drivers/BaseDriver.ts
+++ b/packages/typescript/src/drivers/BaseDriver.ts
@@ -17,6 +17,10 @@ export abstract class BaseDriver {
     return this.#cachedAccessibilityTree;
   }
 
+  setAccessibilityTree(tree: BaseAccessibilityTree) {
+    this.#cachedAccessibilityTree = tree;
+  }
+
   resetAccessibilityTree() {
     this.#cachedAccessibilityTree = null;
   }

--- a/packages/typescript/src/drivers/BaseDriver.ts
+++ b/packages/typescript/src/drivers/BaseDriver.ts
@@ -8,7 +8,19 @@ import type { Keys } from "./keys.ts";
 export abstract class BaseDriver {
   abstract platform: Driver.Platform;
   abstract supportedTools: Set<ToolClass>;
-  abstract getAccessibilityTree(): Promise<BaseAccessibilityTree>;
+  protected abstract fetchAccessibilityTree(): Promise<BaseAccessibilityTree>;
+
+  #cachedAccessibilityTree: BaseAccessibilityTree | null = null;
+
+  async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
+    this.#cachedAccessibilityTree ??= await this.fetchAccessibilityTree();
+    return this.#cachedAccessibilityTree;
+  }
+
+  resetAccessibilityTree() {
+    this.#cachedAccessibilityTree = null;
+  }
+
   abstract click(id: number): Promise<void>;
   abstract dragSlider(id: number, value: number): void | Promise<void>;
   abstract dragAndDrop(fromId: number, toId: number): Promise<void>;

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -183,7 +183,7 @@ export class PlaywrightDriver extends BaseDriver {
   }
 
   @span("driver.get_accessibility_tree", spanAttrs)
-  async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
+  protected async fetchAccessibilityTree(): Promise<BaseAccessibilityTree> {
     await this.waitForPageToLoad();
 
     const frameTree = (await this.client.send(

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -92,7 +92,7 @@ export class SeleniumDriver extends BaseDriver {
   }
 
   @span("driver.get_accessibility_tree", spanAttrs)
-  async getAccessibilityTree(): Promise<BaseAccessibilityTree> {
+  protected async fetchAccessibilityTree(): Promise<BaseAccessibilityTree> {
     // Switch to default content to ensure we're at the top level for frame enumeration
     await this.driver.switchTo().defaultContent();
     logger.debug("Waiting for page to load before getting accessibility tree");

--- a/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/fetchAccessibilityTreeMcpTool.ts
@@ -25,6 +25,7 @@ export const fetchAccessibilityTreeMcpTool = McpTool.define(
       // as if it's processed by Alumnium server
       const client = al.client;
       always(client instanceof NativeClient);
+      al.driver.resetAccessibilityTree();
       const tree = client.session.parseTree(
         (await al.driver.getAccessibilityTree()).toStr(),
       );


### PR DESCRIPTION
Element IDs given to the LLM are positional, so they're only valid against the exact tree snapshot they came from. Previously, the tree was re-fetched every time a tool resolved an ID, so any UI change between planning, acting, and finding an element could shift the numbering, and the action would hit the wrong element. This happened in all `do` calls, including `Alumni` and `Area`.

This PR caches the tree per step and refreshes it only between steps, so the same snapshot is used across planning/acting and finding an element.