### PR TITLE
fix(appium): handle non-unique XCUITest locators

### DIFF
--- a/packages/python/src/alumnium/accessibility/accessibility_element.py
+++ b/packages/python/src/alumnium/accessibility/accessibility_element.py
@@ -10,6 +10,8 @@ class AccessibilityElement:
     label: str | None = None
     type: str | None = None
     value: str | None = None
+    index: int | None = None
+    match_count: int | None = None
     androidresourceid: str | None = None
     androidclass: str | None = None
     androidtext: str | None = None

--- a/packages/python/src/alumnium/accessibility/xcuitest_accessibility_tree.py
+++ b/packages/python/src/alumnium/accessibility/xcuitest_accessibility_tree.py
@@ -9,6 +9,7 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
         self.xml_string = xml_string
         self._next_raw_id = 0
         self._raw = None
+        self._lookup_xml = None
 
     def to_str(self) -> str:
         """Parse XML and add raw_id attributes to all elements."""
@@ -24,6 +25,7 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
         # Serialize back to string
         indent(root)
         self._raw = tostring(root, encoding="unicode")
+        self._lookup_xml = self._raw
         return self._raw
 
     def _add_raw_ids(self, elem: Element) -> None:
@@ -44,8 +46,9 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
             AccessibilityElement with type, name, value, label attributes
         """
         # Get raw XML with raw_id attributes
-        raw_xml = self.to_str()
-        root = fromstring(raw_xml)
+        self.to_str()
+        assert self._lookup_xml is not None
+        root = fromstring(self._lookup_xml)
 
         # Find element with matching raw_id
         def find_element(elem: Element, target_id: str) -> Element | None:
@@ -61,6 +64,14 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
         if element is None:
             raise KeyError(f"No element with raw_id={raw_id} found")
 
+        attrs = ("name", "value", "label")
+        matches = [
+            candidate
+            for candidate in root.iter()
+            if candidate.tag == element.tag
+            and all(not element.get(attr) or candidate.get(attr) == element.get(attr) for attr in attrs)
+        ]
+
         # Extract properties for XCUITest
         return AccessibilityElement(
             id=raw_id,
@@ -68,6 +79,8 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
             name=element.get("name"),
             value=element.get("value"),
             label=element.get("label"),
+            index=matches.index(element),
+            match_count=len(matches),
         )
 
     def scope_to_area(self, raw_id: int) -> "XCUITestAccessibilityTree":
@@ -97,4 +110,8 @@ class XCUITestAccessibilityTree(BaseAccessibilityTree):
         indent(target_elem)
         scoped_xml = tostring(target_elem, encoding="unicode")
 
-        return XCUITestAccessibilityTree(scoped_xml)
+        assert self._lookup_xml is not None
+        scoped_tree = XCUITestAccessibilityTree(scoped_xml)
+        scoped_tree._raw = scoped_xml
+        scoped_tree._lookup_xml = self._lookup_xml
+        return scoped_tree

--- a/packages/python/src/alumnium/drivers/appium_driver.py
+++ b/packages/python/src/alumnium/drivers/appium_driver.py
@@ -5,7 +5,7 @@ from typing import Literal
 from appium.webdriver import Remote
 from appium.webdriver.common.appiumby import AppiumBy as By
 from appium.webdriver.webelement import WebElement
-from selenium.common.exceptions import UnknownMethodException
+from selenium.common.exceptions import NoSuchElementException, UnknownMethodException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
@@ -182,6 +182,14 @@ class AppiumDriver(BaseDriver):
             predicate += f" AND {props_str}"
 
         logger.debug(f"Finding element by predicate: {predicate}")
+        if element.match_count and element.match_count > 1:
+            matches = self.driver.find_elements(By.IOS_PREDICATE, predicate)
+            if element.index is None or element.index < 0 or element.index >= len(matches):
+                raise NoSuchElementException(
+                    f"Could not resolve XCUITest locator occurrence {element.index} "
+                    f"for {predicate}; Appium returned {len(matches)} matches"
+                )
+            return matches[element.index]
         return self.driver.find_element(By.IOS_PREDICATE, predicate)  # type: ignore[reportReturnType]
 
     # Use XPath for UIAutomator2

--- a/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
+++ b/packages/python/tests/accessibility/test_xcuitest_accessibility_tree.py
@@ -30,3 +30,41 @@ def test_scope_to_area_returns_original_if_not_found(simple_tree: XCUITestAccess
     result = simple_tree.scope_to_area(99999)
     # Should return the original tree when element not found
     assert result.to_str() == simple_tree.to_str()
+
+
+def test_tracks_positions_among_elements_with_same_locator_attributes():
+    duplicate_tree = duplicate_elements_tree()
+
+    assert duplicate_tree.element_by_id(2).index == 0
+    assert duplicate_tree.element_by_id(2).match_count == 3
+    assert duplicate_tree.element_by_id(5).index == 1
+    assert duplicate_tree.element_by_id(5).match_count == 3
+    assert duplicate_tree.element_by_id(7).index == 2
+    assert duplicate_tree.element_by_id(7).match_count == 3
+
+
+def test_scope_to_area_preserves_full_tree_ids_and_locator_positions():
+    duplicate_tree = duplicate_elements_tree()
+    area = duplicate_tree.scope_to_area(4)
+
+    assert 'raw_id="7"' in area.to_str()
+    assert area.element_by_id(7).index == 2
+    assert area.element_by_id(7).match_count == 3
+
+
+def duplicate_elements_tree() -> XCUITestAccessibilityTree:
+    return XCUITestAccessibilityTree(
+        """<XCUIElementTypeApplication>
+        <XCUIElementTypeButton name="Action" label="Action">
+            <XCUIElementTypeStaticText name="First"/>
+        </XCUIElementTypeButton>
+        <XCUIElementTypeOther name="Area">
+            <XCUIElementTypeButton name="Action" label="Action">
+                <XCUIElementTypeStaticText name="Second"/>
+            </XCUIElementTypeButton>
+            <XCUIElementTypeButton name="Action" label="Action">
+                <XCUIElementTypeStaticText name="Third"/>
+            </XCUIElementTypeButton>
+        </XCUIElementTypeOther>
+        </XCUIElementTypeApplication>"""
+    )

--- a/packages/python/tests/drivers/test_appium_driver.py
+++ b/packages/python/tests/drivers/test_appium_driver.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock
+
+from appium.webdriver.common.appiumby import AppiumBy as By
+from selenium.common.exceptions import NoSuchElementException
+
+from alumnium.accessibility import AccessibilityElement
+from alumnium.drivers.appium_driver import AppiumDriver
+
+
+def test_find_element_ios_keeps_single_element_query_for_unique_predicate():
+    remote = ios_remote()
+    native_element = MagicMock()
+    remote.find_element.return_value = native_element
+    driver = AppiumDriver(remote)
+    element = AccessibilityElement(
+        id=2,
+        type="XCUIElementTypeButton",
+        name="Continue",
+        index=0,
+        match_count=1,
+    )
+
+    assert driver._find_element_ios(element) is native_element
+    remote.find_element.assert_called_once_with(
+        By.IOS_PREDICATE,
+        'type == "XCUIElementTypeButton" AND name == "Continue"',
+    )
+    remote.find_elements.assert_not_called()
+
+
+def test_find_element_ios_selects_recorded_duplicate_occurrence():
+    remote = ios_remote()
+    native_elements = [MagicMock(), MagicMock()]
+    remote.find_elements.return_value = native_elements
+    driver = AppiumDriver(remote)
+    element = AccessibilityElement(
+        id=3,
+        type="XCUIElementTypeButton",
+        name="Action",
+        index=1,
+        match_count=2,
+    )
+
+    assert driver._find_element_ios(element) is native_elements[1]
+    remote.find_elements.assert_called_once_with(
+        By.IOS_PREDICATE,
+        'type == "XCUIElementTypeButton" AND name == "Action"',
+    )
+    remote.find_element.assert_not_called()
+
+
+def test_find_element_ios_fails_when_appium_returns_fewer_duplicates():
+    remote = ios_remote()
+    remote.find_elements.return_value = [MagicMock(), MagicMock()]
+    driver = AppiumDriver(remote)
+    element = AccessibilityElement(
+        id=4,
+        type="XCUIElementTypeButton",
+        name="Action",
+        index=2,
+        match_count=3,
+    )
+
+    try:
+        driver._find_element_ios(element)
+    except NoSuchElementException as error:
+        assert (
+            'occurrence 2 for type == "XCUIElementTypeButton" AND name == "Action"; Appium returned 2 matches'
+            in str(error)
+        )
+    else:
+        raise AssertionError("Expected duplicate lookup to fail")
+
+
+def ios_remote() -> MagicMock:
+    remote = MagicMock()
+    remote.capabilities = {"automationName": "XCUITest"}
+    return remote

--- a/packages/typescript/src/accessibility/AccessibilityElement.ts
+++ b/packages/typescript/src/accessibility/AccessibilityElement.ts
@@ -5,6 +5,8 @@ export interface AccessibilityElement {
   label?: string | undefined;
   type?: string | undefined;
   value?: string | undefined;
+  index?: number | undefined;
+  matchCount?: number | undefined;
   androidResourceId?: string | undefined;
   androidClass?: string | undefined;
   androidText?: string | undefined;

--- a/packages/typescript/src/accessibility/XCUITestAccessibilityTree.test.ts
+++ b/packages/typescript/src/accessibility/XCUITestAccessibilityTree.test.ts
@@ -20,5 +20,39 @@ describe("XCUITestAccessibilityTree", () => {
         type: "XCUIElementTypeButton",
       });
     });
+
+    it("tracks positions among elements with the same locator attributes", () => {
+      const tree = duplicateElementsTree();
+
+      expect(tree.elementById(2)).toMatchObject({ index: 0, matchCount: 3 });
+      expect(tree.elementById(5)).toMatchObject({ index: 1, matchCount: 3 });
+      expect(tree.elementById(7)).toMatchObject({ index: 2, matchCount: 3 });
+    });
+  });
+
+  describe("scopeToArea", () => {
+    it("preserves full-tree IDs and locator positions", () => {
+      const tree = duplicateElementsTree();
+      const area = tree.scopeToArea(4);
+
+      expect(area.toStr()).toContain("raw_id=7");
+      expect(area.elementById(7)).toMatchObject({ index: 2, matchCount: 3 });
+    });
   });
 });
+
+function duplicateElementsTree(): XCUITestAccessibilityTree {
+  return new XCUITestAccessibilityTree(`<XCUIElementTypeApplication>
+    <XCUIElementTypeButton name="Action" label="Action">
+      <XCUIElementTypeStaticText name="First"></XCUIElementTypeStaticText>
+    </XCUIElementTypeButton>
+    <XCUIElementTypeOther name="Area">
+      <XCUIElementTypeButton name="Action" label="Action">
+        <XCUIElementTypeStaticText name="Second"></XCUIElementTypeStaticText>
+      </XCUIElementTypeButton>
+      <XCUIElementTypeButton name="Action" label="Action">
+        <XCUIElementTypeStaticText name="Third"></XCUIElementTypeStaticText>
+      </XCUIElementTypeButton>
+    </XCUIElementTypeOther>
+  </XCUIElementTypeApplication>`);
+}

--- a/packages/typescript/src/accessibility/XCUITestAccessibilityTree.ts
+++ b/packages/typescript/src/accessibility/XCUITestAccessibilityTree.ts
@@ -9,10 +9,12 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
   #xmlString: string;
   #nextRawId: number = 0;
   #raw: string | null = null;
+  #lookupXml: string | null;
 
   constructor(xmlString: string) {
     super();
     this.#xmlString = xmlString;
+    this.#lookupXml = null;
   }
 
   /** Parse XML and add raw_id attributes to all elements. */
@@ -29,6 +31,7 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
 
     // Serialize back to string
     this.#raw = XmlRenderer.render([root]);
+    this.#lookupXml = this.#raw;
     return this.#raw;
   }
 
@@ -53,8 +56,9 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
    */
   elementById(rawId: number): AccessibilityElement {
     // Get raw XML with raw_id attributes
-    const rawXml = this.toStr();
-    const root = this.#parseRoot(rawXml);
+    this.toStr();
+    always(this.#lookupXml);
+    const root = this.#parseRoot(this.#lookupXml);
 
     // Find element with matching raw_id
     const findElement = (elem: Element, targetId: string): Element | null => {
@@ -79,6 +83,27 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
       throw new Error(`No element with raw_id=${rawId} found`);
     }
 
+    const attrs = ["name", "value", "label"];
+    const matches: Element[] = [];
+    const collectMatches = (candidate: Element): void => {
+      const matchesTarget =
+        candidate.tagName === element.tagName &&
+        attrs.every((attr) => {
+          const value = element.attribs[attr];
+          return !value || candidate.attribs[attr] === value;
+        });
+      if (matchesTarget) {
+        matches.push(candidate);
+      }
+      for (const child of candidate.children) {
+        const childEl = Xml.nodeAsTag(child);
+        if (childEl) {
+          collectMatches(childEl);
+        }
+      }
+    };
+    collectMatches(root);
+
     // Extract properties for XCUITest
     return {
       id: rawId,
@@ -86,6 +111,8 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
       name: element.attribs["name"],
       value: element.attribs["value"],
       label: element.attribs["label"],
+      index: matches.indexOf(element),
+      matchCount: matches.length,
     };
   }
 
@@ -124,7 +151,11 @@ export class XCUITestAccessibilityTree extends BaseAccessibilityTree {
     // Convert the scoped element back to XML string
     const scopedXml = XmlRenderer.render([targetElem]);
 
-    return new XCUITestAccessibilityTree(scopedXml);
+    always(this.#lookupXml);
+    const scopedTree = new XCUITestAccessibilityTree(scopedXml);
+    scopedTree.#raw = scopedXml;
+    scopedTree.#lookupXml = this.#lookupXml;
+    return scopedTree;
   }
 
   #parseRoot(xml: string): Element {

--- a/packages/typescript/src/drivers/AppiumDriver.test.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Browser } from "webdriverio";
+import type { AccessibilityElement } from "../accessibility/AccessibilityElement.ts";
+import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts";
+import { AppiumDriver } from "./AppiumDriver.ts";
+
+describe("AppiumDriver", () => {
+  describe("findElement", () => {
+    it("keeps the single-element query for a unique iOS predicate", async () => {
+      const nativeElement = createNativeElement("unique");
+      const { browser, driver } = createDriver(
+        {
+          id: 2,
+          type: "XCUIElementTypeButton",
+          name: "Continue",
+          index: 0,
+          matchCount: 1,
+        },
+        [],
+        nativeElement,
+      );
+
+      await expect(driver.findElement(2)).resolves.toBe(nativeElement);
+      expect(browser.$).toHaveBeenCalledOnce();
+      expect(browser.$$).not.toHaveBeenCalled();
+    });
+
+    it("selects the recorded occurrence for duplicate iOS predicates", async () => {
+      const firstElement = createNativeElement("first");
+      const secondElement = createNativeElement("second");
+      const { browser, driver } = createDriver(
+        {
+          id: 3,
+          type: "XCUIElementTypeButton",
+          name: "Action",
+          index: 1,
+          matchCount: 2,
+        },
+        [firstElement, secondElement],
+      );
+
+      await expect(driver.findElement(3)).resolves.toBe(secondElement);
+      expect(browser.$$).toHaveBeenCalledWith(
+        '-ios predicate string:type == "XCUIElementTypeButton" AND name == "Action"',
+      );
+      expect(browser.$).not.toHaveBeenCalled();
+    });
+
+    it("fails when Appium returns fewer duplicates than the tree", async () => {
+      const { driver } = createDriver(
+        {
+          id: 4,
+          type: "XCUIElementTypeButton",
+          name: "Action",
+          index: 2,
+          matchCount: 3,
+        },
+        [createNativeElement("first"), createNativeElement("second")],
+      );
+
+      await expect(driver.findElement(4)).rejects.toThrow(
+        'occurrence 2 for type == "XCUIElementTypeButton" AND name == "Action"; Appium returned 2 matches',
+      );
+    });
+  });
+});
+
+function createDriver(
+  accessibilityElement: AccessibilityElement,
+  duplicateElements: WebdriverIO.Element[],
+  uniqueElement = createNativeElement("unique"),
+) {
+  const browser = {
+    capabilities: { platformName: "iOS" },
+    $: vi.fn(() => ({ getElement: () => uniqueElement })),
+    $$: vi.fn(async () =>
+      duplicateElements.map((element) => ({ getElement: () => element })),
+    ),
+  };
+  const driver = new AppiumDriver(browser as unknown as Browser);
+  driver.setAccessibilityTree(new StubAccessibilityTree(accessibilityElement));
+  return { browser, driver };
+}
+
+function createNativeElement(elementId: string): WebdriverIO.Element {
+  return { elementId } as WebdriverIO.Element;
+}
+
+class StubAccessibilityTree extends BaseAccessibilityTree {
+  #element: AccessibilityElement;
+
+  constructor(element: AccessibilityElement) {
+    super();
+    this.#element = element;
+  }
+
+  toStr(): string {
+    return "<XCUIElementTypeApplication/>";
+  }
+
+  elementById(): AccessibilityElement {
+    return this.#element;
+  }
+
+  scopeToArea(): BaseAccessibilityTree {
+    return this;
+  }
+}

--- a/packages/typescript/src/drivers/AppiumDriver.ts
+++ b/packages/typescript/src/drivers/AppiumDriver.ts
@@ -210,7 +210,20 @@ export class AppiumDriver extends BaseDriver {
       }
 
       logger.debug(`Finding element by predicate: ${predicate}`);
-      return this.driver.$(`-ios predicate string:${predicate}`).getElement();
+      const selector = `-ios predicate string:${predicate}`;
+      if (element.matchCount && element.matchCount > 1) {
+        const matches = await this.driver.$$(selector);
+        const match =
+          element.index === undefined ? undefined : matches[element.index];
+        if (!match) {
+          throw new Error(
+            `Could not resolve XCUITest locator occurrence ${element.index} ` +
+              `for ${predicate}; Appium returned ${matches.length} matches`,
+          );
+        }
+        return match.getElement();
+      }
+      return this.driver.$(selector).getElement();
     } else {
       // Use XPath for UIAutomator2
       let xpath = `//${element.type}`;


### PR DESCRIPTION
## What changed\n\n- track each XCUITest element's occurrence among equivalent iOS predicates\n- preserve full-tree IDs and occurrence metadata for area-scoped lookups\n- select the matching Appium element in both TypeScript and Python\n- fail explicitly when the accessibility tree and Appium results diverge\n- add regression coverage for unique, duplicate, scoped, and inconsistent results\n\n## Why\n\nMultiple iOS elements can share the same 	ype, 
ame, alue, and label. The existing single-element predicate query always returned the first match, even when a later element was selected from the accessibility tree.\n\n## Verification\n\n- TypeScript focused unit tests: 6 passed\n- Python focused unit tests: 7 passed\n- TypeScript type check, formatting, and lint\n- Python type check, formatting, and lint\n- diff whitespace check\n\nCloses #132