### PR TITLE
fix(trees): several tree fixes

### DIFF
--- a/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
@@ -150,7 +150,7 @@ export abstract class BaseServerAccessibilityTree {
     const xmlRoots: Xml.Tag[] = [];
 
     for (const root of roots) {
-      const xmlRoot = this.#treeNodeToXmlTag(root, null, options);
+      const xmlRoot = this.#treeNodeToXmlTag(root, null, null, options);
       if (!xmlRoot) continue;
 
       xmlRoots.push(xmlRoot);
@@ -163,13 +163,14 @@ export abstract class BaseServerAccessibilityTree {
 
       this.pruneBackendRedundantNodes(xmlRoot);
       this.#trimGenericChildren(xmlRoot);
-      this.#preserveTextAtTrimmingBorders(xmlRoot);
     }
 
-    return XmlRenderer.render(xmlRoots);
+    return XmlRenderer.render(xmlRoots, {
+      tagAliases: Object.fromEntries(
+        Array.from(this.genericRoles, (role) => [role, "div"]),
+      ),
+    });
   }
-
-  #commonGenericRole = "div";
 
   protected genericRoles = new Set(["generic"]);
 
@@ -182,6 +183,8 @@ export abstract class BaseServerAccessibilityTree {
   protected preserveNameRoles = new Set<string>();
 
   protected trimmingBorderRoles = new Set<string>();
+
+  protected trimmingBorderChildRoles = new Set<string>();
 
   protected deduplicateAttrs = new Set<string>();
 
@@ -197,8 +200,8 @@ export abstract class BaseServerAccessibilityTree {
 
   protected pruneBackendRedundantNodes(_xmlTag: Xml.Tag): void {}
 
-  #isGenericRole(role: string): boolean {
-    return role === this.#commonGenericRole || this.genericRoles.has(role);
+  protected isGenericRole(role: string): boolean {
+    return this.genericRoles.has(role);
   }
 
   protected genericAttrs = new Set(["id"]);
@@ -223,6 +226,7 @@ export abstract class BaseServerAccessibilityTree {
   #treeNodeToXmlTag(
     node: Tree.Node,
     xmlParent: Xml.Tag | null,
+    trimmingBorder: Xml.Tag | null,
     options: BaseServerAccessibilityTree.TreeToXmlOptions,
   ): Xml.Tag | null {
     const { role, name = "", children } = node;
@@ -240,9 +244,8 @@ export abstract class BaseServerAccessibilityTree {
       return null;
     }
 
-    const isGeneric = this.#isGenericRole(role);
-    const tag = isGeneric ? this.#commonGenericRole : role;
-    const xmlTag = Xml.tag(tag);
+    const isGeneric = this.isGenericRole(role);
+    const xmlTag = Xml.tag(role);
 
     if (!excludeAttrs.has("name") && name) xmlTag.attribs.name = name;
 
@@ -254,8 +257,13 @@ export abstract class BaseServerAccessibilityTree {
 
     this.#removeDuplicateAttrs(xmlTag);
 
+    const childTrimmingBorder = this.trimmingBorderRoles.has(xmlTag.tagName)
+      ? xmlTag
+      : isGeneric && children.length === 1
+        ? trimmingBorder
+        : null;
     for (const child of children)
-      this.#treeNodeToXmlTag(child, xmlTag, options);
+      this.#treeNodeToXmlTag(child, xmlTag, childTrimmingBorder, options);
 
     const textContentAttr = this.textContentAttr(role);
     const textContentValue = textContentAttr
@@ -280,7 +288,8 @@ export abstract class BaseServerAccessibilityTree {
       if (
         xmlTag.children.length === 1 &&
         !hasNonGenericAttrs &&
-        !this.#textPromotedTags.has(xmlTag)
+        !this.#textPromotedTags.has(xmlTag) &&
+        !this.#isTextOnlyTrimmingBorderChild(xmlTag, trimmingBorder)
       ) {
         const child = xmlTag.children[0];
         always(child);
@@ -293,25 +302,18 @@ export abstract class BaseServerAccessibilityTree {
     return null;
   }
 
-  #preserveTextAtTrimmingBorders(xmlTag: Xml.Tag): void {
-    for (const child of xmlTag.children) {
-      const childTag = Xml.nodeAsTag(child);
-      if (childTag) this.#preserveTextAtTrimmingBorders(childTag);
-    }
-
-    if (!this.trimmingBorderRoles.has(xmlTag.tagName)) return;
-    if (xmlTag.children.length !== 1) return;
-
+  #isTextOnlyTrimmingBorderChild(
+    xmlTag: Xml.Tag,
+    trimmingBorder: Xml.Tag | null,
+  ): boolean {
     const child = xmlTag.children[0];
-    const text = child && Xml.nodeAsText(child);
-    if (!text) return;
-
-    const sourceId = this.#sourceIdsByRenderedNode.get(child);
-    if (!sourceId) return;
-
-    xmlTag.children = [
-      Xml.tag(this.#commonGenericRole, { id: String(sourceId) }, [text]),
-    ];
+    return (
+      !!trimmingBorder &&
+      this.trimmingBorderChildRoles.has(xmlTag.tagName) &&
+      xmlTag.children.length === 1 &&
+      !!child &&
+      !!Xml.nodeAsText(child)
+    );
   }
 
   #trimGenericChildren(xmlParent: Xml.Tag): void {
@@ -322,7 +324,7 @@ export abstract class BaseServerAccessibilityTree {
       this.#trimGenericChildren(xmlTag);
       if (this.shouldTrimEmptyNode(xmlTag)) return false;
       return !(
-        this.#isGenericRole(xmlTag.tagName) &&
+        this.isGenericRole(xmlTag.tagName) &&
         this.shouldTrimEmptyGeneric(xmlTag)
       );
     });
@@ -331,7 +333,12 @@ export abstract class BaseServerAccessibilityTree {
       const xmlTag = Xml.nodeAsTag(xmlChild);
       if (!xmlTag) return [xmlChild];
 
-      if (!this.#isGenericRole(xmlTag.tagName)) return [xmlTag];
+      if (!this.isGenericRole(xmlTag.tagName)) return [xmlTag];
+      const trimmingBorder = this.trimmingBorderRoles.has(xmlParent.tagName)
+        ? xmlParent
+        : null;
+      if (this.#isTextOnlyTrimmingBorderChild(xmlTag, trimmingBorder))
+        return [xmlTag];
 
       const hasTextChild = xmlTag.children.some((child) =>
         Xml.nodeAsText(child),
@@ -368,7 +375,7 @@ export abstract class BaseServerAccessibilityTree {
 
       const id = this.#sourceIdsByRenderedNode.get(child);
       if (!id) return [child];
-      return [Xml.tag(this.#commonGenericRole, { id: String(id) }, [text])];
+      return [Xml.tag("generic", { id: String(id) }, [text])];
     });
   }
 

--- a/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
@@ -163,6 +163,7 @@ export abstract class BaseServerAccessibilityTree {
 
       this.pruneBackendRedundantNodes(xmlRoot);
       this.#trimGenericChildren(xmlRoot);
+      this.#preserveTextAtTrimmingBorders(xmlRoot);
     }
 
     return XmlRenderer.render(xmlRoots);
@@ -179,6 +180,8 @@ export abstract class BaseServerAccessibilityTree {
   protected redundantTextAttrs = new Set(["name", "label"]);
 
   protected preserveNameRoles = new Set<string>();
+
+  protected trimmingBorderRoles = new Set<string>();
 
   protected deduplicateAttrs = new Set<string>();
 
@@ -288,6 +291,27 @@ export abstract class BaseServerAccessibilityTree {
 
     xmlParent.children.push(xmlTag);
     return null;
+  }
+
+  #preserveTextAtTrimmingBorders(xmlTag: Xml.Tag): void {
+    for (const child of xmlTag.children) {
+      const childTag = Xml.nodeAsTag(child);
+      if (childTag) this.#preserveTextAtTrimmingBorders(childTag);
+    }
+
+    if (!this.trimmingBorderRoles.has(xmlTag.tagName)) return;
+    if (xmlTag.children.length !== 1) return;
+
+    const child = xmlTag.children[0];
+    const text = child && Xml.nodeAsText(child);
+    if (!text) return;
+
+    const sourceId = this.#sourceIdsByRenderedNode.get(child);
+    if (!sourceId) return;
+
+    xmlTag.children = [
+      Xml.tag(this.#commonGenericRole, { id: String(sourceId) }, [text]),
+    ];
   }
 
   #trimGenericChildren(xmlParent: Xml.Tag): void {

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -13,12 +13,12 @@ describe(ServerChromiumAccessibilityTree, () => {
       const tree = await basicChromiumTree();
 
       expect(tree.toXml()).toMatchInlineSnapshot(`
-        "<RootWebArea name="TodoMVC: React" id=1>
+        "<RootWebArea name="TodoMVC: React" id=1 focusable>
           <div id=4>
             <div id=5>
               <heading id=6 level=1>todos</heading>
               <div id=8>
-                <textbox name="New Todo Input" id=9 editable="plaintext">
+                <textbox name="New Todo Input" id=9 focusable editable="plaintext" settable>
                   <div id=11 editable="plaintext"/>
                 </textbox>
                 <LabelText id=12>New Todo Input</LabelText>
@@ -26,7 +26,7 @@ describe(ServerChromiumAccessibilityTree, () => {
             </div>
             <main id=14>
               <div id=15>
-                <checkbox id=16/>
+                <checkbox id=16 focusable/>
                 <LabelText id=17>
                   <div id=19>\\u276f</div>
                   <div id=20>Toggle All Input</div>
@@ -34,11 +34,11 @@ describe(ServerChromiumAccessibilityTree, () => {
               </div>
               <list id=21>
                 <listitem id=22 level=1>
-                  <checkbox id=24/>
+                  <checkbox id=24 focusable focused checked/>
                   <LabelText id=25>hello</LabelText>
                 </listitem>
                 <listitem id=27 level=1>
-                  <checkbox id=29/>
+                  <checkbox id=29 focusable/>
                   <LabelText id=30>he</LabelText>
                 </listitem>
               </list>
@@ -47,16 +47,16 @@ describe(ServerChromiumAccessibilityTree, () => {
               1 item left!
               <list id=35>
                 <listitem id=36 level=1>
-                  <link id=37>All</link>
+                  <link id=37 focusable>All</link>
                 </listitem>
                 <listitem id=39 level=1>
-                  <link id=40>Active</link>
+                  <link id=40 focusable>Active</link>
                 </listitem>
                 <listitem id=42 level=1>
-                  <link id=43>Completed</link>
+                  <link id=43 focusable>Completed</link>
                 </listitem>
               </list>
-              <button id=45>Clear completed</button>
+              <button id=45 focusable>Clear completed</button>
             </div>
           </div>
           <contentinfo id=47>
@@ -64,7 +64,7 @@ describe(ServerChromiumAccessibilityTree, () => {
             <paragraph id=50>Created by the TodoMVC Team</paragraph>
             <paragraph id=52>
               Part of
-              <link id=54>TodoMVC</link>
+              <link id=54 focusable>TodoMVC</link>
             </paragraph>
           </contentinfo>
         </RootWebArea>"
@@ -103,6 +103,71 @@ describe(ServerChromiumAccessibilityTree, () => {
           1.2K views
           <div id=7>10 months ago</div>
         </group>"
+      `);
+    });
+
+    it("preserves checkbox checked attribute", () => {
+      const rawXml = lit`
+        <main raw_id=40 backendDOMNodeId=32 nodeId="f0:32">
+          <generic raw_id=41 backendDOMNodeId=33 nodeId="f0:33">
+            <checkbox raw_id=42 backendDOMNodeId=34 nodeId="f0:34" name="❯ Toggle All Input" focusable focused checked/>
+            <none raw_id=43 backendDOMNodeId=35 nodeId="f0:35" ignored>
+              <generic raw_id=44 backendDOMNodeId=84 nodeId="f0:84">
+                <StaticText raw_id=45 nodeId="f0:-1000000047" name="❯">
+                  <InlineTextBox raw_id=46 nodeId="f0:-1000000048" name="❯"/>
+                </StaticText>
+              </generic>
+              <StaticText raw_id=47 backendDOMNodeId=61 nodeId="f0:61" name="Toggle All Input">
+                <InlineTextBox raw_id=48 nodeId="f0:-1000000049" name="Toggle All Input"/>
+              </StaticText>
+            </none>
+          </generic>
+          <list raw_id=49 backendDOMNodeId=36 nodeId="f0:36">
+            <listitem raw_id=50 backendDOMNodeId=82 nodeId="f0:82" level=1>
+              <none raw_id=51 backendDOMNodeId=81 nodeId="f0:81" ignored>
+                <checkbox raw_id=52 backendDOMNodeId=78 nodeId="f0:78" focusable checked/>
+                <LabelText raw_id=53 backendDOMNodeId=79 nodeId="f0:79">
+                  <StaticText raw_id=54 backendDOMNodeId=88 nodeId="f0:88" name="Buy milk">
+                    <InlineTextBox raw_id=55 nodeId="f0:-1000000033" name="Buy milk"/>
+                  </StaticText>
+                </LabelText>
+              </none>
+            </listitem>
+            <listitem raw_id=56 backendDOMNodeId=96 nodeId="f0:96" level=1>
+              <none raw_id=57 backendDOMNodeId=95 nodeId="f0:95" ignored>
+                <checkbox raw_id=58 backendDOMNodeId=92 nodeId="f0:92" focusable checked/>
+                <LabelText raw_id=59 backendDOMNodeId=93 nodeId="f0:93">
+                  <StaticText raw_id=60 backendDOMNodeId=99 nodeId="f0:99" name="Buy bread">
+                    <InlineTextBox raw_id=61 nodeId="f0:-1000000044" name="Buy bread"/>
+                  </StaticText>
+                </LabelText>
+              </none>
+            </listitem>
+          </list>
+        </main>
+      `;
+      const tree = new ServerChromiumAccessibilityTree(rawXml);
+
+      expect(tree.toXml()).toMatchInlineSnapshot(`
+        "<main id=1>
+          <div id=2>
+            <checkbox name="❯ Toggle All Input" id=3 focusable focused checked/>
+            <div id=4>
+              <div id=6>❯</div>
+              <div id=8>Toggle All Input</div>
+            </div>
+          </div>
+          <list id=10>
+            <listitem id=11 level=1>
+              <checkbox id=13 focusable checked/>
+              <LabelText id=14>Buy milk</LabelText>
+            </listitem>
+            <listitem id=17 level=1>
+              <checkbox id=19 focusable checked/>
+              <LabelText id=20>Buy bread</LabelText>
+            </listitem>
+          </list>
+        </main>"
       `);
     });
 

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -189,7 +189,7 @@ describe(ServerChromiumAccessibilityTree, () => {
       );
     });
 
-    it("maps text-only web-area borders to their StaticText node", () => {
+    it("preserves an element inside text-only web-area borders", () => {
       const rawXml = lit`
         <Iframe raw_id=14 backendDOMNodeId=15 nodeId="f1:15">
           <RootWebArea raw_id=15 backendDOMNodeId=11 nodeId="f3:11" focusable url="https://the-internet.herokuapp.com/frame_middle">
@@ -209,12 +209,12 @@ describe(ServerChromiumAccessibilityTree, () => {
 
       expect(tree.toXml()).toMatchInlineSnapshot(`
         "<Iframe id=1>
-          <RootWebArea id=2 focusable url=\"https://the-internet.herokuapp.com/frame_middle\">
-            <div id=6>MIDDLE</div>
+          <RootWebArea id=2 focusable url="https://the-internet.herokuapp.com/frame_middle">
+            <div id=5>MIDDLE</div>
           </RootWebArea>
         </Iframe>"
       `);
-      expect(tree.getRawId(6)).toBe(19);
+      expect(tree.getRawId(5)).toBe(18);
     });
 
     it("trims names and whitespace-only generic nodes", () => {

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -18,9 +18,7 @@ describe(ServerChromiumAccessibilityTree, () => {
             <div id=5>
               <heading id=6 level=1>todos</heading>
               <div id=8>
-                <textbox name="New Todo Input" id=9 focusable editable="plaintext" settable>
-                  <div id=11 editable="plaintext"/>
-                </textbox>
+                <textbox name="New Todo Input" id=9 focusable editable="plaintext" settable/>
                 <LabelText id=12>New Todo Input</LabelText>
               </div>
             </div>
@@ -253,6 +251,23 @@ describe(ServerChromiumAccessibilityTree, () => {
           <div id=5 live="polite" focusable/>
           <alert id=6 live="assertive" atomic relevant="additions text"/>
         </group>"
+      `);
+    });
+
+    it("removes internal editable children", () => {
+      const rawXml = lit`
+        <RootWebArea raw_id="1" backendDOMNodeId="1" name="Search">
+          <combobox raw_id="2" backendDOMNodeId="2" name="Search" focusable="true" editable="plaintext" settable="true">
+            <generic raw_id="3" backendDOMNodeId="3" editable="plaintext"/>
+          </combobox>
+        </RootWebArea>
+      `;
+      const tree = new ServerChromiumAccessibilityTree(rawXml);
+
+      expect(tree.toXml()).toBe(lit`
+        <RootWebArea name="Search" id=1>
+          <combobox name="Search" id=2 focusable editable="plaintext" settable/>
+        </RootWebArea>
       `);
     });
 

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -189,6 +189,34 @@ describe(ServerChromiumAccessibilityTree, () => {
       );
     });
 
+    it("maps text-only web-area borders to their StaticText node", () => {
+      const rawXml = lit`
+        <Iframe raw_id=14 backendDOMNodeId=15 nodeId="f1:15">
+          <RootWebArea raw_id=15 backendDOMNodeId=11 nodeId="f3:11" focusable url="https://the-internet.herokuapp.com/frame_middle">
+            <none raw_id=16 backendDOMNodeId=29 nodeId="f3:29" ignored>
+              <none raw_id=17 backendDOMNodeId=31 nodeId="f3:31" ignored>
+                <generic raw_id=18 backendDOMNodeId=32 nodeId="f3:32">
+                  <StaticText raw_id=19 backendDOMNodeId=33 nodeId="f3:33" name="MIDDLE">
+                    <InlineTextBox raw_id=20 nodeId="f3:-1000000003" name="MIDDLE"/>
+                  </StaticText>
+                </generic>
+              </none>
+            </none>
+          </RootWebArea>
+        </Iframe>
+      `;
+      const tree = new ServerChromiumAccessibilityTree(rawXml);
+
+      expect(tree.toXml()).toMatchInlineSnapshot(`
+        "<Iframe id=1>
+          <RootWebArea id=2 focusable url=\"https://the-internet.herokuapp.com/frame_middle\">
+            <div id=6>MIDDLE</div>
+          </RootWebArea>
+        </Iframe>"
+      `);
+      expect(tree.getRawId(6)).toBe(19);
+    });
+
     it("trims names and whitespace-only generic nodes", () => {
       const rawXml = lit`
         <generic raw_id="1" ignored="false" name="">

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
@@ -83,6 +83,8 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
 
   protected override preserveNameRoles = new Set(["RootWebArea"]);
 
+  protected override trimmingBorderRoles = new Set(["RootWebArea"]);
+
   protected override textContentAttr(_role: string): string | undefined {
     return undefined;
   }

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
@@ -104,5 +104,28 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
     );
   }
 
+  protected override pruneBackendRedundantNodes(xmlTag: Xml.Tag): void {
+    for (const child of xmlTag.children) {
+      const childTag = Xml.nodeAsTag(child);
+      if (childTag) this.pruneBackendRedundantNodes(childTag);
+    }
+
+    if (!("editable" in xmlTag.attribs || "settable" in xmlTag.attribs)) return;
+
+    xmlTag.children = xmlTag.children.filter((child) => {
+      const childTag = Xml.nodeAsTag(child);
+      if (!childTag || !this.isGenericRole(childTag.tagName)) return true;
+
+      const attrs = Object.keys(childTag.attribs).filter(
+        (attrName) => attrName !== "id" && attrName !== "editable",
+      );
+      return (
+        !!childTag.children.length ||
+        attrs.length > 0 ||
+        childTag.attribs.editable !== xmlTag.attribs.editable
+      );
+    });
+  }
+
   //#endregion
 }

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
@@ -85,6 +85,8 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
 
   protected override trimmingBorderRoles = new Set(["RootWebArea"]);
 
+  protected override trimmingBorderChildRoles = new Set(["generic"]);
+
   protected override textContentAttr(_role: string): string | undefined {
     return undefined;
   }

--- a/packages/typescript/src/server/accessibility/ServerUIAutomator2AccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerUIAutomator2AccessibilityTree.ts
@@ -49,19 +49,11 @@ export class ServerUIAutomator2AccessibilityTree extends BaseServerAccessibility
       .join("\n");
   }
 
-  #genericRoles = new Set([
-    "FrameLayout",
-    "LinearLayout",
-    "LinearLayoutCompat",
-    "RelativeLayout",
-    "ViewGroup",
-  ]);
-
   protected override parseRole(xmlTag: Xml.Tag): string {
     const role = xmlTag.attribs.type ?? xmlTag.tagName;
     const simplifiedRole = role.split(".").at(-1);
     always(simplifiedRole);
-    return this.#genericRoles.has(simplifiedRole) ? "generic" : simplifiedRole;
+    return simplifiedRole;
   }
 
   protected override parseName(
@@ -121,11 +113,15 @@ export class ServerUIAutomator2AccessibilityTree extends BaseServerAccessibility
   }
 
   protected override genericRoles = new Set([
-    "generic",
+    "FrameLayout",
+    "LinearLayout",
+    "LinearLayoutCompat",
+    "RelativeLayout",
+    "ViewGroup",
     "root",
     "hierarchy",
-    "TextView",
     "View",
+    "TextView",
   ]);
 
   protected override genericAttrs = new Set(["id", "resource-id"]);
@@ -151,7 +147,8 @@ export class ServerUIAutomator2AccessibilityTree extends BaseServerAccessibility
         ? Xml.nodeAsText(childTag.children[0])
         : null;
       return !(
-        childTag?.tagName === "div" &&
+        childTag &&
+        this.isGenericRole(childTag.tagName) &&
         childText?.data === contentDescription &&
         childTag.children.length === 1 &&
         Object.keys(childTag.attribs).every((attrName) =>

--- a/packages/typescript/src/server/accessibility/ServerXCUITestAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerXCUITestAccessibilityTree.ts
@@ -102,7 +102,7 @@ export class ServerXCUITestAccessibilityTree extends BaseServerAccessibilityTree
     return xml;
   }
 
-  override genericRoles = new Set(["generic", "StaticText"]);
+  protected override genericRoles = new Set(["generic", "StaticText"]);
 
   protected override redundantTextAttrs = new Set(["name", "label", "value"]);
 
@@ -122,7 +122,7 @@ export class ServerXCUITestAccessibilityTree extends BaseServerAccessibilityTree
     const onlyChild = xmlTag.children[0];
     always(onlyChild);
     const childTag = Xml.nodeAsTag(onlyChild);
-    if (!childTag || childTag.tagName !== "div") return;
+    if (!childTag || !this.isGenericRole(childTag.tagName)) return;
     if (Object.keys(childTag.attribs).some((attrName) => attrName !== "id"))
       return;
     if (childTag.children.length !== 1) return;

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-10469df26510664b.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-10469df26510664b.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-150b12b183a111c.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-150b12b183a111c.snap.xml
@@ -392,9 +392,7 @@
         </div>
         <div id=822>
           <div id=823>
-            <textbox name="Describe a task or ask a question" id=824 focusable editable="plaintext" settable multiline>
-              <div id=826 editable="plaintext"/>
-            </textbox>
+            <textbox name="Describe a task or ask a question" id=824 focusable editable="plaintext" settable multiline/>
             <button name="Send" id=827 disabled/>
           </div>
           <div id=828>
@@ -1005,9 +1003,7 @@
         <heading id=1878 level=3>Get the developer newsletter</heading>
         <paragraph id=1881>Product updates, how-tos, community spotlights, and more. Delivered monthly to your inbox.</paragraph>
         <div id=1886>
-          <textbox name="Email address" id=1887 focusable editable="plaintext" settable required>
-            <div id=1889 editable="plaintext"/>
-          </textbox>
+          <textbox name="Email address" id=1887 focusable editable="plaintext" settable required/>
           <button name="Subscribe" id=1890 disabled/>
         </div>
         <paragraph id=1893>Please provide your email address if you'd like to receive our monthly developer newsletter. You can unsubscribe at any time.</paragraph>
@@ -1022,9 +1018,7 @@
             <image name="Claude" id=1903/>
           </link>
           <div id=1905>
-            <textbox name="Ask Claude" id=1906 focusable editable="plaintext" settable multiline>
-              <div id=1908 editable="plaintext"/>
-            </textbox>
+            <textbox name="Ask Claude" id=1906 focusable editable="plaintext" settable multiline/>
             <button name="Submit" id=1909 focusable/>
           </div>
         </div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1ec10e56d31837f7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1ec10e56d31837f7.snap.xml
@@ -18,9 +18,7 @@
     <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
       <heading id=34 level=1>todos</heading>
     </link>
-    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-      <div id=39 editable="plaintext"/>
-    </textbox>
+    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
   </sectionheader>
   <contentinfo id=42>
     <paragraph id=43>Double-click to edit a todo</paragraph>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1f3b8748a4365d31.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1f3b8748a4365d31.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2074f3a59d6cb9ee.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2074f3a59d6cb9ee.snap.xml
@@ -18,9 +18,7 @@
     <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
       <heading id=34 level=1>todos</heading>
     </link>
-    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-      <div id=39 editable="plaintext"/>
-    </textbox>
+    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
   </sectionheader>
   <contentinfo id=42>
     <paragraph id=43>Double-click to edit a todo</paragraph>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-27091d1e1af92d34.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-27091d1e1af92d34.snap.xml
@@ -187,9 +187,7 @@
             <image name="Claude" id=454/>
           </link>
           <div id=456>
-            <textbox name="Ask Claude" id=457 focusable editable="plaintext" settable multiline>
-              <div id=459 editable="plaintext"/>
-            </textbox>
+            <textbox name="Ask Claude" id=457 focusable editable="plaintext" settable multiline/>
             <button name="Submit" id=460 focusable/>
           </div>
         </div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2abf19817179a2a.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2abf19817179a2a.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2fdca23858e60509.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2fdca23858e60509.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-31c70b39b22c7e26.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-31c70b39b22c7e26.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-31de17e4ff19450e.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-31de17e4ff19450e.snap.xml
@@ -20,9 +20,7 @@
               <div id=63>
                 <div id=65>
                   Where
-                  <searchbox name="Where" id=70 focusable editable="plaintext" settable>
-                    <div id=73 editable="plaintext"/>
-                  </searchbox>
+                  <searchbox name="Where" id=70 focusable editable="plaintext" settable/>
                 </div>
                 <button id=75 focusable>
                   <div id=78>When</div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
@@ -15,21 +15,15 @@
       <div id=28>
         <LabelText id=29>
           Text input
-          <textbox name="Text input" id=32 focusable editable="plaintext" settable>
-            <div id=33 editable="plaintext"/>
-          </textbox>
+          <textbox name="Text input" id=32 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=34>
           Password
-          <textbox name="Password" id=37 focusable editable="plaintext" settable>
-            <div id=38 editable="plaintext"/>
-          </textbox>
+          <textbox name="Password" id=37 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=39>
           Textarea
-          <textbox name="Textarea" id=42 focusable editable="plaintext" settable multiline>
-            <div id=43 editable="plaintext"/>
-          </textbox>
+          <textbox name="Textarea" id=42 focusable editable="plaintext" settable multiline/>
         </LabelText>
         <LabelText id=44>
           Disabled input
@@ -55,9 +49,7 @@
         </LabelText>
         <LabelText id=72>
           Dropdown (datalist)
-          <combobox name="Dropdown (datalist)" id=75 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-            <div id=79 editable="plaintext"/>
-          </combobox>
+          <combobox name="Dropdown (datalist)" id=75 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
         </LabelText>
         <LabelText id=81>
           File input
@@ -84,9 +76,7 @@
         </LabelText>
         <LabelText id=112>
           Date picker
-          <textbox name="Date picker" id=115 focusable editable="plaintext" settable>
-            <div id=116 editable="plaintext"/>
-          </textbox>
+          <textbox name="Date picker" id=115 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=117>
           Example range

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-404080fcef09eb53.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-404080fcef09eb53.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-410de441fbd4a97f.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-410de441fbd4a97f.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-43b3b85068ceb7c2.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-43b3b85068ceb7c2.snap.xml
@@ -36,9 +36,7 @@
       <div id=57>
         <complementary id=59>
           <navigation name="Documentation" id=60>
-            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable>
-              <div id=65 editable="plaintext"/>
-            </searchbox>
+            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable/>
             <div id=66>
               <div id=67>
                 GET STARTED

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-492a8980e94af965.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-492a8980e94af965.snap.xml
@@ -50,9 +50,7 @@
             <form id=206>
               <div id=209>
                 <LabelText id=210>Enter your email</LabelText>
-                <textbox name="Enter your email" id=214 focusable editable="plaintext" settable>
-                  <div id=216 editable="plaintext"/>
-                </textbox>
+                <textbox name="Enter your email" id=214 focusable editable="plaintext" settable/>
               </div>
               <button id=217 focusable>Sign up for GitHub</button>
             </form>
@@ -344,9 +342,7 @@
           <form id=1020>
             <div id=1023>
               <LabelText id=1024>Enter your email</LabelText>
-              <textbox name="Enter your email" id=1028 focusable editable="plaintext" settable>
-                <div id=1030 editable="plaintext"/>
-              </textbox>
+              <textbox name="Enter your email" id=1028 focusable editable="plaintext" settable/>
             </div>
             <button id=1031 focusable>Sign up for GitHub</button>
           </form>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-50740a13c58568af.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-50740a13c58568af.snap.xml
@@ -18,9 +18,7 @@
     <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
       <heading id=34 level=1>todos</heading>
     </link>
-    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-      <div id=39 editable="plaintext"/>
-    </textbox>
+    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
   </sectionheader>
   <contentinfo id=42>
     <paragraph id=43>Double-click to edit a todo</paragraph>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-55dcf4e98a494f46.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-55dcf4e98a494f46.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-57399e5a1a88876c.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-57399e5a1a88876c.snap.xml
@@ -36,9 +36,7 @@
       <div id=57>
         <complementary id=59>
           <navigation name="Documentation" id=60>
-            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable>
-              <div id=65 editable="plaintext"/>
-            </searchbox>
+            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable/>
             <div id=66>
               <div id=67>
                 GET STARTED

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-588896b59d6d6947.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-588896b59d6d6947.snap.xml
@@ -9,9 +9,7 @@
       <div id=15>
         <div id=17>
           <LabelText id=18>E-mail</LabelText>
-          <textbox name="E-mail" id=21 focusable editable="plaintext" settable>
-            <div id=22 editable="plaintext"/>
-          </textbox>
+          <textbox name="E-mail" id=21 focusable editable="plaintext" settable/>
         </div>
         <button id=23 focusable>Retrieve password</button>
       </div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-59cdfe25fa15bfb7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-59cdfe25fa15bfb7.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-5d35f5b60496cda9.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-5d35f5b60496cda9.snap.xml
@@ -36,9 +36,7 @@
       <div id=57>
         <complementary id=59>
           <navigation name="Documentation" id=60>
-            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable>
-              <div id=65 editable="plaintext"/>
-            </searchbox>
+            <searchbox name="Filter navigation" id=62 focusable editable="plaintext" settable/>
             <div id=66>
               <div id=67>
                 GET STARTED
@@ -916,9 +914,7 @@
   <button id=1607 focusable hasPopup="listbox">
     <banner id=1609>
       <LabelText id=1611>Search</LabelText>
-      <searchbox name="Search" id=1617 focusable focused editable="plaintext" settable autocomplete="both">
-        <div id=1620 editable="plaintext"/>
-      </searchbox>
+      <searchbox name="Search" id=1617 focusable focused editable="plaintext" settable autocomplete="both"/>
     </banner>
     <paragraph id=1623>No recent searches</paragraph>
     <contentinfo id=1626>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-789a3d5baf773baa.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-789a3d5baf773baa.snap.xml
@@ -37,9 +37,7 @@
                   <div id=125>
                     <div id=126>
                       <LabelText id=127>Search</LabelText>
-                      <combobox name="Search" id=134 focusable focused editable="plaintext" settable autocomplete="list" hasPopup="listbox" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results">
-                        <div id=135 editable="plaintext"/>
-                      </combobox>
+                      <combobox name="Search" id=134 focusable focused editable="plaintext" settable autocomplete="list" hasPopup="listbox" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results"/>
                       <listbox name="Suggestions" id=139 focusable orientation="vertical">
                         <option name=", jump to this explore page" id=140>Enterprise</option>
                         <option name=", jump to this explore page" id=147>Security</option>
@@ -73,9 +71,7 @@
             <form id=267>
               <div id=270>
                 <LabelText id=271>Enter your email</LabelText>
-                <textbox name="Enter your email" id=275 focusable editable="plaintext" settable>
-                  <div id=277 editable="plaintext"/>
-                </textbox>
+                <textbox name="Enter your email" id=275 focusable editable="plaintext" settable/>
               </div>
               <button id=278 focusable>Sign up for GitHub</button>
             </form>
@@ -367,9 +363,7 @@
           <form id=1081>
             <div id=1084>
               <LabelText id=1085>Enter your email</LabelText>
-              <textbox name="Enter your email" id=1089 focusable editable="plaintext" settable>
-                <div id=1091 editable="plaintext"/>
-              </textbox>
+              <textbox name="Enter your email" id=1089 focusable editable="plaintext" settable/>
             </div>
             <button id=1092 focusable>Sign up for GitHub</button>
           </form>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
@@ -21,15 +21,11 @@
         </LabelText>
         <LabelText id=36>
           Password
-          <textbox name="Password" id=39 focusable editable="plaintext" settable>
-            <div id=40 editable="plaintext"/>
-          </textbox>
+          <textbox name="Password" id=39 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=41>
           Textarea
-          <textbox name="Textarea" id=44 focusable editable="plaintext" settable multiline>
-            <div id=45 editable="plaintext"/>
-          </textbox>
+          <textbox name="Textarea" id=44 focusable editable="plaintext" settable multiline/>
         </LabelText>
         <LabelText id=46>
           Disabled input
@@ -55,9 +51,7 @@
         </LabelText>
         <LabelText id=74>
           Dropdown (datalist)
-          <combobox name="Dropdown (datalist)" id=77 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-            <div id=81 editable="plaintext"/>
-          </combobox>
+          <combobox name="Dropdown (datalist)" id=77 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
         </LabelText>
         <LabelText id=83>
           File input
@@ -84,9 +78,7 @@
         </LabelText>
         <LabelText id=114>
           Date picker
-          <textbox name="Date picker" id=117 focusable editable="plaintext" settable>
-            <div id=118 editable="plaintext"/>
-          </textbox>
+          <textbox name="Date picker" id=117 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=119>
           Example range

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-8279aa19508bbf54.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-8279aa19508bbf54.snap.xml
@@ -18,9 +18,7 @@
     <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
       <heading id=34 level=1>todos</heading>
     </link>
-    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-      <div id=39 editable="plaintext"/>
-    </textbox>
+    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
   </sectionheader>
   <contentinfo id=42>
     <paragraph id=43>Double-click to edit a todo</paragraph>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-897b7080e4ce17b2.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-897b7080e4ce17b2.snap.xml
@@ -41,9 +41,7 @@
                 <link name="All products" id=63 focusable url="https://developers.cloudflare.com/"/>
                 <link id=65 focusable url="https://developers.cloudflare.com/workers/">Workers</link>
               </div>
-              <searchbox name="Filter navigation" id=70 focusable editable="plaintext" settable>
-                <div id=73 editable="plaintext"/>
-              </searchbox>
+              <searchbox name="Filter navigation" id=70 focusable editable="plaintext" settable/>
             </div>
             <list id=76>
               <listitem id=77 level=1>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-a77cf21cbb4ca4ee.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-a77cf21cbb4ca4ee.snap.xml
@@ -3,24 +3,24 @@
     <RootWebArea id=5 focusable url="https://the-internet.herokuapp.com/frame_top">
       <Iframe id=8>
         <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">
-          <div id=12>LEFT</div>
+          <div id=11>LEFT</div>
         </RootWebArea>
       </Iframe>
       <Iframe id=14>
         <RootWebArea id=15 focusable url="https://the-internet.herokuapp.com/frame_middle">
-          <div id=19>MIDDLE</div>
+          <div id=18>MIDDLE</div>
         </RootWebArea>
       </Iframe>
       <Iframe id=21>
         <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">
-          <div id=25>RIGHT</div>
+          <div id=24>RIGHT</div>
         </RootWebArea>
       </Iframe>
     </RootWebArea>
   </Iframe>
   <Iframe id=27>
     <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">
-      <div id=31>BOTTOM</div>
+      <div id=30>BOTTOM</div>
     </RootWebArea>
   </Iframe>
 </RootWebArea>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-a77cf21cbb4ca4ee.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-a77cf21cbb4ca4ee.snap.xml
@@ -2,17 +2,25 @@
   <Iframe id=4>
     <RootWebArea id=5 focusable url="https://the-internet.herokuapp.com/frame_top">
       <Iframe id=8>
-        <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">LEFT</RootWebArea>
+        <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">
+          <div id=12>LEFT</div>
+        </RootWebArea>
       </Iframe>
       <Iframe id=14>
-        <RootWebArea id=15 focusable url="https://the-internet.herokuapp.com/frame_middle">MIDDLE</RootWebArea>
+        <RootWebArea id=15 focusable url="https://the-internet.herokuapp.com/frame_middle">
+          <div id=19>MIDDLE</div>
+        </RootWebArea>
       </Iframe>
       <Iframe id=21>
-        <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">RIGHT</RootWebArea>
+        <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">
+          <div id=25>RIGHT</div>
+        </RootWebArea>
       </Iframe>
     </RootWebArea>
   </Iframe>
   <Iframe id=27>
-    <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">BOTTOM</RootWebArea>
+    <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">
+      <div id=31>BOTTOM</div>
+    </RootWebArea>
   </Iframe>
 </RootWebArea>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ac557bfb2cd6fa98.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ac557bfb2cd6fa98.snap.xml
@@ -18,9 +18,7 @@
     <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
       <heading id=34 level=1>todos</heading>
     </link>
-    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-      <div id=39 editable="plaintext"/>
-    </textbox>
+    <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
   </sectionheader>
   <contentinfo id=42>
     <paragraph id=43>Double-click to edit a todo</paragraph>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b03cec15ba5db523.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b03cec15ba5db523.snap.xml
@@ -10,9 +10,7 @@
     </div>
     <div id=39>
       <search id=40>
-        <combobox name="Search" id=45 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-          <div id=47 editable="plaintext"/>
-        </combobox>
+        <combobox name="Search" id=45 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
         <button name="Search" id=48 focusable/>
       </search>
       <div id=52>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b7ea79e5a0ff4102.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b7ea79e5a0ff4102.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b9a1bc8a824a98c5.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b9a1bc8a824a98c5.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c130faab944d98ef.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c130faab944d98ef.snap.xml
@@ -2,17 +2,25 @@
   <Iframe id=4>
     <RootWebArea id=5 focusable url="https://the-internet.herokuapp.com/frame_top">
       <Iframe id=8>
-        <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">LEFT</RootWebArea>
+        <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">
+          <div id=12>LEFT</div>
+        </RootWebArea>
       </Iframe>
       <Iframe id=14>
-        <RootWebArea id=15 focusable focused url="https://the-internet.herokuapp.com/frame_middle">MIDDLE</RootWebArea>
+        <RootWebArea id=15 focusable focused url="https://the-internet.herokuapp.com/frame_middle">
+          <div id=19>MIDDLE</div>
+        </RootWebArea>
       </Iframe>
       <Iframe id=21>
-        <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">RIGHT</RootWebArea>
+        <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">
+          <div id=25>RIGHT</div>
+        </RootWebArea>
       </Iframe>
     </RootWebArea>
   </Iframe>
   <Iframe id=27>
-    <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">BOTTOM</RootWebArea>
+    <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">
+      <div id=31>BOTTOM</div>
+    </RootWebArea>
   </Iframe>
 </RootWebArea>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c130faab944d98ef.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c130faab944d98ef.snap.xml
@@ -3,24 +3,24 @@
     <RootWebArea id=5 focusable url="https://the-internet.herokuapp.com/frame_top">
       <Iframe id=8>
         <RootWebArea id=9 focusable url="https://the-internet.herokuapp.com/frame_left">
-          <div id=12>LEFT</div>
+          <div id=11>LEFT</div>
         </RootWebArea>
       </Iframe>
       <Iframe id=14>
         <RootWebArea id=15 focusable focused url="https://the-internet.herokuapp.com/frame_middle">
-          <div id=19>MIDDLE</div>
+          <div id=18>MIDDLE</div>
         </RootWebArea>
       </Iframe>
       <Iframe id=21>
         <RootWebArea id=22 focusable url="https://the-internet.herokuapp.com/frame_right">
-          <div id=25>RIGHT</div>
+          <div id=24>RIGHT</div>
         </RootWebArea>
       </Iframe>
     </RootWebArea>
   </Iframe>
   <Iframe id=27>
     <RootWebArea id=28 focusable url="https://the-internet.herokuapp.com/frame_bottom">
-      <div id=31>BOTTOM</div>
+      <div id=30>BOTTOM</div>
     </RootWebArea>
   </Iframe>
 </RootWebArea>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c3548b4ed111784b.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c3548b4ed111784b.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c8f1f2a864cf0020.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-c8f1f2a864cf0020.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-cf1d6b89e21df101.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-cf1d6b89e21df101.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d300ba6ae540c88.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d300ba6ae540c88.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d6643d00ef390cf4.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d6643d00ef390cf4.snap.xml
@@ -76,9 +76,7 @@
             <form id=251>
               <div id=254>
                 <LabelText id=255>Enter your email</LabelText>
-                <textbox name="Enter your email" id=259 focusable editable="plaintext" settable>
-                  <div id=261 editable="plaintext"/>
-                </textbox>
+                <textbox name="Enter your email" id=259 focusable editable="plaintext" settable/>
               </div>
               <button id=262 focusable>Sign up for GitHub</button>
             </form>
@@ -370,9 +368,7 @@
           <form id=1065>
             <div id=1068>
               <LabelText id=1069>Enter your email</LabelText>
-              <textbox name="Enter your email" id=1073 focusable editable="plaintext" settable>
-                <div id=1075 editable="plaintext"/>
-              </textbox>
+              <textbox name="Enter your email" id=1073 focusable editable="plaintext" settable/>
             </div>
             <button id=1076 focusable>Sign up for GitHub</button>
           </form>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e0377270879208d7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e0377270879208d7.snap.xml
@@ -7,9 +7,7 @@
       </link>
     </div>
     <search id=28>
-      <combobox id=33 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-        <div id=34 editable="plaintext"/>
-      </combobox>
+      <combobox id=33 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
       <button name="Search" id=35 focusable/>
     </search>
   </banner>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
@@ -21,9 +21,7 @@
         </LabelText>
         <LabelText id=36>
           Password
-          <textbox name="Password" id=39 focusable editable="plaintext" settable>
-            <div id=40 editable="plaintext"/>
-          </textbox>
+          <textbox name="Password" id=39 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=41>
           Textarea
@@ -55,9 +53,7 @@
         </LabelText>
         <LabelText id=76>
           Dropdown (datalist)
-          <combobox name="Dropdown (datalist)" id=79 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-            <div id=83 editable="plaintext"/>
-          </combobox>
+          <combobox name="Dropdown (datalist)" id=79 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
         </LabelText>
         <LabelText id=85>
           File input
@@ -84,9 +80,7 @@
         </LabelText>
         <LabelText id=116>
           Date picker
-          <textbox name="Date picker" id=119 focusable editable="plaintext" settable>
-            <div id=120 editable="plaintext"/>
-          </textbox>
+          <textbox name="Date picker" id=119 focusable editable="plaintext" settable/>
         </LabelText>
         <LabelText id=121>
           Example range

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e3bf8568585359c2.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e3bf8568585359c2.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e5256153142f362e.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e5256153142f362e.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
@@ -21,21 +21,15 @@
           <div id=44>
             <LabelText id=45>
               Text input
-              <textbox name="Text input" id=48 focusable editable="plaintext" settable>
-                <div id=49 editable="plaintext"/>
-              </textbox>
+              <textbox name="Text input" id=48 focusable editable="plaintext" settable/>
             </LabelText>
             <LabelText id=50>
               Password
-              <textbox name="Password" id=53 focusable editable="plaintext" settable>
-                <div id=54 editable="plaintext"/>
-              </textbox>
+              <textbox name="Password" id=53 focusable editable="plaintext" settable/>
             </LabelText>
             <LabelText id=55>
               Textarea
-              <textbox name="Textarea" id=58 focusable editable="plaintext" settable multiline>
-                <div id=59 editable="plaintext"/>
-              </textbox>
+              <textbox name="Textarea" id=58 focusable editable="plaintext" settable multiline/>
             </LabelText>
             <LabelText id=60>
               Disabled input
@@ -61,9 +55,7 @@
             </LabelText>
             <LabelText id=88>
               Dropdown (datalist)
-              <combobox name="Dropdown (datalist)" id=91 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-                <div id=95 editable="plaintext"/>
-              </combobox>
+              <combobox name="Dropdown (datalist)" id=91 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
             </LabelText>
             <LabelText id=97>
               File input
@@ -90,9 +82,7 @@
             </LabelText>
             <LabelText id=128>
               Date picker
-              <textbox name="Date picker" id=131 focusable editable="plaintext" settable>
-                <div id=132 editable="plaintext"/>
-              </textbox>
+              <textbox name="Date picker" id=131 focusable editable="plaintext" settable/>
             </LabelText>
             <LabelText id=133>
               Example range

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
@@ -27,15 +27,11 @@
             </LabelText>
             <LabelText id=52>
               Password
-              <textbox name="Password" id=55 focusable editable="plaintext" settable>
-                <div id=56 editable="plaintext"/>
-              </textbox>
+              <textbox name="Password" id=55 focusable editable="plaintext" settable/>
             </LabelText>
             <LabelText id=57>
               Textarea
-              <textbox name="Textarea" id=60 focusable editable="plaintext" settable multiline>
-                <div id=61 editable="plaintext"/>
-              </textbox>
+              <textbox name="Textarea" id=60 focusable editable="plaintext" settable multiline/>
             </LabelText>
             <LabelText id=62>
               Disabled input
@@ -61,9 +57,7 @@
             </LabelText>
             <LabelText id=90>
               Dropdown (datalist)
-              <combobox name="Dropdown (datalist)" id=93 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox">
-                <div id=97 editable="plaintext"/>
-              </combobox>
+              <combobox name="Dropdown (datalist)" id=93 focusable editable="plaintext" settable autocomplete="list" hasPopup="listbox"/>
             </LabelText>
             <LabelText id=99>
               File input
@@ -90,9 +84,7 @@
             </LabelText>
             <LabelText id=130>
               Date picker
-              <textbox name="Date picker" id=133 focusable editable="plaintext" settable>
-                <div id=134 editable="plaintext"/>
-              </textbox>
+              <textbox name="Date picker" id=133 focusable editable="plaintext" settable/>
             </LabelText>
             <LabelText id=135>
               Example range

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-fa3fe23dc3b6fc4d.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-fa3fe23dc3b6fc4d.snap.xml
@@ -19,9 +19,7 @@
       <link id=33 focusable url="https://todomvc.com/examples/vue/dist/#/">
         <heading id=34 level=1>todos</heading>
       </link>
-      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable>
-        <div id=39 editable="plaintext"/>
-      </textbox>
+      <textbox name="What needs to be done?" id=37 focusable focused editable="plaintext" settable/>
     </sectionheader>
     <main id=40>
       <div id=41>

--- a/packages/typescript/src/xml/Xml.ts
+++ b/packages/typescript/src/xml/Xml.ts
@@ -1,7 +1,7 @@
 import { always } from "alwaysly";
 import { Element, isTag, isText, Text } from "domhandler";
-import { parseDocument } from "htmlparser2";
-import type * as DomHandler from "domhandler";
+import { Parser } from "htmlparser2";
+import * as DomHandler from "domhandler";
 
 export namespace Xml {
   export type Node = DomHandler.Node;
@@ -19,8 +19,40 @@ export namespace Xml {
 
 export abstract class Xml {
   static parseRootChildren(xml: string): Xml.Node[] {
-    const root = parseDocument(xml.trim(), { xmlMode: true });
-    return root.children;
+    const handler = new DomHandler.DomHandler();
+
+    const originalOnopentag = handler.onopentag;
+    let truishAttrs: Record<string, string> = {};
+
+    // @ts-expect-error: DomHandler is poorly typed.
+    handler.onopentagname = () => (truishAttrs = {});
+
+    // @ts-expect-error: See above.
+    handler.onattribute = (
+      name: string,
+      value: string,
+      quote: string | undefined,
+    ) => {
+      if (value === "" && quote === undefined) truishAttrs[name] = "true";
+    };
+
+    handler.onopentag = (name, attribs) => {
+      // NOTE: Weirdly this is the way to parse no-value attributes,
+      // i.e., `checked`. See: https://github.com/fb55/htmlparser2/issues/974
+      originalOnopentag.call(handler, name, { ...attribs, ...truishAttrs });
+    };
+
+    const parser = new Parser(handler, {
+      xmlMode: true,
+      lowerCaseTags: false,
+      lowerCaseAttributeNames: false,
+      recognizeSelfClosing: true,
+    });
+
+    parser.write(xml.trim());
+    parser.end();
+
+    return handler.root.children;
   }
 
   static parseMultirootChildren(xml: string): Xml.Node[] {

--- a/packages/typescript/src/xml/XmlRenderer.test.ts
+++ b/packages/typescript/src/xml/XmlRenderer.test.ts
@@ -26,6 +26,15 @@ describe("XmlRenderer", () => {
       `);
   });
 
+  it("aliases tag names when rendering", () => {
+    const generic = Xml.tag("generic", { id: "1" }, [Xml.text("Text")]);
+
+    expect(
+      XmlRenderer.render(generic, { tagAliases: { generic: "div" } }),
+    ).toBe("<div id=1>Text</div>");
+    expect(generic.tagName).toBe("generic");
+  });
+
   it("removes formatting whitespace when minified", () => {
     const root = Xml.tag("root", {}, [Xml.tag("child")]);
 

--- a/packages/typescript/src/xml/XmlRenderer.test.ts
+++ b/packages/typescript/src/xml/XmlRenderer.test.ts
@@ -123,6 +123,18 @@ describe("XmlRenderer", () => {
     );
   });
 
+  it("parses valueless attributes without nesting self-closing siblings", () => {
+    const elements = Xml.parseRootChildren(
+      '<link focusable/><StaticText name="Explore GitHub Copilot"/>',
+    );
+
+    expect(XmlRenderer.render(elements as Xml.AnyElement[]))
+      .toMatchInlineSnapshot(`
+        "<link focusable/>
+        <StaticText name="Explore GitHub Copilot"/>"
+      `);
+  });
+
   it("formats multiple roots, comments, CDATA, and directives", () => {
     const elements = Xml.parseRootChildren(
       "<?target value?><one><!-- note --><![CDATA[ content ]]></one><two/>",

--- a/packages/typescript/src/xml/XmlRenderer.ts
+++ b/packages/typescript/src/xml/XmlRenderer.ts
@@ -19,6 +19,7 @@ export namespace XmlRenderer {
     minify?: boolean;
     indentation?: string;
     compactAttrs?: boolean;
+    tagAliases?: Readonly<Record<string, string>>;
   }
 }
 
@@ -31,6 +32,7 @@ export abstract class XmlRenderer {
     node: AnyNode | ArrayLike<AnyNode>,
     options: XmlRenderer.Options = this.defaultOptions,
   ): string {
+    options = { ...this.defaultOptions, ...options };
     const nodes = "length" in node ? node : [node];
     const output = this.#renderFormattedChildren(nodes, options, 0, false);
     return options.minify ? output.replace(/\n\s*/g, "") : output;
@@ -133,7 +135,7 @@ export abstract class XmlRenderer {
     depth: number,
     preserveSpace: boolean,
   ): string {
-    const name = element.name;
+    const name = options.tagAliases?.[element.name] ?? element.name;
     const prefix = preserveSpace ? "" : this.#indent(depth, options);
     const attributes = this.#formatAttributes(element.attribs, options);
     const children = element.children;

--- a/packages/typescript/tests/system/complexApps.test.ts
+++ b/packages/typescript/tests/system/complexApps.test.ts
@@ -61,7 +61,7 @@ describe("Complex apps", () => {
 
       await al.do("type in 'alumnium' in the search input");
 
-      await al.do("select 'alumnium' from the search suggestions");
+      await al.do("press 'Enter' in the search input");
 
       await al.check("search results are relevant to 'alumnium' query", {
         assert: expect.assert,


### PR DESCRIPTION
Several fixes for trees:

- I noticed that `checked` wasn't properly parsed, which made the TODO system tests fail (and occasionally randomly pass). This PR addresses this problem, which hopefully will make both system tests more stable as well as increase overall performance. It was like that at least from the initial Python -> TypeScript transformation, but more likely was even present in Python implementation.

- In certain cases, tree trimming was removing everything up to the root element, losing the clickable elements.

- Trimming didn't consider if the element is actually present in DOM or if it's an a11y node. Now it's fixed.