### PR TITLE
feat: expose per-step execution metrics and artifacts from Alumni (#293)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,7 @@ For local development, you may need to configure the following environment varia
 | `ALUMNIUM_LOG_PATH`  | Path to the alumnium log directory                     | `stdout(logs to console)` |
 | `ALUMNIUM_LOG_LEVEL` | Log level or configuration value                       | `WARNING`                 |
 | `ALUMNIUM_CACHE`     | Cache provider or disable it                           | `filesystem`              |
+| `ALUMNIUM_ARTIFACTS_DIR` | Base dir for library execution artifacts (`al.artifacts_dir`) | `~/.alumnium/artifacts` |
 
 ### 5. Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,8 @@ For local development, you may need to configure the following environment varia
 | `ALUMNIUM_LOG_LEVEL` | Log level or configuration value                       | `WARNING`                 |
 | `ALUMNIUM_CACHE`     | Cache provider or disable it                           | `filesystem`              |
 | `ALUMNIUM_ARTIFACTS_DIR` | Base dir for library execution artifacts (`al.artifacts_dir`) | `~/.alumnium/artifacts` |
+| `ALUMNIUM_CAPTURE_SCREENSHOTS` | Capture a screenshot per `do`/`check`/`get` call | `false` |
+| `ALUMNIUM_DRIVER_TRACE` | Record a Playwright trace for the session | `false` |
 
 ### 5. Pull Request Process
 

--- a/packages/python/src/alumnium/__init__.py
+++ b/packages/python/src/alumnium/__init__.py
@@ -7,8 +7,10 @@ logger: logging.Logger = get_logger(__name__)
 logger.addHandler(logging.NullHandler())
 
 ARTIFACTS_DIR = getenv("ALUMNIUM_ARTIFACTS_DIR", "")
+CAPTURE_SCREENSHOTS = getenv("ALUMNIUM_CAPTURE_SCREENSHOTS", "false").lower() == "true"
 CHANGE_ANALYSIS = getenv("ALUMNIUM_CHANGE_ANALYSIS", "false").lower() == "true"
 DELAY = float(getenv("ALUMNIUM_DELAY", 0.5))
+DRIVER_TRACE = getenv("ALUMNIUM_DRIVER_TRACE", "false").lower() == "true"
 EXCLUDE_ATTRIBUTES = set(filter(None, getenv("ALUMNIUM_EXCLUDE_ATTRIBUTES", "").split(",")))
 FULL_PAGE_SCREENSHOT = getenv("ALUMNIUM_FULL_PAGE_SCREENSHOT", "false").lower() == "true"
 PLANNER = getenv("ALUMNIUM_PLANNER", "true").lower() == "true"

--- a/packages/python/src/alumnium/__init__.py
+++ b/packages/python/src/alumnium/__init__.py
@@ -6,6 +6,7 @@ from .logutils import configure_logging, get_logger
 logger: logging.Logger = get_logger(__name__)
 logger.addHandler(logging.NullHandler())
 
+ARTIFACTS_DIR = getenv("ALUMNIUM_ARTIFACTS_DIR", "")
 CHANGE_ANALYSIS = getenv("ALUMNIUM_CHANGE_ANALYSIS", "false").lower() == "true"
 DELAY = float(getenv("ALUMNIUM_DELAY", 0.5))
 EXCLUDE_ATTRIBUTES = set(filter(None, getenv("ALUMNIUM_EXCLUDE_ATTRIBUTES", "").split(",")))

--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -1,5 +1,9 @@
+import time
 from asyncio import AbstractEventLoop
+from contextlib import contextmanager
 from os import getenv
+from pathlib import Path
+from typing import Literal
 
 from appium.webdriver.webdriver import WebDriver as Appium
 from playwright.async_api import Page as PageAsync
@@ -7,8 +11,9 @@ from playwright.sync_api import Page
 from retry import retry
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from . import CHANGE_ANALYSIS, DELAY, EXCLUDE_ATTRIBUTES, PLANNER, RETRIES
+from . import ARTIFACTS_DIR, CHANGE_ANALYSIS, DELAY, EXCLUDE_ATTRIBUTES, PLANNER, RETRIES
 from .area import Area
+from .artifacts_store import ArtifactsStore
 from .cache import Cache
 from .clients.http_client import HttpClient
 from .clients.typecasting import Data
@@ -18,6 +23,7 @@ from .drivers.playwright_async_driver import PlaywrightAsyncDriver
 from .drivers.playwright_driver import PlaywrightDriver
 from .drivers.selenium_driver import SeleniumDriver
 from .logutils import get_logger
+from .metrics import Artifact, SessionMetrics, SessionTokens, StepMetrics, TokenUsage
 from .models import Model
 from .result import DoResult, DoStep
 from .tools import BaseTool
@@ -78,11 +84,89 @@ class Alumni:
 
         self.cache = Cache(self.client)
 
+        # Execution metrics + artifacts (issue #293).
+        self._artifacts = ArtifactsStore(str(self.client.session_id), ARTIFACTS_DIR or None)
+        self._steps: list[StepMetrics] = []
+        self._step_counter = 0
+        self._metric_usage = TokenUsage()
+        self._metrics_started_at = time.time()
+        self._tracing = self._start_tracing()
+
     def quit(self) -> None:
+        # Capture stats + trace while the session and driver are still alive.
+        try:
+            stats = self.client.stats
+        except Exception as e:
+            logger.debug(f"Could not fetch session stats on quit: {e}")
+            stats = None
+        self._stop_tracing()
+        if stats is not None:
+            self._artifacts.save_token_stats(stats)
         self.client.quit()
         self.driver.quit()
 
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
+    def _start_tracing(self) -> bool:
+        """Best-effort start of Playwright tracing. Returns True if this session owns the trace."""
+        if not isinstance(self.driver, PlaywrightDriver):
+            return False
+        try:
+            self.driver.page.context.tracing.start(screenshots=True, snapshots=True)
+            return True
+        except Exception as e:
+            # E.g. the caller already started tracing on this context — don't interfere.
+            logger.debug(f"Playwright tracing not started: {e}")
+            return False
+
+    def _stop_tracing(self) -> None:
+        if not self._tracing or not isinstance(self.driver, PlaywrightDriver):
+            return
+        try:
+            self._artifacts.ensure_dir()
+            self.driver.page.context.tracing.stop(path=str(self._artifacts.trace_path))
+        except Exception as e:
+            logger.warning(f"Failed to stop Playwright tracing: {e}")
+        finally:
+            self._tracing = False
+
+    def _accumulate_usage(self) -> None:
+        """Add the most recent client call's token usage to the current step's running total."""
+        self._metric_usage = self._metric_usage + TokenUsage.from_dict(self.client.last_usage)
+
+    def _capture_screenshot(self, label: str) -> Artifact | None:
+        try:
+            self._step_counter += 1
+            return self._artifacts.save_screenshot(self._step_counter, label, self.driver.screenshot)
+        except Exception as e:
+            logger.debug(f"Screenshot capture skipped: {e}")
+            return None
+
+    @contextmanager
+    def _record_step(self, kind: Literal["do", "check", "get"], label: str):
+        """Record one StepMetrics per public do/check/get call (outcome via thrown exception)."""
+        started_at = time.time()
+        monotonic_start = time.monotonic()
+        outcome: Literal["passed", "failed"] = "passed"
+        try:
+            yield
+        except Exception:
+            outcome = "failed"
+            raise
+        finally:
+            duration = time.monotonic() - monotonic_start
+            artifact = self._capture_screenshot(label)
+            self._steps.append(
+                StepMetrics(
+                    kind=kind,
+                    label=label,
+                    outcome=outcome,
+                    started_at=started_at,
+                    finished_at=time.time(),
+                    duration=duration,
+                    tokens=self._metric_usage,
+                    artifacts=[artifact] if artifact is not None else [],
+                )
+            )
+
     def do(self, goal: str) -> DoResult:
         """
         Executes a series of steps to achieve the given goal.
@@ -93,12 +177,19 @@ class Alumni:
         Returns:
             DoResult containing the explanation and executed steps with their actions.
         """
+        with self._record_step("do", goal):
+            return self._do(goal)
+
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
+    def _do(self, goal: str) -> DoResult:
+        self._metric_usage = TokenUsage()
         app = self.driver.app
         self.driver.reset_accessibility_tree()
         initial_accessibility_tree = self.driver.accessibility_tree
         before_tree = initial_accessibility_tree.to_str() if self.change_analysis else None
         before_url = self.driver.url if self.change_analysis else None
         explanation, steps = self.client.plan_actions(goal, initial_accessibility_tree.to_str(), app=app)
+        self._accumulate_usage()
 
         executed_steps = []
         for idx, step in enumerate(steps):
@@ -107,6 +198,7 @@ class Alumni:
                 self.driver.reset_accessibility_tree()
             accessibility_tree = self.driver.accessibility_tree
             actor_explanation, actions = self.client.execute_action(goal, step, accessibility_tree.to_str(), app=app)
+            self._accumulate_usage()
 
             # When planner is off, explanation is just the goal — replace with actor's reasoning.
             if explanation == goal:
@@ -136,7 +228,6 @@ class Alumni:
 
         return DoResult(explanation=explanation, steps=executed_steps, changes=changes)
 
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
     def check(self, statement: str, vision: bool = False) -> str:
         """
         Checks a given statement true or false.
@@ -151,6 +242,12 @@ class Alumni:
         Raises:
             AssertionError: If the verification fails.
         """
+        with self._record_step("check", statement):
+            return self._check(statement, vision)
+
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
+    def _check(self, statement: str, vision: bool = False) -> str:
+        self._metric_usage = TokenUsage()
         self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             f"Is the following true or false - {statement}",
@@ -160,10 +257,10 @@ class Alumni:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
+        self._accumulate_usage()
         assert value, explanation
         return explanation
 
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
     def get(self, data: str, vision: bool = False) -> Data:
         """
         Extracts requested data from the page.
@@ -175,6 +272,12 @@ class Alumni:
         Returns:
             The extracted data. If data cannot be extracted, returns the explanation string.
         """
+        with self._record_step("get", data):
+            return self._get(data, vision)
+
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
+    def _get(self, data: str, vision: bool = False) -> Data:
+        self._metric_usage = TokenUsage()
         self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             data,
@@ -184,6 +287,7 @@ class Alumni:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
+        self._accumulate_usage()
         return explanation if value is None else value
 
     @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
@@ -249,3 +353,35 @@ class Alumni:
         Returns the stats of the session.
         """
         return self.client.stats
+
+    @property
+    def metrics(self) -> SessionMetrics:
+        """
+        Returns per-step execution metrics for the session (issue #293).
+
+        Steps are ordered by call: ``metrics.steps[i]`` is the i-th do()/check()/get() call.
+        Read before ``quit()`` for server-authoritative session token totals.
+        """
+        finished_at = time.time()
+        try:
+            tokens = SessionTokens.from_dict(self.client.stats)
+        except Exception as e:
+            logger.debug(f"Falling back to summed step tokens for session metrics: {e}")
+            total = TokenUsage()
+            for step in self._steps:
+                total = total + step.tokens
+            tokens = SessionTokens(total=total)
+        return SessionMetrics(
+            started_at=self._metrics_started_at,
+            finished_at=finished_at,
+            duration=finished_at - self._metrics_started_at,
+            tokens=tokens,
+            steps=list(self._steps),
+        )
+
+    @property
+    def artifacts_dir(self) -> Path:
+        """
+        Returns the directory where per-session artifacts (screenshots, traces) are written.
+        """
+        return self._artifacts.dir

--- a/packages/python/src/alumnium/alumni.py
+++ b/packages/python/src/alumnium/alumni.py
@@ -1,9 +1,10 @@
 import time
 from asyncio import AbstractEventLoop
-from contextlib import contextmanager
+from functools import wraps
 from os import getenv
 from pathlib import Path
-from typing import Literal
+from types import FunctionType
+from typing import Literal, cast
 
 from appium.webdriver.webdriver import WebDriver as Appium
 from playwright.async_api import Page as PageAsync
@@ -11,7 +12,16 @@ from playwright.sync_api import Page
 from retry import retry
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from . import ARTIFACTS_DIR, CHANGE_ANALYSIS, DELAY, EXCLUDE_ATTRIBUTES, PLANNER, RETRIES
+from . import (
+    ARTIFACTS_DIR,
+    CAPTURE_SCREENSHOTS,
+    CHANGE_ANALYSIS,
+    DELAY,
+    DRIVER_TRACE,
+    EXCLUDE_ATTRIBUTES,
+    PLANNER,
+    RETRIES,
+)
 from .area import Area
 from .artifacts_store import ArtifactsStore
 from .cache import Cache
@@ -31,6 +41,47 @@ from .tools import BaseTool
 logger = get_logger(__name__)
 
 
+def record_metrics(method: FunctionType):
+    """
+    Records one `StepMetrics` entry per public `do()`/`check()`/`get()` call.
+
+    Wraps the retried method, so the recorded duration and token usage cover every attempt and the
+    outcome is decided by whether the call ultimately raised. The step kind is the method name and
+    the label is its first argument (the goal, statement, or data description).
+    """
+
+    kind = cast(Literal["do", "check", "get"], method.__name__)
+
+    @wraps(method)
+    def wrapper(self: "Alumni", label: str, *args, **kwargs):
+        started_at = time.time()
+        monotonic_start = time.monotonic()
+        usage_before = self.client.usage_total
+        outcome: Literal["passed", "failed"] = "passed"
+        try:
+            return method(self, label, *args, **kwargs)
+        except Exception:
+            outcome = "failed"
+            raise
+        finally:
+            duration = time.monotonic() - monotonic_start
+            artifact = self._capture_screenshot(label)
+            self._steps.append(
+                StepMetrics(
+                    kind=kind,
+                    label=label,
+                    outcome=outcome,
+                    started_at=started_at,
+                    finished_at=time.time(),
+                    duration=duration,
+                    tokens=self.client.usage_total - usage_before,
+                    artifacts=[artifact] if artifact is not None else [],
+                )
+            )
+
+    return wrapper
+
+
 class Alumni:
     def __init__(
         self,
@@ -41,15 +92,19 @@ class Alumni:
         planner: bool | None = None,
         change_analysis: bool | None = None,
         exclude_attributes: set[str] | None = None,
+        capture_screenshots: bool | None = None,
+        driver_trace: bool | None = None,
     ):
         planner = planner if planner is not None else PLANNER
         self.change_analysis = change_analysis if change_analysis is not None else CHANGE_ANALYSIS
         exclude_attributes = exclude_attributes if exclude_attributes is not None else EXCLUDE_ATTRIBUTES
+        self.capture_screenshots = capture_screenshots if capture_screenshots is not None else CAPTURE_SCREENSHOTS
+        driver_trace = driver_trace if driver_trace is not None else DRIVER_TRACE
 
         if isinstance(driver, Appium):
             self.driver = AppiumDriver(driver)
         elif isinstance(driver, Page):
-            self.driver = PlaywrightDriver(driver)
+            self.driver = PlaywrightDriver(driver, driver_trace=driver_trace)
         elif (
             isinstance(driver, tuple) and isinstance(driver[0], PageAsync) and isinstance(driver[1], AbstractEventLoop)
         ):
@@ -88,51 +143,17 @@ class Alumni:
         self._artifacts = ArtifactsStore(str(self.client.session_id), ARTIFACTS_DIR or None)
         self._steps: list[StepMetrics] = []
         self._step_counter = 0
-        self._metric_usage = TokenUsage()
         self._metrics_started_at = time.time()
-        self._tracing = self._start_tracing()
 
     def quit(self) -> None:
-        # Capture stats + trace while the session and driver are still alive.
-        try:
-            stats = self.client.stats
-        except Exception as e:
-            logger.debug(f"Could not fetch session stats on quit: {e}")
-            stats = None
-        self._stop_tracing()
-        if stats is not None:
-            self._artifacts.save_token_stats(stats)
+        # Write the driver trace while the session and driver are still alive.
+        self.driver.save_trace(self._artifacts.trace_path)
         self.client.quit()
         self.driver.quit()
 
-    def _start_tracing(self) -> bool:
-        """Best-effort start of Playwright tracing. Returns True if this session owns the trace."""
-        if not isinstance(self.driver, PlaywrightDriver):
-            return False
-        try:
-            self.driver.page.context.tracing.start(screenshots=True, snapshots=True)
-            return True
-        except Exception as e:
-            # E.g. the caller already started tracing on this context — don't interfere.
-            logger.debug(f"Playwright tracing not started: {e}")
-            return False
-
-    def _stop_tracing(self) -> None:
-        if not self._tracing or not isinstance(self.driver, PlaywrightDriver):
-            return
-        try:
-            self._artifacts.ensure_dir()
-            self.driver.page.context.tracing.stop(path=str(self._artifacts.trace_path))
-        except Exception as e:
-            logger.warning(f"Failed to stop Playwright tracing: {e}")
-        finally:
-            self._tracing = False
-
-    def _accumulate_usage(self) -> None:
-        """Add the most recent client call's token usage to the current step's running total."""
-        self._metric_usage = self._metric_usage + TokenUsage.from_dict(self.client.last_usage)
-
     def _capture_screenshot(self, label: str) -> Artifact | None:
+        if not self.capture_screenshots:
+            return None
         try:
             self._step_counter += 1
             return self._artifacts.save_screenshot(self._step_counter, label, self.driver.screenshot)
@@ -140,33 +161,8 @@ class Alumni:
             logger.debug(f"Screenshot capture skipped: {e}")
             return None
 
-    @contextmanager
-    def _record_step(self, kind: Literal["do", "check", "get"], label: str):
-        """Record one StepMetrics per public do/check/get call (outcome via thrown exception)."""
-        started_at = time.time()
-        monotonic_start = time.monotonic()
-        outcome: Literal["passed", "failed"] = "passed"
-        try:
-            yield
-        except Exception:
-            outcome = "failed"
-            raise
-        finally:
-            duration = time.monotonic() - monotonic_start
-            artifact = self._capture_screenshot(label)
-            self._steps.append(
-                StepMetrics(
-                    kind=kind,
-                    label=label,
-                    outcome=outcome,
-                    started_at=started_at,
-                    finished_at=time.time(),
-                    duration=duration,
-                    tokens=self._metric_usage,
-                    artifacts=[artifact] if artifact is not None else [],
-                )
-            )
-
+    @record_metrics
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
     def do(self, goal: str) -> DoResult:
         """
         Executes a series of steps to achieve the given goal.
@@ -177,19 +173,12 @@ class Alumni:
         Returns:
             DoResult containing the explanation and executed steps with their actions.
         """
-        with self._record_step("do", goal):
-            return self._do(goal)
-
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
-    def _do(self, goal: str) -> DoResult:
-        self._metric_usage = TokenUsage()
         app = self.driver.app
         self.driver.reset_accessibility_tree()
         initial_accessibility_tree = self.driver.accessibility_tree
         before_tree = initial_accessibility_tree.to_str() if self.change_analysis else None
         before_url = self.driver.url if self.change_analysis else None
         explanation, steps = self.client.plan_actions(goal, initial_accessibility_tree.to_str(), app=app)
-        self._accumulate_usage()
 
         executed_steps = []
         for idx, step in enumerate(steps):
@@ -198,7 +187,6 @@ class Alumni:
                 self.driver.reset_accessibility_tree()
             accessibility_tree = self.driver.accessibility_tree
             actor_explanation, actions = self.client.execute_action(goal, step, accessibility_tree.to_str(), app=app)
-            self._accumulate_usage()
 
             # When planner is off, explanation is just the goal — replace with actor's reasoning.
             if explanation == goal:
@@ -228,6 +216,8 @@ class Alumni:
 
         return DoResult(explanation=explanation, steps=executed_steps, changes=changes)
 
+    @record_metrics
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
     def check(self, statement: str, vision: bool = False) -> str:
         """
         Checks a given statement true or false.
@@ -242,12 +232,6 @@ class Alumni:
         Raises:
             AssertionError: If the verification fails.
         """
-        with self._record_step("check", statement):
-            return self._check(statement, vision)
-
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
-    def _check(self, statement: str, vision: bool = False) -> str:
-        self._metric_usage = TokenUsage()
         self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             f"Is the following true or false - {statement}",
@@ -257,10 +241,11 @@ class Alumni:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
-        self._accumulate_usage()
         assert value, explanation
         return explanation
 
+    @record_metrics
+    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
     def get(self, data: str, vision: bool = False) -> Data:
         """
         Extracts requested data from the page.
@@ -272,12 +257,6 @@ class Alumni:
         Returns:
             The extracted data. If data cannot be extracted, returns the explanation string.
         """
-        with self._record_step("get", data):
-            return self._get(data, vision)
-
-    @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]
-    def _get(self, data: str, vision: bool = False) -> Data:
-        self._metric_usage = TokenUsage()
         self.driver.reset_accessibility_tree()
         explanation, value = self.client.retrieve(
             data,
@@ -287,7 +266,6 @@ class Alumni:
             screenshot=self.driver.screenshot if vision else None,
             app=self.driver.app,
         )
-        self._accumulate_usage()
         return explanation if value is None else value
 
     @retry(tries=RETRIES, delay=DELAY, logger=logger)  # pyright: ignore[reportArgumentType]

--- a/packages/python/src/alumnium/artifacts_store.py
+++ b/packages/python/src/alumnium/artifacts_store.py
@@ -1,4 +1,3 @@
-import json
 import re
 from base64 import b64decode
 from pathlib import Path
@@ -45,25 +44,3 @@ class ArtifactsStore:
     def trace_path(self) -> Path:
         """Path where a Playwright trace archive is written (on quit)."""
         return self.dir / "trace.zip"
-
-    def trace_artifact(self) -> Artifact | None:
-        """Return an Artifact for the trace archive if it exists on disk."""
-        if self.trace_path.exists():
-            return Artifact(path=self.trace_path, kind="trace", mime="application/zip")
-        return None
-
-    def ensure_dir(self) -> Path:
-        """Create and return the session artifacts directory."""
-        self.dir.mkdir(parents=True, exist_ok=True)
-        return self.dir
-
-    def save_token_stats(self, stats: dict) -> Path | None:
-        """Persist session token stats to token-stats.json. Returns None on failure (non-fatal)."""
-        try:
-            self.ensure_dir()
-            path = self.dir / "token-stats.json"
-            path.write_text(json.dumps(stats, indent=2))
-            return path
-        except Exception as e:
-            logger.warning(f"Failed to save token stats: {e}")
-            return None

--- a/packages/python/src/alumnium/artifacts_store.py
+++ b/packages/python/src/alumnium/artifacts_store.py
@@ -1,0 +1,69 @@
+import json
+import re
+from base64 import b64decode
+from pathlib import Path
+
+from .logutils import get_logger
+from .metrics import Artifact
+
+logger = get_logger(__name__)
+
+
+def _kebab_case(text: str) -> str:
+    """Sanitize a label into a filesystem-safe, kebab-cased slug (max 50 chars)."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text).strip("-").lower()
+    return slug[:50] or "step"
+
+
+class ArtifactsStore:
+    """Writes per-session execution artifacts (screenshots, traces) to disk.
+
+    Mirrors the MCP server's artifacts store: files live under
+    ``<base>/<session_id>/`` where ``<base>`` defaults to ``~/.alumnium/artifacts``
+    and can be overridden with the ``ALUMNIUM_ARTIFACTS_DIR`` environment variable.
+    """
+
+    def __init__(self, session_id: str, base_dir: str | None = None):
+        root = Path(base_dir).expanduser() if base_dir else Path.home() / ".alumnium" / "artifacts"
+        self.dir = root / str(session_id)
+        self._screenshots_dir = self.dir / "screenshots"
+
+    def save_screenshot(self, step_num: int, label: str, screenshot: str) -> Artifact | None:
+        """Save a base64-encoded PNG screenshot for a step. Returns None on failure (non-fatal)."""
+        try:
+            filename = f"{step_num:02d}-{_kebab_case(label)}.png"
+            self._screenshots_dir.mkdir(parents=True, exist_ok=True)
+            path = self._screenshots_dir / filename
+            path.write_bytes(b64decode(screenshot))
+            logger.debug(f"Saved screenshot to {path}")
+            return Artifact(path=path, kind="screenshot", mime="image/png")
+        except Exception as e:
+            logger.warning(f"Failed to save screenshot: {e}")
+            return None
+
+    @property
+    def trace_path(self) -> Path:
+        """Path where a Playwright trace archive is written (on quit)."""
+        return self.dir / "trace.zip"
+
+    def trace_artifact(self) -> Artifact | None:
+        """Return an Artifact for the trace archive if it exists on disk."""
+        if self.trace_path.exists():
+            return Artifact(path=self.trace_path, kind="trace", mime="application/zip")
+        return None
+
+    def ensure_dir(self) -> Path:
+        """Create and return the session artifacts directory."""
+        self.dir.mkdir(parents=True, exist_ok=True)
+        return self.dir
+
+    def save_token_stats(self, stats: dict) -> Path | None:
+        """Persist session token stats to token-stats.json. Returns None on failure (non-fatal)."""
+        try:
+            self.ensure_dir()
+            path = self.dir / "token-stats.json"
+            path.write_text(json.dumps(stats, indent=2))
+            return path
+        except Exception as e:
+            logger.warning(f"Failed to save token stats: {e}")
+            return None

--- a/packages/python/src/alumnium/clients/http_client.py
+++ b/packages/python/src/alumnium/clients/http_client.py
@@ -9,6 +9,7 @@ from requests import ConnectionError, delete, get, post
 
 from ..cli import run_server
 from ..logutils import get_logger
+from ..metrics import TokenUsage
 from ..models import Model
 from ..tools.base_tool import BaseTool
 from ..tools.tool_to_schema_converter import convert_tools_to_schemas
@@ -32,8 +33,9 @@ class HttpClient:
         self._server_pid: str | None = None
         self.base_url = self._resolve_url(url)
         self.session_id = None
-        # Token usage reported by the most recent plan/step/statement call.
-        self.last_usage: dict[str, int] = {}
+        # Cumulative token usage across all plan/step/statement calls in this session.
+        # Reassigned, never mutated in place, so callers can hold a snapshot and diff against it.
+        self.usage_total = TokenUsage()
 
         tool_schemas = convert_tools_to_schemas(tools)
 
@@ -71,6 +73,9 @@ class HttpClient:
         response.raise_for_status()
         return response.json()
 
+    def _accumulate_usage(self, response_data: dict) -> None:
+        self.usage_total = self.usage_total + TokenUsage.from_dict(response_data.get("usage"))
+
     def quit(self):
         try:
             if self.session_id:
@@ -100,7 +105,7 @@ class HttpClient:
         )
         response.raise_for_status()
         response_data = response.json()
-        self.last_usage = response_data.get("usage") or {}
+        self._accumulate_usage(response_data)
         return (response_data["explanation"], response_data["steps"])
 
     def add_example(self, goal: str, actions: list[str]):
@@ -129,7 +134,7 @@ class HttpClient:
         )
         response.raise_for_status()
         data = response.json()
-        self.last_usage = data.get("usage") or {}
+        self._accumulate_usage(data)
         return data["explanation"], data["actions"]
 
     def retrieve(
@@ -155,7 +160,7 @@ class HttpClient:
         )
         response.raise_for_status()
         data = response.json()
-        self.last_usage = data.get("usage") or {}
+        self._accumulate_usage(data)
         return data["explanation"], loosely_typecast(data["result"])
 
     def find_area(self, description: str, accessibility_tree: str, app: str = "unknown"):

--- a/packages/python/src/alumnium/clients/http_client.py
+++ b/packages/python/src/alumnium/clients/http_client.py
@@ -32,6 +32,8 @@ class HttpClient:
         self._server_pid: str | None = None
         self.base_url = self._resolve_url(url)
         self.session_id = None
+        # Token usage reported by the most recent plan/step/statement call.
+        self.last_usage: dict[str, int] = {}
 
         tool_schemas = convert_tools_to_schemas(tools)
 
@@ -98,6 +100,7 @@ class HttpClient:
         )
         response.raise_for_status()
         response_data = response.json()
+        self.last_usage = response_data.get("usage") or {}
         return (response_data["explanation"], response_data["steps"])
 
     def add_example(self, goal: str, actions: list[str]):
@@ -126,6 +129,7 @@ class HttpClient:
         )
         response.raise_for_status()
         data = response.json()
+        self.last_usage = data.get("usage") or {}
         return data["explanation"], data["actions"]
 
     def retrieve(
@@ -151,6 +155,7 @@ class HttpClient:
         )
         response.raise_for_status()
         data = response.json()
+        self.last_usage = data.get("usage") or {}
         return data["explanation"], loosely_typecast(data["result"])
 
     def find_area(self, description: str, accessibility_tree: str, app: str = "unknown"):

--- a/packages/python/src/alumnium/drivers/base_driver.py
+++ b/packages/python/src/alumnium/drivers/base_driver.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from ..accessibility import BaseAccessibilityTree
 from . import Element
@@ -43,6 +44,14 @@ class BaseDriver(ABC):
     @abstractmethod
     def quit(self):
         pass
+
+    def save_trace(self, path: Path) -> bool:
+        """
+        Stops the driver trace started at initialization and writes it to the given path.
+
+        Returns False when the driver does not support tracing or tracing was not started.
+        """
+        return False
 
     @abstractmethod
     def back(self):

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -34,7 +34,7 @@ class PlaywrightDriver(BaseDriver):
             f"{{ const arguments = [...scriptArgs, resolve]; {f.read()} }})"
         )
 
-    def __init__(self, page: Page):
+    def __init__(self, page: Page, driver_trace: bool = False):
         self.page = page
         self.autoswitch_to_new_tab = True
         self.full_page_screenshot = FULL_PAGE_SCREENSHOT
@@ -47,8 +47,11 @@ class PlaywrightDriver(BaseDriver):
             UploadTool,
         }
         self.oopif_frames: set[Frame] = set()
+        self._tracing = False
         self._init_cdp_session()
         self._setup_page_tracking(page)
+        if driver_trace:
+            self._start_tracing()
 
     @property
     def platform(self) -> str:
@@ -117,7 +120,20 @@ class PlaywrightDriver(BaseDriver):
             self.page.keyboard.press(key.value)
 
     def quit(self):
+        # Discard the trace if nobody claimed it via save_trace(), so the context closes cleanly.
+        self._stop_tracing()
         self.page.close()
+
+    def save_trace(self, path: Path) -> bool:
+        if not self._tracing:
+            return False
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._stop_tracing(path)
+            return path.exists()
+        except Exception as e:
+            logger.warning(f"Failed to save Playwright trace: {e}")
+            return False
 
     def back(self):
         self.page.go_back()
@@ -229,6 +245,24 @@ class PlaywrightDriver(BaseDriver):
         logger.debug(f"Auto-switching to new tab {page.title()} ({page.url})")
         self.page = page
         self._init_cdp_session()
+
+    def _start_tracing(self):
+        try:
+            self.page.context.tracing.start(screenshots=True, snapshots=True)
+            self._tracing = True
+        except Exception as e:
+            # E.g. the caller already started tracing on this context — don't interfere.
+            logger.warning(f"Playwright tracing not started: {e}")
+
+    def _stop_tracing(self, path: Path | None = None):
+        if not self._tracing:
+            return
+        try:
+            self.page.context.tracing.stop(path=str(path) if path else None)
+        except Exception as e:
+            logger.debug(f"Failed to stop Playwright tracing: {e}")
+        finally:
+            self._tracing = False
 
     def _send_cdp_command(self, method: str, params: dict | None = None):
         return self.client.send(method, params or {})

--- a/packages/python/src/alumnium/metrics.py
+++ b/packages/python/src/alumnium/metrics.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+# Field names mirror the server's `LlmUsage` schema (packages/typescript/src/llm/llmSchema.ts)
+# verbatim so the server -> client -> reporter layers cannot drift.
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cache_creation",
+    "cache_read",
+    "reasoning",
+)
+
+
+@dataclass
+class TokenUsage:
+    """Token usage for a single call or aggregated across a session."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+    cache_creation: int = 0
+    cache_read: int = 0
+    reasoning: int = 0
+
+    @staticmethod
+    def from_dict(data: dict[str, int] | None) -> "TokenUsage":
+        """Build a TokenUsage from a server `LlmUsage` payload, ignoring unknown keys."""
+        data = data or {}
+        return TokenUsage(**{name: int(data.get(name, 0)) for name in _TOKEN_FIELDS})
+
+    def __add__(self, other: "TokenUsage") -> "TokenUsage":
+        return TokenUsage(**{name: getattr(self, name) + getattr(other, name) for name in _TOKEN_FIELDS})
+
+
+@dataclass
+class SessionTokens:
+    """Session-level token usage, mirroring the server's `LlmUsageStats` shape.
+
+    `cache` is a sibling of `total` (the cache-attributable subset). The MCP server exposes this as
+    "cached"; the library standardises on the server's "cache" name.
+    """
+
+    total: TokenUsage = field(default_factory=TokenUsage)
+    cache: TokenUsage = field(default_factory=TokenUsage)
+
+    @staticmethod
+    def from_dict(data: dict[str, dict[str, int]] | None) -> "SessionTokens":
+        data = data or {}
+        return SessionTokens(
+            total=TokenUsage.from_dict(data.get("total")),
+            cache=TokenUsage.from_dict(data.get("cache")),
+        )
+
+
+@dataclass
+class Artifact:
+    """A file captured during a step (screenshot, trace, ...), typed so consumers route by kind/mime."""
+
+    path: Path
+    kind: Literal["screenshot", "trace"]
+    mime: str
+
+
+@dataclass
+class StepMetrics:
+    """Metrics for a single public `do()`/`check()`/`get()` call.
+
+    Correlation is positional: entries appear in `SessionMetrics.steps` in call order.
+    """
+
+    kind: Literal["do", "check", "get"]
+    label: str
+    outcome: Literal["passed", "failed"]
+    started_at: float
+    finished_at: float
+    duration: float
+    tokens: TokenUsage = field(default_factory=TokenUsage)
+    artifacts: list[Artifact] = field(default_factory=list)
+
+
+@dataclass
+class SessionMetrics:
+    """Execution metrics for an Alumni session, read via `al.metrics`."""
+
+    started_at: float
+    finished_at: float
+    duration: float
+    tokens: SessionTokens = field(default_factory=SessionTokens)
+    steps: list[StepMetrics] = field(default_factory=list)
+
+    @property
+    def last(self) -> StepMetrics | None:
+        """The most recently recorded step, or None if no calls have been made."""
+        return self.steps[-1] if self.steps else None

--- a/packages/python/src/alumnium/metrics.py
+++ b/packages/python/src/alumnium/metrics.py
@@ -34,6 +34,10 @@ class TokenUsage:
     def __add__(self, other: "TokenUsage") -> "TokenUsage":
         return TokenUsage(**{name: getattr(self, name) + getattr(other, name) for name in _TOKEN_FIELDS})
 
+    def __sub__(self, other: "TokenUsage") -> "TokenUsage":
+        """Field-wise delta, mirroring the server's `subtractLlmUsage` (no clamping)."""
+        return TokenUsage(**{name: getattr(self, name) - getattr(other, name) for name in _TOKEN_FIELDS})
+
 
 @dataclass
 class SessionTokens:

--- a/packages/python/tests/drivers/test_playwright_driver_trace.py
+++ b/packages/python/tests/drivers/test_playwright_driver_trace.py
@@ -1,0 +1,87 @@
+from alumnium.drivers.playwright_driver import PlaywrightDriver
+from alumnium.drivers.selenium_driver import SeleniumDriver
+
+
+class _FakeTracing:
+    def __init__(self, start_error: Exception | None = None):
+        self.start_error = start_error
+        self.started = False
+        self.stopped_with: list[str | None] = []
+
+    def start(self, screenshots: bool = False, snapshots: bool = False):
+        if self.start_error:
+            raise self.start_error
+        self.started = True
+
+    def stop(self, path: str | None = None):
+        self.stopped_with.append(path)
+        if path:
+            open(path, "w").close()
+
+
+class _FakeContext:
+    def __init__(self, tracing: _FakeTracing):
+        self.tracing = tracing
+
+
+class _FakePage:
+    def __init__(self, tracing: _FakeTracing):
+        self.context = _FakeContext(tracing)
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _make_driver(trace: bool, start_error: Exception | None = None) -> tuple[PlaywrightDriver, _FakePage]:
+    """Build a PlaywrightDriver without a live browser to exercise the trace lifecycle."""
+    page = _FakePage(_FakeTracing(start_error))
+    driver = object.__new__(PlaywrightDriver)
+    driver.page = page  # type: ignore[assignment]
+    driver._tracing = False
+    if trace:
+        driver._start_tracing()
+    return driver, page
+
+
+def test_save_trace_writes_archive_when_tracing_enabled(tmp_path):
+    driver, page = _make_driver(trace=True)
+    path = tmp_path / "session" / "trace.zip"
+
+    assert driver.save_trace(path) is True
+    assert path.exists()
+    assert page.context.tracing.stopped_with == [str(path)]
+
+    # The trace is already claimed, so quitting does not stop tracing again.
+    driver.quit()
+    assert page.context.tracing.stopped_with == [str(path)]
+    assert page.closed
+
+
+def test_save_trace_is_noop_when_tracing_disabled(tmp_path):
+    driver, page = _make_driver(trace=False)
+    path = tmp_path / "trace.zip"
+
+    assert driver.save_trace(path) is False
+    assert not path.exists()
+    assert page.context.tracing.stopped_with == []
+
+
+def test_start_tracing_tolerates_context_already_traced(tmp_path):
+    driver, _ = _make_driver(trace=True, start_error=RuntimeError("Tracing has already been started"))
+
+    assert driver._tracing is False
+    assert driver.save_trace(tmp_path / "trace.zip") is False
+
+
+def test_quit_stops_unclaimed_trace():
+    driver, page = _make_driver(trace=True)
+    driver.quit()
+
+    assert page.context.tracing.stopped_with == [None]
+    assert page.closed
+
+
+def test_other_drivers_do_not_support_tracing(tmp_path):
+    driver = object.__new__(SeleniumDriver)
+    assert driver.save_trace(tmp_path / "trace.zip") is False

--- a/packages/python/tests/test_alumni_metrics.py
+++ b/packages/python/tests/test_alumni_metrics.py
@@ -1,0 +1,80 @@
+import pytest
+
+from alumnium.alumni import Alumni
+from alumnium.artifacts_store import ArtifactsStore
+from alumnium.metrics import TokenUsage
+
+# A valid 1x1 transparent PNG, base64-encoded.
+PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+class _FakeDriver:
+    @property
+    def screenshot(self) -> str:
+        return PNG_1X1
+
+
+class _FakeClient:
+    def __init__(self, stats: dict):
+        self._stats = stats
+        self.last_usage: dict = {}
+
+    @property
+    def stats(self) -> dict:
+        return self._stats
+
+
+def _make_alumni(tmp_path, stats: dict | None = None) -> Alumni:
+    """Build an Alumni instance without a live server/driver to exercise metrics recording."""
+    al = object.__new__(Alumni)
+    al.driver = _FakeDriver()
+    al.client = _FakeClient(stats or {"total": {}, "cache": {}})
+    al._artifacts = ArtifactsStore("sess", str(tmp_path))
+    al._steps = []
+    al._step_counter = 0
+    al._metric_usage = TokenUsage()
+    al._metrics_started_at = 100.0
+    return al
+
+
+def test_record_step_passed_captures_tokens_and_artifact(tmp_path):
+    al = _make_alumni(tmp_path)
+    with al._record_step("do", "click button"):
+        al._metric_usage = TokenUsage(input_tokens=7, total_tokens=7)
+
+    assert len(al._steps) == 1
+    step = al._steps[0]
+    assert step.kind == "do"
+    assert step.label == "click button"
+    assert step.outcome == "passed"
+    assert step.tokens.input_tokens == 7
+    assert step.finished_at >= step.started_at
+    assert step.duration >= 0
+    assert len(step.artifacts) == 1
+    assert step.artifacts[0].kind == "screenshot"
+    assert step.artifacts[0].path.exists()
+
+
+def test_record_step_failed_on_exception_and_reraises(tmp_path):
+    al = _make_alumni(tmp_path)
+    with pytest.raises(AssertionError):
+        with al._record_step("check", "total is 5"):
+            raise AssertionError("nope")
+
+    assert len(al._steps) == 1
+    assert al._steps[0].outcome == "failed"
+    assert al._steps[0].kind == "check"
+
+
+def test_metrics_property_uses_server_totals_and_ordered_steps(tmp_path):
+    al = _make_alumni(tmp_path, stats={"total": {"input_tokens": 42}, "cache": {"cache_read": 3}})
+    with al._record_step("get", "cart total"):
+        al._metric_usage = TokenUsage(input_tokens=42, total_tokens=42)
+
+    metrics = al.metrics
+    assert metrics.tokens.total.input_tokens == 42
+    assert metrics.tokens.cache.cache_read == 3
+    assert len(metrics.steps) == 1
+    assert metrics.steps[0].kind == "get"
+    assert metrics.last is metrics.steps[-1]
+    assert metrics.duration >= 0

--- a/packages/python/tests/test_alumni_metrics.py
+++ b/packages/python/tests/test_alumni_metrics.py
@@ -1,6 +1,6 @@
 import pytest
 
-from alumnium.alumni import Alumni
+from alumnium.alumni import Alumni, record_metrics
 from alumnium.artifacts_store import ArtifactsStore
 from alumnium.metrics import TokenUsage
 
@@ -15,32 +15,59 @@ class _FakeDriver:
 
 
 class _FakeClient:
+    """Stands in for HttpClient: accrues a cumulative token total the decorator diffs against."""
+
     def __init__(self, stats: dict):
         self._stats = stats
-        self.last_usage: dict = {}
+        self.usage_total = TokenUsage()
+
+    def spend(self, input_tokens: int) -> None:
+        self.usage_total = self.usage_total + TokenUsage(input_tokens=input_tokens, total_tokens=input_tokens)
 
     @property
     def stats(self) -> dict:
         return self._stats
 
 
-def _make_alumni(tmp_path, stats: dict | None = None) -> Alumni:
+def _make_alumni(tmp_path, stats: dict | None = None, capture_screenshots: bool = True) -> Alumni:
     """Build an Alumni instance without a live server/driver to exercise metrics recording."""
     al = object.__new__(Alumni)
     al.driver = _FakeDriver()
     al.client = _FakeClient(stats or {"total": {}, "cache": {}})
+    al.capture_screenshots = capture_screenshots
     al._artifacts = ArtifactsStore("sess", str(tmp_path))
     al._steps = []
     al._step_counter = 0
-    al._metric_usage = TokenUsage()
     al._metrics_started_at = 100.0
     return al
 
 
-def test_record_step_passed_captures_tokens_and_artifact(tmp_path):
+@record_metrics
+def do(self, goal: str) -> str:
+    self.client.spend(7)
+    return goal
+
+
+@record_metrics
+def check(self, statement: str) -> str:
+    self.client.spend(3)
+    raise AssertionError("nope")
+
+
+@record_metrics
+def check_no_spend(self, statement: str) -> str:
+    return statement
+
+
+@record_metrics
+def get(self, data: str) -> str:
+    self.client.spend(42)
+    return data
+
+
+def test_record_metrics_passed_captures_tokens_and_artifact(tmp_path):
     al = _make_alumni(tmp_path)
-    with al._record_step("do", "click button"):
-        al._metric_usage = TokenUsage(input_tokens=7, total_tokens=7)
+    assert do(al, "click button") == "click button"
 
     assert len(al._steps) == 1
     step = al._steps[0]
@@ -55,21 +82,48 @@ def test_record_step_passed_captures_tokens_and_artifact(tmp_path):
     assert step.artifacts[0].path.exists()
 
 
-def test_record_step_failed_on_exception_and_reraises(tmp_path):
+def test_record_metrics_failed_on_exception_and_reraises(tmp_path):
     al = _make_alumni(tmp_path)
     with pytest.raises(AssertionError):
-        with al._record_step("check", "total is 5"):
-            raise AssertionError("nope")
+        check(al, "total is 5")
 
     assert len(al._steps) == 1
     assert al._steps[0].outcome == "failed"
     assert al._steps[0].kind == "check"
+    # Tokens spent before the failure are still attributed to the step.
+    assert al._steps[0].tokens.input_tokens == 3
+
+
+def test_record_metrics_skips_screenshots_when_disabled(tmp_path):
+    al = _make_alumni(tmp_path, capture_screenshots=False)
+    do(al, "click button")
+
+    assert al._steps[0].artifacts == []
+    assert not (tmp_path / "sess" / "screenshots").exists()
+
+
+def test_record_metrics_reports_only_each_step_own_token_delta(tmp_path):
+    """The client total is cumulative, so each step must report its own delta, not the running sum."""
+    al = _make_alumni(tmp_path)
+    get(al, "cart total")
+    do(al, "click button")
+    get(al, "cart total again")
+
+    assert al.client.usage_total.input_tokens == 91
+    assert [step.tokens.input_tokens for step in al._steps] == [42, 7, 42]
+
+
+def test_record_metrics_records_zero_tokens_for_a_call_that_spends_nothing(tmp_path):
+    al = _make_alumni(tmp_path)
+    do(al, "click button")
+    check_no_spend(al, "nothing happens")
+
+    assert [step.tokens.input_tokens for step in al._steps] == [7, 0]
 
 
 def test_metrics_property_uses_server_totals_and_ordered_steps(tmp_path):
     al = _make_alumni(tmp_path, stats={"total": {"input_tokens": 42}, "cache": {"cache_read": 3}})
-    with al._record_step("get", "cart total"):
-        al._metric_usage = TokenUsage(input_tokens=42, total_tokens=42)
+    get(al, "cart total")
 
     metrics = al.metrics
     assert metrics.tokens.total.input_tokens == 42

--- a/packages/python/tests/test_artifacts_store.py
+++ b/packages/python/tests/test_artifacts_store.py
@@ -1,0 +1,41 @@
+from alumnium.artifacts_store import ArtifactsStore, _kebab_case
+
+# A valid 1x1 transparent PNG, base64-encoded.
+PNG_1X1 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+def test_kebab_case():
+    assert _kebab_case("Click the Login Button!") == "click-the-login-button"
+    assert _kebab_case("") == "step"
+    assert len(_kebab_case("a" * 100)) == 50
+
+
+def test_save_screenshot_writes_file_and_returns_typed_artifact(tmp_path):
+    store = ArtifactsStore("sess1", str(tmp_path))
+    artifact = store.save_screenshot(1, "Click login", PNG_1X1)
+
+    assert artifact is not None
+    assert artifact.kind == "screenshot"
+    assert artifact.mime == "image/png"
+    assert artifact.path.exists()
+    assert artifact.path.name == "01-click-login.png"
+    assert artifact.path.parent == tmp_path / "sess1" / "screenshots"
+
+
+def test_save_screenshot_non_fatal_on_bad_input(tmp_path):
+    store = ArtifactsStore("sess1", str(tmp_path))
+    # Invalid base64 must not raise — capture failures are best-effort.
+    assert store.save_screenshot(1, "x", "A") is None
+
+
+def test_save_token_stats(tmp_path):
+    store = ArtifactsStore("sess1", str(tmp_path))
+    path = store.save_token_stats({"total": {"input_tokens": 1}})
+    assert path is not None
+    assert path.exists()
+    assert "input_tokens" in path.read_text()
+
+
+def test_trace_artifact_absent_by_default(tmp_path):
+    store = ArtifactsStore("sess1", str(tmp_path))
+    assert store.trace_artifact() is None

--- a/packages/python/tests/test_artifacts_store.py
+++ b/packages/python/tests/test_artifacts_store.py
@@ -28,14 +28,7 @@ def test_save_screenshot_non_fatal_on_bad_input(tmp_path):
     assert store.save_screenshot(1, "x", "A") is None
 
 
-def test_save_token_stats(tmp_path):
+def test_trace_path_is_under_session_dir(tmp_path):
     store = ArtifactsStore("sess1", str(tmp_path))
-    path = store.save_token_stats({"total": {"input_tokens": 1}})
-    assert path is not None
-    assert path.exists()
-    assert "input_tokens" in path.read_text()
-
-
-def test_trace_artifact_absent_by_default(tmp_path):
-    store = ArtifactsStore("sess1", str(tmp_path))
-    assert store.trace_artifact() is None
+    assert store.trace_path == tmp_path / "sess1" / "trace.zip"
+    assert not store.trace_path.exists()

--- a/packages/python/tests/test_metrics.py
+++ b/packages/python/tests/test_metrics.py
@@ -23,6 +23,22 @@ def test_token_usage_add_is_pure():
     assert b.reasoning == 7
 
 
+def test_token_usage_sub_is_pure():
+    after = TokenUsage(input_tokens=10, output_tokens=8, total_tokens=18, reasoning=4)
+    before = TokenUsage(input_tokens=4, output_tokens=3, total_tokens=7)
+    delta = after - before
+    assert delta == TokenUsage(input_tokens=6, output_tokens=5, total_tokens=11, reasoning=4)
+    # Operands are not mutated.
+    assert after.input_tokens == 10
+    assert before.input_tokens == 4
+
+
+def test_token_usage_sub_does_not_clamp():
+    """Mirrors the server's `subtractLlmUsage`, which subtracts field-wise without clamping."""
+    delta = TokenUsage(input_tokens=1) - TokenUsage(input_tokens=4)
+    assert delta.input_tokens == -3
+
+
 def test_session_tokens_from_dict_mirrors_server_shape():
     tokens = SessionTokens.from_dict({"total": {"input_tokens": 10}, "cache": {"cache_read": 2}})
     assert tokens.total.input_tokens == 10

--- a/packages/python/tests/test_metrics.py
+++ b/packages/python/tests/test_metrics.py
@@ -1,0 +1,38 @@
+from alumnium.metrics import SessionMetrics, SessionTokens, StepMetrics, TokenUsage
+
+
+def test_token_usage_from_dict_defaults_and_ignores_unknown():
+    usage = TokenUsage.from_dict({"input_tokens": 3, "output_tokens": 4, "unknown": 99})
+    assert usage.input_tokens == 3
+    assert usage.output_tokens == 4
+    assert usage.total_tokens == 0
+    assert usage.reasoning == 0
+
+
+def test_token_usage_from_dict_none():
+    assert TokenUsage.from_dict(None) == TokenUsage()
+
+
+def test_token_usage_add_is_pure():
+    a = TokenUsage(input_tokens=1, output_tokens=2, total_tokens=3)
+    b = TokenUsage(input_tokens=4, output_tokens=5, total_tokens=6, reasoning=7)
+    total = a + b
+    assert total == TokenUsage(input_tokens=5, output_tokens=7, total_tokens=9, reasoning=7)
+    # Operands are not mutated.
+    assert a.input_tokens == 1
+    assert b.reasoning == 7
+
+
+def test_session_tokens_from_dict_mirrors_server_shape():
+    tokens = SessionTokens.from_dict({"total": {"input_tokens": 10}, "cache": {"cache_read": 2}})
+    assert tokens.total.input_tokens == 10
+    assert tokens.cache.cache_read == 2
+
+
+def test_session_metrics_last():
+    metrics = SessionMetrics(started_at=0.0, finished_at=1.0, duration=1.0)
+    assert metrics.last is None
+
+    step = StepMetrics(kind="do", label="x", outcome="passed", started_at=0.0, finished_at=0.5, duration=0.5)
+    metrics.steps.append(step)
+    assert metrics.last is step

--- a/packages/typescript/src/llm/llmSchema.test.ts
+++ b/packages/typescript/src/llm/llmSchema.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { createLlmUsage, subtractLlmUsage } from "./llmSchema.ts";
+
+describe("subtractLlmUsage", () => {
+  it("computes the per-call delta between two cumulative snapshots", () => {
+    const before = {
+      ...createLlmUsage(),
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+    };
+    const after = {
+      ...createLlmUsage(),
+      input_tokens: 25,
+      output_tokens: 12,
+      total_tokens: 37,
+      reasoning: 4,
+    };
+
+    expect(subtractLlmUsage(after, before)).toEqual({
+      input_tokens: 15,
+      output_tokens: 7,
+      total_tokens: 22,
+      cache_creation: 0,
+      cache_read: 0,
+      reasoning: 4,
+    });
+  });
+
+  it("returns zeros when nothing changed", () => {
+    const usage = { ...createLlmUsage(), input_tokens: 3 };
+    expect(subtractLlmUsage(usage, usage)).toEqual(createLlmUsage());
+  });
+});

--- a/packages/typescript/src/llm/llmSchema.ts
+++ b/packages/typescript/src/llm/llmSchema.ts
@@ -30,6 +30,18 @@ export function createLlmUsage(): LlmUsage {
   };
 }
 
+/**
+ * Compute the per-call token usage as the difference between two cumulative
+ * usage snapshots (taken before and after an agent invocation).
+ */
+export function subtractLlmUsage(after: LlmUsage, before: LlmUsage): LlmUsage {
+  const delta = createLlmUsage();
+  (Object.keys(delta) as (keyof LlmUsage)[]).forEach((key) => {
+    delta[key] = after[key] - before[key];
+  });
+  return delta;
+}
+
 export const LlmUsageStats = z.object({
   total: LlmUsage,
   cache: LlmUsage,

--- a/packages/typescript/src/server/serverApp.test.ts
+++ b/packages/typescript/src/server/serverApp.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { pushMock } from "../../tests/unit/mocks.ts";
+import { createLlmUsage } from "../llm/llmSchema.ts";
 import type { Http } from "../Http.ts";
 import { ActorAgent } from "./agents/ActorAgent.ts";
 import { AreaAgent } from "./agents/AreaAgent.ts";
@@ -199,6 +200,7 @@ describe("serverApp", () => {
           "Step 2: Enter 'Buy milk'",
           "Step 3: Press Enter",
         ],
+        usage: createLlmUsage(),
       });
     });
 
@@ -249,6 +251,7 @@ describe("serverApp", () => {
           { args: { id: 9, text: "Buy milk" }, name: "type" },
         ],
         explanation: "Clicking the element and typing text",
+        usage: createLlmUsage(),
       });
     });
   });
@@ -270,6 +273,7 @@ describe("serverApp", () => {
         explanation:
           "Found the requested information in the accessibility tree",
         result: "true",
+        usage: createLlmUsage(),
       });
     });
   });

--- a/packages/typescript/src/server/serverApp.ts
+++ b/packages/typescript/src/server/serverApp.ts
@@ -1,6 +1,6 @@
 import { cors } from "@elysiajs/cors";
 import { Elysia } from "elysia";
-import { LlmUsageStats } from "../llm/llmSchema.ts";
+import { LlmUsageStats, subtractLlmUsage } from "../llm/llmSchema.ts";
 import { Model } from "../Model.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
 import { AccessibilityTreeDiff } from "./accessibility/AccessibilityTreeDiff.ts";
@@ -125,6 +125,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                   const accessibilityTree = session.parseTree(
                     ctx.body.accessibility_tree,
                   );
+                  const usageBefore = session.stats.total;
                   const [explanation, steps] =
                     await session.plannerAgent.invoke(
                       ctx.body.goal,
@@ -133,6 +134,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                   return {
                     explanation,
                     steps,
+                    usage: subtractLlmUsage(session.stats.total, usageBefore),
                   };
                 } catch (error) {
                   logger.error(`Error generating plan: ${error}`);
@@ -163,6 +165,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                 const accessibilityTree = session.parseTree(
                   ctx.body.accessibility_tree,
                 );
+                const usageBefore = session.stats.total;
                 const [explanation, actions] = await session.actorAgent.invoke(
                   ctx.body.goal,
                   ctx.body.step,
@@ -171,6 +174,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                 return {
                   explanation,
                   actions: accessibilityTree.mapToolCallsToRawId(actions),
+                  usage: subtractLlmUsage(session.stats.total, usageBefore),
                 };
               },
               {
@@ -241,6 +245,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                     ...session.excludeAttributes,
                   ]),
                 );
+                const usageBefore = session.stats.total;
                 const [explanation, value] =
                   await session.retrieverAgent.invoke({
                     statement,
@@ -252,6 +257,7 @@ export const serverApp = new Elysia({ prefix: "/v1" })
                 return {
                   result: value,
                   explanation,
+                  usage: subtractLlmUsage(session.stats.total, usageBefore),
                 };
               },
               {

--- a/packages/typescript/src/server/serverSchema.ts
+++ b/packages/typescript/src/server/serverSchema.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "@langchain/core/language_models/base";
 import z from "zod";
+import { LlmUsage } from "../llm/llmSchema.ts";
 import { AppId } from "../AppId.ts";
 import { Driver } from "../drivers/Driver.ts";
 import { Model } from "../Model.ts";
@@ -90,6 +91,8 @@ export const CreatePlanBody = CacheableRequestBody.extend({
 export const CreatePlanResponse = z.object({
   explanation: z.string(),
   steps: z.array(z.string()),
+  // Per-call token usage consumed by this request (absent when the planner is disabled).
+  usage: LlmUsage.optional(),
 });
 
 //#endregion
@@ -106,6 +109,8 @@ export const PlanStepActionsResponse = z.object({
   explanation: z.string(),
   // TODO: Define proper types
   actions: z.array(z.record(z.string(), z.any())),
+  // Per-call token usage consumed by this request.
+  usage: LlmUsage.optional(),
 });
 
 //#endregion
@@ -132,6 +137,8 @@ export const ExecuteStatementBody = CacheableRequestBody.extend({
 export const ExecuteStatementResponse = z.object({
   result: z.union([z.string(), z.array(z.string())]),
   explanation: z.string(),
+  // Per-call token usage consumed by this request.
+  usage: LlmUsage.optional(),
 });
 
 //#endregion

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -30,12 +30,20 @@ step.kind                # "do" | "check" | "get"
 step.outcome             # "passed" | "failed" (failed = the call raised)
 step.duration            # seconds
 step.tokens.input_tokens # per-step token usage
-step.artifacts           # list[Artifact(path, kind, mime)] — screenshots (+ trace)
+step.artifacts           # list[Artifact(path, kind, mime)] — screenshots, when enabled
 
 m.last                   # the most recent step (== m.steps[-1])
 ```
 
-Screenshots (and, for the Playwright driver, a `trace.zip`) are written under `al.artifacts_dir`; see [`ALUMNIUM_ARTIFACTS_DIR`](#alumnium_artifacts_dir). Read `al.metrics` before calling `al.quit()` for server-authoritative session token totals. The existing `al.stats` property is unchanged.
+Artifact capture is opt-in, because screenshots and traces slow down execution:
+
+```python
+al = Alumni(driver, capture_screenshots=True, driver_trace=True)
+```
+
+With `capture_screenshots` enabled, a screenshot is saved after every call and attached to that step's `artifacts`. With `driver_trace` enabled, the Playwright driver records a trace for the whole session and writes it to `trace.zip` on `al.quit()`. Leave `driver_trace` off if you start tracing on the Playwright context yourself. Both are written under `al.artifacts_dir`; see [`ALUMNIUM_ARTIFACTS_DIR`](#alumnium_artifacts_dir).
+
+Read `al.metrics` before calling `al.quit()` for server-authoritative session token totals. The existing `al.stats` property is unchanged.
 
 ## Environment Variables
 
@@ -58,6 +66,10 @@ Sets the cache provider used by Alumnium. Supported values are:
 
 Sets the directory where the filesystem cache is stored. Default is `.alumnium/cache`.
 
+### `ALUMNIUM_CAPTURE_SCREENSHOTS`
+
+Set to `true` to save a screenshot after every `do()`, `check()`, and `get()` call and attach it to the corresponding `al.metrics` step. Screenshots are written under `al.artifacts_dir`. Default is `false`, since capturing screenshots slows down execution. Equivalent to the `capture_screenshots` option of `Alumni()`.
+
 ### `ALUMNIUM_CHANGE_ANALYSIS`
 
 Set to `true` to enable analysis of UI changes made by `do()`. When enabled, Alumnium captures the accessibility tree before and after each action and returns a description of what changed. Default is `false` when using Alumnium as a library and `true` when running Alumnium MCP server.
@@ -65,6 +77,10 @@ Set to `true` to enable analysis of UI changes made by `do()`. When enabled, Alu
 ### `ALUMNIUM_DELAY`
 
 Delay in seconds between retries when an action fails. Default is `0.5`.
+
+### `ALUMNIUM_DRIVER_TRACE`
+
+Set to `true` to record a driver-level trace for the session. Currently only the Playwright driver implements this: it starts a Playwright trace (with screenshots and snapshots) when `Alumni()` is created and writes it to `trace.zip` under `al.artifacts_dir` on `al.quit()`. Other drivers ignore it. Default is `false`, so Alumnium never interferes with tracing you start yourself. Equivalent to the `driver_trace` option of `Alumni()`. Unrelated to [`ALUMNIUM_TRACE`](#alumnium_trace), which controls OpenTelemetry tracing.
 
 ### `ALUMNIUM_EXCLUDE_ATTRIBUTES`
 

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -13,11 +13,39 @@ Playwright driver supports both _headful_ and _headless_ modes, while Selenium d
 
 Alumnium currently supports Appium with XCUITest driver for iOS automation and UiAutomator2 driver for Android automation.
 
+## Execution Metrics & Artifacts
+
+After running `do()`, `check()`, or `get()`, per-step execution metrics are available on `al.metrics` (for third-party reporters and cost/performance analysis). Correlation is positional — `al.metrics.steps[i]` is the i-th call, in order:
+
+```python
+al.do("add a todo 'Buy milk'")
+al.check("the todo list contains 'Buy milk'")
+
+m = al.metrics
+m.duration               # total session duration (seconds)
+m.tokens.total           # session token usage (input_tokens, output_tokens, total_tokens, ...)
+
+step = m.steps[0]        # first call (the do())
+step.kind                # "do" | "check" | "get"
+step.outcome             # "passed" | "failed" (failed = the call raised)
+step.duration            # seconds
+step.tokens.input_tokens # per-step token usage
+step.artifacts           # list[Artifact(path, kind, mime)] — screenshots (+ trace)
+
+m.last                   # the most recent step (== m.steps[-1])
+```
+
+Screenshots (and, for the Playwright driver, a `trace.zip`) are written under `al.artifacts_dir`; see [`ALUMNIUM_ARTIFACTS_DIR`](#alumnium_artifacts_dir). Read `al.metrics` before calling `al.quit()` for server-authoritative session token totals. The existing `al.stats` property is unchanged.
+
 ## Environment Variables
 
 The following environment variables can be used to control the behavior of Alumnium.
 
 Any environment variable listed below may be set to a command substitution of the form `$(command)`. On startup Alumnium runs `command`, trims trailing newlines from its output, and uses the result as the variable's value.
+
+### `ALUMNIUM_ARTIFACTS_DIR`
+
+Sets the base directory where the library stores per-session execution artifacts (step screenshots and, for Playwright, a `trace.zip`) exposed via `al.artifacts_dir` and `al.metrics`. Files are written under `<dir>/<session_id>/`. Default is `~/.alumnium/artifacts`. (For the MCP server, see `ALUMNIUM_MCP_ARTIFACTS_DIR`.)
 
 ### `ALUMNIUM_CACHE`
 


### PR DESCRIPTION
## Summary

Exposes per-step **execution metrics and artifacts** from the Python `Alumni` class so third-party integrations can build rich reporting without reimplementing what the MCP server already computes.

- New **`al.metrics`** namespace (`SessionMetrics`): an ordered `steps` list with **one entry per `do()`/`check()`/`get()` call** (positional correlation), each carrying `kind`, `label`, `outcome` (`passed`/`failed`), wall-clock `started_at`/`finished_at`, `duration`, typed `tokens` (mirroring the server's `LlmUsage` fields verbatim), and typed `artifacts`; plus session `duration`, `tokens`, and `last`.
- New **`al.artifacts_dir`**: per-step screenshots and (for Playwright) a `trace.zip`, written to disk and exposed as typed `Artifact(path, kind, mime)` — mirroring the MCP `McpArtifactsStore`. Configurable via `ALUMNIUM_ARTIFACTS_DIR`.
- **Server**: `/plans`, `/steps`, `/statements` responses now include per-call token `usage` (before/after `session.stats` delta; new `subtractLlmUsage` helper).
- **Fully non-breaking**: `do`/`check`/`get` signatures and return types are unchanged, and the existing `al.stats` property is untouched.

## Motivation

The [alumnium-cucumber](https://github.com/iammac2/alumnium-cucumber) BDD reporter (and any non-MCP integration) needs per-step duration, token usage, and artifacts to produce cost/performance reporting and rich failure evidence. Today that data is only reachable through the MCP server, forcing consumers to hand-time steps, reimplement screenshotting per-driver, and forgo token accounting entirely. This PR surfaces the already-computed data through a stable library API, so consumers stop reinventing it.

## Related Issue(s)

#293

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

## Code or UI Demos (if applicable)

Full `behave examples/` run of the downstream reporter against local Ollama (`ollama/mistral-small3.1:24b`), exercising the new API end-to-end:

```
2 features passed, 0 failed, 0 skipped
6 scenarios passed, 0 failed, 0 skipped
29 steps passed, 0 failed, 0 skipped
```

Resulting metrics (verified in the report): **29/29 ste + a captured screenshot; **6/6 scenarios** produced a
Playwright trace; run-level totals aggregated: `{"inputns": 1262, "total_tokens": 15489}`.

Per-step shape from `al.metrics`:

```python
al.do("navigate to the login page")
step = al.metrics.steps[0]
step.kind        # "do"
step.outcome     # "passed"
step.duration    # 19.73
step.tokens      # TokenUsage(input_tokens=1409, output, ...)
step.artifacts   # [Artifact(path=.../01-navigate-....pimage/png")]
al.artifacts_dir # ~/.alumnium/artifacts/<session_id>  ken-stats.json)
```

## Checklist

- [x] I have read the [Contributing Guidelines](https:/ium/blob/main/CONTRIBUTING.md)
- [x] I have added or updated relevant documentation _(cs & Artifacts" + `ALUMNIUM_ARTIFACTS_DIR`; CONTRIBUTING
env-var table)_
- [x] I have written or updated necessary tests _(new `acts_store.py`, `test_alumni_metrics.py`,
`llmSchema.test.ts`; updated `serverApp.test.ts`)_
- [x] I have tested the changes locally _(Python unit 2 format/types/lint green; full behave e2e vs local
Ollama)_
- [x] The changes follow the project's coding style andlint clean; unit tests co-located in `src/**` per vitest
`unit` project; Python tests under `packages/python/tes
- [x] I have not included any sensitive or credential-r
- [x] I have ensured these changes maintain or improve ) _(N/A — no UI changes)_
- [x] I have considered security implications of these endpoints in this phase; artifacts written only to alocal, user-configurable directory; no credentials hand

## Additional Notes

- **Scope = Phase 1 of #293** (per-step stats + artifacaccessibility-tree-on-`check()`-failure (#3),`al.model_id` (#4), and `al.ask()` LLM-endpoint reuse (onMetrics` shape is designed so those are purely
additive.
- **Correlation is positional** (`al.metrics.steps[i]` result.id` was added, keeping the change non-breaking
(per maintainer guidance in the issue discussion).
- **`Area.do/check/get` do not yet record into `al.metrtional) — a small follow-up.
- **Playwright tracing is best-effort**: if the caller e context, Alumnium skips it and won't interfere.- **API parity**: the required server changes are share`al.metrics` on the TypeScript client `Alumni` is atracked parity follow-up (the issue targets the Python
- **Downstream consumer**: iammac2/alumnium-cucumber#9 s the reporter used for the e2e demo above).
- This branch is pushed to a fork (`iammac2:feat/293-exe I have pull-only access to this repo.