### PR TITLE
feat!(playwright): autoswitch to a tab that opens slowly

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
@@ -13,6 +13,7 @@ import ai.alumnium.tool.UploadTool;
 import ai.alumnium.util.Retry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.CDPSession;
@@ -45,9 +46,15 @@ public final class PlaywrightDriver extends BaseDriver {
       loadScript("/ai/alumnium/driver/scripts/waitFor.js");
   private static final String CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed";
 
+  private static final int NEW_TAB_DELAY = 50;
+  private static final int NEW_TAB_TIMEOUT = 10_000;
+
   private Page page;
   private CDPSession client;
-  private final List<Page> pages = new ArrayList<>();
+  private final List<Page> openedPages = new ArrayList<>();
+  private final Set<BrowserContext> watchedContexts = new HashSet<>();
+  private Page previousPage;
+  private boolean pendingWindowOpen = false;
   private final Set<Frame> oopifFrames = new HashSet<>();
   public boolean autoswitchToNewTab = true;
   public boolean fullPageScreenshot = Config.FULL_PAGE_SCREENSHOT;
@@ -62,7 +69,7 @@ public final class PlaywrightDriver extends BaseDriver {
 
   public PlaywrightDriver(Page page) {
     this.page = page;
-    setupPageTracking(page);
+    watchContextOf(page);
     initCDPSession();
   }
 
@@ -78,6 +85,7 @@ public final class PlaywrightDriver extends BaseDriver {
 
   @Override
   protected ChromiumAccessibilityTree fetchAccessibilityTree() {
+    switchToNewTab();
     waitForPageToLoad();
 
     Map<String, Object> frameTreeResp = sendCdp("Page.getFrameTree", null);
@@ -225,7 +233,7 @@ public final class PlaywrightDriver extends BaseDriver {
     }
 
     boolean isOopif = frame != page.mainFrame() && oopifFrames.contains(frame);
-    CDPSession session = isOopif ? page.context().newCDPSession(frame) : client;
+    CDPSession session = isOopif ? page.context().newCDPSession(frame) : session();
     try {
       sendCdpOn(session, "DOM.enable", null);
       sendCdpOn(session, "DOM.getFlattenedDocument", null);
@@ -258,21 +266,19 @@ public final class PlaywrightDriver extends BaseDriver {
 
   @Override
   public void switchToNextTab() {
-    page.waitForTimeout(100);
-    if (pages.size() <= 1) return;
-    int idx = pages.indexOf(page);
-    this.page = pages.get((idx + 1) % pages.size());
-    initCDPSession();
+    List<Page> tabs = openTabs();
+    if (tabs.size() <= 1) return; // Only one tab, nothing to switch
+    int idx = tabs.indexOf(page);
+    activatePage(tabs.get((idx + 1) % tabs.size()));
     page.waitForLoadState();
   }
 
   @Override
   public void switchToPreviousTab() {
-    page.waitForTimeout(100);
-    if (pages.size() <= 1) return;
-    int idx = pages.indexOf(page);
-    this.page = pages.get((idx - 1 + pages.size()) % pages.size());
-    initCDPSession();
+    List<Page> tabs = openTabs();
+    if (tabs.size() <= 1) return; // Only one tab, nothing to switch
+    int idx = tabs.indexOf(page);
+    activatePage(tabs.get((idx - 1 + tabs.size()) % tabs.size()));
     page.waitForLoadState();
   }
 
@@ -286,8 +292,39 @@ public final class PlaywrightDriver extends BaseDriver {
 
   private void initCDPSession() {
     oopifFrames.clear();
+
+    if (client != null) {
+      try {
+        client.detach();
+      } catch (RuntimeException e) {
+        // The target may already be closed.
+      }
+    }
+
     this.client = page.context().newCDPSession(page);
+    enablePageEvents();
     enableTargetAutoAttach();
+  }
+
+  private void enablePageEvents() {
+    try {
+      client.send("Page.enable");
+
+      // Playwright page event fires after navigation, so it can be very slow.
+      // Use CDP instead which fires when the browser is asked to open a window.
+      client.on(
+          "Page.windowOpen",
+          event -> {
+            JsonElement url = event.get("url");
+            String opened = url == null || url.isJsonNull() ? "" : url.getAsString();
+            LOG.debug("Window open requested: {}", opened.isEmpty() ? "(empty)" : opened);
+            pendingWindowOpen = true;
+          });
+
+      LOG.debug("Enabled Page events for new tab detection");
+    } catch (RuntimeException e) {
+      LOG.debug("Could not enable Page events: {}", e.getMessage());
+    }
   }
 
   private void mergeFrameNodes(
@@ -335,7 +372,12 @@ public final class PlaywrightDriver extends BaseDriver {
   }
 
   private Map<String, Object> sendCdp(String method, Map<String, Object> params) {
-    return sendCdpOn(client, method, params);
+    return sendCdpOn(session(), method, params);
+  }
+
+  private CDPSession session() {
+    if (client == null) initCDPSession();
+    return client;
   }
 
   private Map<String, Object> sendCdpOn(
@@ -396,55 +438,109 @@ public final class PlaywrightDriver extends BaseDriver {
         });
   }
 
-  private void setupPageTracking(Page initialPage) {
-    pages.add(initialPage);
-    attachPageListeners(initialPage);
+  private void flushEvents() {
+    page.context().cookies();
   }
 
-  private void attachPageListeners(Page page) {
-    page.onPopup(this::onPopup);
-    page.onClose(this::onPageClose);
+  private void watchContextOf(Page page) {
+    BrowserContext context = page.context();
+    if (!watchedContexts.add(context)) return;
+
+    context.onPage(this::onPageOpened);
+    LOG.debug("Watching browser context for new tabs");
   }
 
-  private void onPopup(Page popup) {
-    LOG.debug("New popup opened: {}", popup.url());
-    pages.add(popup);
-    attachPageListeners(popup);
+  private void onPageOpened(Page opened) {
+    LOG.debug("New tab opened: {}", opened.url());
+    pendingWindowOpen = false;
+    openedPages.add(opened);
+    watchContextOf(opened);
+    opened.onClose(this::onPageClosed);
   }
 
-  private void onPageClose(Page closed) {
-    if (pages.remove(closed)) {
-      LOG.debug("Page closed: {}", closed.url());
+  private void onPageClosed(Page closed) {
+    openedPages.remove(closed);
+    if (closed != page) return;
+
+    if (previousPage == null || previousPage.isClosed()) {
+      LOG.warn("Active tab was closed and the tab it came from is gone");
+      return;
     }
+
+    LOG.debug("Active tab was closed, returning to {}", previousPage.url());
+    this.page = previousPage;
+    this.previousPage = null;
+    resetAccessibilityTree();
+    // Opening a session here would run inside whatever call delivered this
+    // event, on a tab that may be gone as well. Let the next command open one.
+    this.client = null;
   }
 
   private void autoswitchToNewTabAction(Runnable action) {
     if (!autoswitchToNewTab) {
       action.run();
+      openedPages.clear();
       return;
     }
 
-    Page newPage;
+    // Page.windowOpen is watched on the CDP session, so it has to be live
+    // before the action runs. The session is dropped when a tab closes.
+    session();
+
+    action.run();
+    page.waitForTimeout(NEW_TAB_DELAY);
+
+    if (openedPages.isEmpty() && pendingWindowOpen) {
+      waitForAnnouncedTab();
+    }
+    switchToNewTab();
+  }
+
+  private void waitForAnnouncedTab() {
+    pendingWindowOpen = false;
+    LOG.debug("A tab is opening, waiting for the browser to report it");
     try {
-      newPage =
-          page.context()
-              .waitForPage(
-                  new BrowserContext.WaitForPageOptions()
-                      .setTimeout(Config.PLAYWRIGHT_NEW_TAB_TIMEOUT),
-                  action);
+      page.context()
+          .waitForPage(
+              new BrowserContext.WaitForPageOptions().setTimeout(NEW_TAB_TIMEOUT), () -> {});
     } catch (TimeoutError e) {
-      return;
+      LOG.debug("  <- No tab was reported, continuing");
+    }
+  }
+
+  private void switchToNewTab() {
+    flushEvents();
+
+    Page opened = null;
+    for (Page candidate : openedPages) {
+      if (!candidate.isClosed()) opened = candidate;
     }
 
-    if (newPage != null) {
-      LOG.debug("Auto-switching to new tab {} ({})", newPage.url(), newPage.title());
-      if (!pages.contains(newPage)) {
-        pages.add(newPage);
-        attachPageListeners(newPage);
-      }
-      this.page = newPage;
-      initCDPSession();
+    openedPages.clear();
+    if (opened == null) return;
+
+    LOG.debug("Auto-switching to new tab: {}", opened.url());
+    opened.waitForLoadState();
+    activatePage(opened);
+  }
+
+  private void activatePage(Page target) {
+    if (target != page) this.previousPage = page;
+    this.page = target;
+    watchContextOf(target);
+    resetAccessibilityTree();
+    initCDPSession();
+  }
+
+  private List<Page> openTabs() {
+    openedPages.clear();
+    flushEvents();
+
+    List<Page> tabs = new ArrayList<>();
+    for (Page tab : page.context().pages()) {
+      if (!tab.isClosed()) tabs.add(tab);
     }
+    return tabs;
   }
 
   private static String frameIdOf(Map<String, Object> frameInfo) {

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -3,7 +3,15 @@ from base64 import b64encode
 from contextlib import asynccontextmanager
 from urllib.parse import urlparse
 
-from playwright.async_api import Error, Frame, Locator, Page, TimeoutError
+from playwright.async_api import (
+    BrowserContext,
+    CDPSession,
+    Error,
+    Frame,
+    Locator,
+    Page,
+    TimeoutError,
+)
 
 from .. import FULL_PAGE_SCREENSHOT
 from ..accessibility import ChromiumAccessibilityTree
@@ -37,8 +45,12 @@ class PlaywrightAsyncDriver(BaseDriver):
             UploadTool,
         }
         self.oopif_frames: set[Frame] = set()
+        self._opened_pages: list[Page] = []
+        self._watched_contexts: set[BrowserContext] = set()
+        self._previous_page: Page | None = None
+        self._pending_window_open = False
+        self._watch_context_of(page)
         self._run_async(self._init_cdp_session())
-        self._run_async(self._setup_page_tracking(page))
 
     @property
     def platform(self) -> str:
@@ -56,6 +68,7 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     @property
     async def _accessibility_tree(self) -> ChromiumAccessibilityTree:
+        await self._switch_to_new_tab()
         await self._wait_for_page_to_load()
 
         frame_tree = await self._send_cdp_command("Page.getFrameTree")
@@ -213,9 +226,7 @@ class PlaywrightAsyncDriver(BaseDriver):
         if is_oopif:
             session = await self.page.context.new_cdp_session(frame)
         else:
-            if self.client is None:
-                self.client = await self.page.context.new_cdp_session(self.page)
-            session = self.client
+            session = await self._cdp_session()
         try:
             # Beware!
             await session.send("DOM.enable")
@@ -273,29 +284,96 @@ class PlaywrightAsyncDriver(BaseDriver):
     async def _autoswitch_to_new_tab(self):
         if not self.autoswitch_to_new_tab:
             yield
+            self._opened_pages.clear()
             return
 
+        # Page.windowOpen is watched on the CDP session, so it has to be live
+        # before the action runs. The session is dropped when a tab closes.
+        await self._cdp_session()
+
+        yield
+
+        await self.page.wait_for_timeout(PlaywrightDriver.NEW_TAB_DELAY)
+
+        if not self._opened_pages and self._pending_window_open:
+            await self._wait_for_announced_tab()
+        await self._switch_to_new_tab()
+
+    async def _wait_for_announced_tab(self):
+        self._pending_window_open = False
+        logger.debug("A tab is opening, waiting for the browser to report it")
         try:
-            async with self.page.context.expect_page(timeout=PlaywrightDriver.NEW_TAB_TIMEOUT) as new_page_info:
-                yield
+            await self.page.context.wait_for_event("page", timeout=PlaywrightDriver.NEW_TAB_TIMEOUT)
         except TimeoutError:
+            logger.debug("  <- No tab was reported, continuing")
+
+    async def _switch_to_new_tab(self):
+        await self._flush_events()
+
+        opened = [page for page in self._opened_pages if not page.is_closed()]
+        self._opened_pages.clear()
+        if not opened:
             return
 
-        page = await new_page_info.value
-        title = await page.title()
-        logger.debug(f"Auto-switching to new tab {title} ({page.url})")
+        page = opened[-1]
+        logger.debug(f"Auto-switching to new tab: {page.url}")
+        await page.wait_for_load_state()
+        await self._activate_page(page)
+
+    async def _activate_page(self, page: Page):
+        if page is not self.page:
+            self._previous_page = self.page
         self.page = page
+        self._watch_context_of(page)
+        self.reset_accessibility_tree()
         await self._init_cdp_session()
 
-    async def _send_cdp_command(self, method: str, params: dict | None = None):
-        if self.client is None:
-            self.client = await self.page.context.new_cdp_session(self.page)
-        return await self.client.send(method, params or {})
+    async def _open_tabs(self) -> list[Page]:
+        self._opened_pages.clear()
+        await self._flush_events()
+        return [page for page in self.page.context.pages if not page.is_closed()]
 
-    async def _init_cdp_session(self):
+    async def _flush_events(self):
+        await self.page.context.cookies()
+
+    async def _send_cdp_command(self, method: str, params: dict | None = None):
+        client = await self._cdp_session()
+        return await client.send(method, params or {})
+
+    async def _cdp_session(self) -> CDPSession:
+        """The session of the active tab, opened on demand."""
+        return self.client or await self._init_cdp_session()
+
+    async def _init_cdp_session(self) -> CDPSession:
         self.oopif_frames.clear()
-        self.client = await self.page.context.new_cdp_session(self.page)
+
+        if self.client is not None:
+            try:
+                await self.client.detach()
+            except Exception:
+                pass  # The target may already be closed.
+
+        client = await self.page.context.new_cdp_session(self.page)
+        self.client = client
+        await self._enable_page_events(client)
         await self._enable_target_auto_attach()
+        return client
+
+    async def _enable_page_events(self, client: CDPSession):
+        try:
+            await client.send("Page.enable")
+
+            # Playwright page event fires after navigation, so it can be very slow.
+            # Use CDP instead which fires when the browser is asked to open a window.
+            client.on("Page.windowOpen", self._on_window_open)
+
+            logger.debug("Enabled Page events for new tab detection")
+        except Exception as e:
+            logger.debug(f"Could not enable Page events: {e}")
+
+    def _on_window_open(self, event: dict):
+        logger.debug(f"Window open requested: {event.get('url') or '(empty)'}")
+        self._pending_window_open = True
 
     async def _enable_target_auto_attach(self):
         try:
@@ -418,23 +496,40 @@ class PlaywrightAsyncDriver(BaseDriver):
                 node["_parent_iframe_backend_node_id"] = frame_to_iframe_map[frame_id]
             all_nodes.append(node)
 
-    async def _setup_page_tracking(self, initial_page: Page):
-        self._pages: list[Page] = [initial_page]
-        self._attach_page_listeners(initial_page)
+    def _watch_context_of(self, page: Page):
+        context = page.context
+        if context in self._watched_contexts:
+            return
 
-    def _attach_page_listeners(self, page: Page):
-        page.on("popup", self._on_popup_sync)
-        page.on("close", self._on_page_close)
+        self._watched_contexts.add(context)
+        context.on("page", self._on_page_opened)
+        logger.debug("Watching browser context for new tabs")
 
-    def _on_popup_sync(self, popup: Page):
-        logger.debug(f"New popup opened: {popup.url}")
-        self._pages.append(popup)
-        self._attach_page_listeners(popup)
+    def _on_page_opened(self, page: Page):
+        logger.debug(f"New tab opened: {page.url}")
+        self._pending_window_open = False
+        self._opened_pages.append(page)
+        self._watch_context_of(page)
+        page.on("close", self._on_page_closed)
 
-    def _on_page_close(self, popup: Page):
-        if popup in self._pages:
-            logger.debug(f"Page closed: {popup.url}")
-            self._pages.remove(popup)
+    def _on_page_closed(self, page: Page):
+        if page in self._opened_pages:
+            self._opened_pages.remove(page)
+        if page is not self.page:
+            return
+
+        previous = self._previous_page
+        if previous is None or previous.is_closed():
+            logger.warning("Active tab was closed and the tab it came from is gone")
+            return
+
+        logger.debug(f"Active tab was closed, returning to {previous.url}")
+        self.page = previous
+        self._previous_page = None
+        self.reset_accessibility_tree()
+        # Opening a session here would run inside whatever call delivered this
+        # event, on a tab that may be gone as well. Let the next command open one.
+        self.client = None
 
     def _get_all_frame_ids(self, frame_info: dict) -> list[str]:
         frame_ids = [frame_info["frame"]["id"]]
@@ -459,26 +554,24 @@ class PlaywrightAsyncDriver(BaseDriver):
         self._run_async(self._switch_to_next_tab())
 
     async def _switch_to_next_tab(self):
-        await self.page.wait_for_timeout(100)
-        if len(self._pages) <= 1:
-            return
+        pages = await self._open_tabs()
+        if len(pages) <= 1:
+            return  # Only one tab, nothing to switch
 
-        current_index = self._pages.index(self.page)
-        self.page = self._pages[(current_index + 1) % len(self._pages)]
-        await self._init_cdp_session()
+        current_index = pages.index(self.page)
+        await self._activate_page(pages[(current_index + 1) % len(pages)])
         await self.page.wait_for_load_state()
 
     def switch_to_previous_tab(self):
         self._run_async(self._switch_to_previous_tab())
 
     async def _switch_to_previous_tab(self):
-        await self.page.wait_for_timeout(100)
-        if len(self._pages) <= 1:
-            return
+        pages = await self._open_tabs()
+        if len(pages) <= 1:
+            return  # Only one tab, nothing to switch
 
-        current_index = self._pages.index(self.page)
-        self.page = self._pages[(current_index - 1) % len(self._pages)]
-        await self._init_cdp_session()
+        current_index = pages.index(self.page)
+        await self._activate_page(pages[(current_index - 1) % len(pages)])
         await self.page.wait_for_load_state()
 
     def _run_async(self, coro):

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -1,10 +1,17 @@
 from base64 import b64encode
 from contextlib import contextmanager
-from os import getenv
 from pathlib import Path
 from urllib.parse import urlparse
 
-from playwright.sync_api import Error, Frame, Locator, Page, TimeoutError
+from playwright.sync_api import (
+    BrowserContext,
+    CDPSession,
+    Error,
+    Frame,
+    Locator,
+    Page,
+    TimeoutError,
+)
 
 from .. import FULL_PAGE_SCREENSHOT
 from ..accessibility import ChromiumAccessibilityTree
@@ -22,7 +29,8 @@ logger = get_logger(__name__)
 
 
 class PlaywrightDriver(BaseDriver):
-    NEW_TAB_TIMEOUT = int(getenv("ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT", "200"))
+    NEW_TAB_DELAY = 50
+    NEW_TAB_TIMEOUT = 10_000
     NOT_SELECTABLE_ERROR = "Element is not a <select> element"
     CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed"
 
@@ -36,6 +44,7 @@ class PlaywrightDriver(BaseDriver):
 
     def __init__(self, page: Page):
         self.page = page
+        self.client: CDPSession | None = None
         self.autoswitch_to_new_tab = True
         self.full_page_screenshot = FULL_PAGE_SCREENSHOT
         self.supported_tools = {
@@ -47,14 +56,19 @@ class PlaywrightDriver(BaseDriver):
             UploadTool,
         }
         self.oopif_frames: set[Frame] = set()
+        self._opened_pages: list[Page] = []
+        self._watched_contexts: set[BrowserContext] = set()
+        self._previous_page: Page | None = None
+        self._pending_window_open = False
+        self._watch_context_of(page)
         self._init_cdp_session()
-        self._setup_page_tracking(page)
 
     @property
     def platform(self) -> str:
         return "chromium"
 
     def _fetch_accessibility_tree(self) -> ChromiumAccessibilityTree:
+        self._switch_to_new_tab()
         self._wait_for_page_to_load()
 
         frame_tree = self._send_cdp_command("Page.getFrameTree")
@@ -165,7 +179,7 @@ class PlaywrightDriver(BaseDriver):
             raise ValueError(f"Element {id} has no backendNodeId")
 
         is_oopif = frame != self.page.main_frame and frame in self.oopif_frames
-        session = self.page.context.new_cdp_session(frame) if is_oopif else self.client
+        session = self.page.context.new_cdp_session(frame) if is_oopif else self._cdp_session()
         try:
             # Beware!
             session.send("DOM.enable")
@@ -215,28 +229,96 @@ class PlaywrightDriver(BaseDriver):
 
     @contextmanager
     def _autoswitch_to_new_tab(self):
-        # If auto-switch is disabled, just yield without waiting for new pages
         if not self.autoswitch_to_new_tab:
             yield
+            self._opened_pages.clear()
             return
 
+        # Page.windowOpen is watched on the CDP session, so it has to be live
+        # before the action runs. The session is dropped when a tab closes.
+        self._cdp_session()
+
+        yield
+
+        self.page.wait_for_timeout(self.NEW_TAB_DELAY)
+
+        if not self._opened_pages and self._pending_window_open:
+            self._wait_for_announced_tab()
+        self._switch_to_new_tab()
+
+    def _wait_for_announced_tab(self):
+        self._pending_window_open = False
+        logger.debug("A tab is opening, waiting for the browser to report it")
         try:
-            with self.page.context.expect_page(timeout=self.NEW_TAB_TIMEOUT) as new_page_info:
-                yield
+            self.page.context.wait_for_event("page", timeout=self.NEW_TAB_TIMEOUT)
         except TimeoutError:
+            logger.debug("  <- No tab was reported, continuing")
+
+    def _switch_to_new_tab(self):
+        self._flush_events()
+        opened = [page for page in self._opened_pages if not page.is_closed()]
+        self._opened_pages.clear()
+        if not opened:
             return
-        page = new_page_info.value
-        logger.debug(f"Auto-switching to new tab {page.title()} ({page.url})")
+
+        page = opened[-1]
+        logger.debug(f"Auto-switching to new tab: {page.url}")
+        page.wait_for_load_state()
+        self._activate_page(page)
+
+    def _activate_page(self, page: Page):
+        if page is not self.page:
+            self._previous_page = self.page
         self.page = page
+        self._watch_context_of(page)
+        self.reset_accessibility_tree()
         self._init_cdp_session()
 
-    def _send_cdp_command(self, method: str, params: dict | None = None):
-        return self.client.send(method, params or {})
+    def _open_tabs(self) -> list[Page]:
+        self._opened_pages.clear()
 
-    def _init_cdp_session(self):
+        self._flush_events()
+        return [page for page in self.page.context.pages if not page.is_closed()]
+
+    def _flush_events(self):
+        self.page.context.cookies()
+
+    def _send_cdp_command(self, method: str, params: dict | None = None):
+        return self._cdp_session().send(method, params or {})
+
+    def _cdp_session(self) -> CDPSession:
+        return self.client or self._init_cdp_session()
+
+    def _init_cdp_session(self) -> CDPSession:
         self.oopif_frames.clear()
-        self.client = self.page.context.new_cdp_session(self.page)
+
+        if self.client is not None:
+            try:
+                self.client.detach()
+            except Exception:
+                pass  # The target may already be closed.
+
+        client = self.page.context.new_cdp_session(self.page)
+        self.client = client
+        self._enable_page_events(client)
         self._enable_target_auto_attach()
+        return client
+
+    def _enable_page_events(self, client: CDPSession):
+        try:
+            client.send("Page.enable")
+
+            # Playwright page event fires after navigation, so it can be very slow.
+            # Use CDP instead which fires when the browser is asked to open a window.
+            client.on("Page.windowOpen", self._on_window_open)
+
+            logger.debug("Enabled Page events for new tab detection")
+        except Exception as e:
+            logger.debug(f"Could not enable Page events: {e}")
+
+    def _on_window_open(self, event: dict):
+        logger.debug(f"Window open requested: {event.get('url') or '(empty)'}")
+        self._pending_window_open = True
 
     def _enable_target_auto_attach(self):
         try:
@@ -361,23 +443,40 @@ class PlaywrightDriver(BaseDriver):
             logger.debug(f"  -> Frame {frame_id[:20]}...: failed ({e})")
             return []
 
-    def _setup_page_tracking(self, initial_page: Page):
-        self._pages: list[Page] = [initial_page]
-        self._attach_page_listeners(initial_page)
+    def _watch_context_of(self, page: Page):
+        context = page.context
+        if context in self._watched_contexts:
+            return
 
-    def _attach_page_listeners(self, page: Page):
-        page.on("popup", self._on_popup)
-        page.on("close", self._on_page_close)
+        self._watched_contexts.add(context)
+        context.on("page", self._on_page_opened)
+        logger.debug("Watching browser context for new tabs")
 
-    def _on_popup(self, popup: Page):
-        logger.debug(f"New popup opened: {popup.url}")
-        self._pages.append(popup)
-        self._attach_page_listeners(popup)
+    def _on_page_opened(self, page: Page):
+        logger.debug(f"New tab opened: {page.url}")
+        self._pending_window_open = False
+        self._opened_pages.append(page)
+        self._watch_context_of(page)
+        page.on("close", self._on_page_closed)
 
-    def _on_page_close(self, popup: Page):
-        if popup in self._pages:
-            logger.debug(f"Page closed: {popup.url}")
-            self._pages.remove(popup)
+    def _on_page_closed(self, page: Page):
+        if page in self._opened_pages:
+            self._opened_pages.remove(page)
+        if page is not self.page:
+            return
+
+        previous = self._previous_page
+        if previous is None or previous.is_closed():
+            logger.warning("Active tab was closed and the tab it came from is gone")
+            return
+
+        logger.debug(f"Active tab was closed, returning to {previous.url}")
+        self.page = previous
+        self._previous_page = None
+        self.reset_accessibility_tree()
+        # Opening a session here would run inside whatever call delivered this
+        # event, on a tab that may be gone as well. Let the next command open one.
+        self.client = None
 
     def _get_all_frame_ids(self, frame_info: dict) -> list[str]:
         frame_ids = [frame_info["frame"]["id"]]
@@ -400,23 +499,19 @@ class PlaywrightDriver(BaseDriver):
         return search_frame(cdp_frame_tree["frameTree"])
 
     def switch_to_next_tab(self):
-        # Brief wait to allow popup handlers to complete
-        self.page.wait_for_timeout(100)
-        if len(self._pages) <= 1:
+        pages = self._open_tabs()
+        if len(pages) <= 1:
             return  # Only one tab, nothing to switch
 
-        current_index = self._pages.index(self.page)
-        self.page = self._pages[(current_index + 1) % len(self._pages)]
-        self._init_cdp_session()
+        current_index = pages.index(self.page)
+        self._activate_page(pages[(current_index + 1) % len(pages)])
         self.page.wait_for_load_state()
 
     def switch_to_previous_tab(self):
-        # Brief wait to allow popup handlers to complete
-        self.page.wait_for_timeout(100)
-        if len(self._pages) <= 1:
+        pages = self._open_tabs()
+        if len(pages) <= 1:
             return  # Only one tab, nothing to switch
 
-        current_index = self._pages.index(self.page)
-        self.page = self._pages[(current_index - 1) % len(self._pages)]
-        self._init_cdp_session()
+        current_index = pages.index(self.page)
+        self._activate_page(pages[(current_index - 1) % len(pages)])
         self.page.wait_for_load_state()

--- a/packages/typescript/src/Env.ts
+++ b/packages/typescript/src/Env.ts
@@ -209,13 +209,6 @@ export const Env = {
     return envVar("ALUMNIUM_PLAYWRIGHT_HEADLESS", z.stringbool().default(true));
   },
 
-  get ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT() {
-    return envVar(
-      "ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT",
-      z.coerce.number().default(200),
-    );
-  },
-
   get ALUMNIUM_TEST_MAX_CONCURRENCY() {
     const defaultValue = 4;
     const cpusCount = os.cpus().length;

--- a/packages/typescript/src/drivers/PlaywrightDriver.test.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.test.ts
@@ -37,7 +37,11 @@ describe("PlaywrightDriver", () => {
     const session = { send, on: vi.fn(), detach: vi.fn() };
     const page = {
       on: vi.fn(),
-      context: () => ({ newCDPSession: vi.fn(async () => session) }),
+      context: () => ({
+        newCDPSession: vi.fn(async () => session),
+        on: vi.fn(),
+        cookies: vi.fn(async () => []),
+      }),
       mainFrame: () => frame,
       frames: () => [frame],
       evaluate: vi.fn(async () => undefined),
@@ -69,7 +73,11 @@ describe("PlaywrightDriver", () => {
       });
       const session = { send, on: vi.fn(), detach: vi.fn() };
       const frame = {};
-      const context = { newCDPSession: vi.fn(async () => session) };
+      const context = {
+        newCDPSession: vi.fn(async () => session),
+        on: vi.fn(),
+        cookies: vi.fn(async () => []),
+      };
       const page = {
         on: vi.fn(),
         context: () => context,
@@ -112,7 +120,11 @@ describe("PlaywrightDriver", () => {
       const frame = {};
       const page = {
         on: vi.fn(),
-        context: () => ({ newCDPSession: vi.fn(async () => session) }),
+        context: () => ({
+          newCDPSession: vi.fn(async () => session),
+          on: vi.fn(),
+          cookies: vi.fn(async () => []),
+        }),
         mainFrame: () => frame,
       };
       const driver = new TestPlaywrightDriver(page as unknown as Page);
@@ -139,7 +151,11 @@ describe("PlaywrightDriver", () => {
       const frame = {};
       const page = {
         on: vi.fn(),
-        context: () => ({ newCDPSession: vi.fn(async () => session) }),
+        context: () => ({
+          newCDPSession: vi.fn(async () => session),
+          on: vi.fn(),
+          cookies: vi.fn(async () => []),
+        }),
         mainFrame: () => frame,
       };
       const driver = new TestPlaywrightDriver(page as unknown as Page);
@@ -170,7 +186,11 @@ describe("PlaywrightDriver", () => {
       const oopifFrame = {};
       const page = {
         on: vi.fn(),
-        context: () => ({ newCDPSession: vi.fn(async () => session) }),
+        context: () => ({
+          newCDPSession: vi.fn(async () => session),
+          on: vi.fn(),
+          cookies: vi.fn(async () => []),
+        }),
         mainFrame: () => mainFrame,
       };
       const driver = new TestPlaywrightDriver(page as unknown as Page);

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -1,5 +1,11 @@
 import { always, ensure } from "alwaysly";
-import type { CDPSession, Frame, Locator, Page } from "playwright-core";
+import type {
+  BrowserContext,
+  CDPSession,
+  Frame,
+  Locator,
+  Page,
+} from "playwright-core";
 import { BaseAccessibilityTree } from "../accessibility/BaseAccessibilityTree.ts";
 import { ChromiumAccessibilityTree } from "../accessibility/ChromiumAccessibilityTree.ts";
 import type { ToolClass } from "../tools/BaseTool.ts";
@@ -21,6 +27,7 @@ import { Telemetry } from "../telemetry/Telemetry.ts";
 import type { Tracer } from "../telemetry/Tracer.ts";
 import { TreeDevDrillError } from "../tree/dev/TreeDevDrillError.ts";
 import { retry } from "../utils/retry.ts";
+import { sleep } from "../utils/timers.ts";
 import type { Driver } from "./Driver.ts";
 import {
   waiterScriptSource,
@@ -59,6 +66,9 @@ const CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed";
 const WAITER_SCRIPT = waiterScriptSource; // await readScript("waiter.js");
 const WAIT_FOR_SCRIPT = `(...scriptArgs) => new Promise((resolve) => { const arguments = [...scriptArgs, resolve]; ${waitForScriptSource /* await readScript("waitFor.js") */} })`;
 
+const NEW_TAB_DELAY = 50;
+const NEW_TAB_TIMEOUT = 10_000;
+
 const RETRY_OPTIONS: retry.Options = {
   maxAttempts: 2,
   backOff: 500,
@@ -68,7 +78,13 @@ const RETRY_OPTIONS: retry.Options = {
 export class PlaywrightDriver extends BaseDriver {
   private client!: CDPSession;
   page: Page;
-  private _pages: Page[] = [];
+
+  private openedPages: Page[] = [];
+  private watchedContexts: Set<BrowserContext> = new Set();
+  private previousPage: Page | undefined;
+  private pendingWindowOpen = false;
+  private cdpSessionReady: Promise<void>;
+
   // frameId → url for OOPIF frames tracked via Target.attachedToTarget events
   private oopifFrameIds: Map<string, string> = new Map();
   // Playwright Frame objects that correspond to OOPIFs (populated during getAccessibilityTree)
@@ -82,46 +98,89 @@ export class PlaywrightDriver extends BaseDriver {
     TypeTool,
     UploadTool,
   ]);
-  public newTabTimeout = Env.ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT;
   public autoswitchToNewTab = true;
   public fullPageScreenshot = Env.ALUMNIUM_FULL_PAGE_SCREENSHOT;
 
   constructor(page: Page) {
     super();
     this.page = page;
-    this.setupPageTracking(page);
-    void this.initCDPSession();
+    this.watchContextOf(page);
+    this.cdpSessionReady = this.initCDPSession();
   }
 
-  private setupPageTracking(initialPage: Page): void {
-    this._pages = [initialPage];
-    this.attachPageListeners(initialPage);
+  private watchContextOf(page: Page): void {
+    const context = page.context();
+    if (this.watchedContexts.has(context)) return;
+
+    this.watchedContexts.add(context);
+    context.on("page", (opened) => this.onPageOpened(opened));
+    logger.debug("Watching browser context for new tabs");
   }
 
-  private attachPageListeners(page: Page): void {
-    page.on("popup", (popup) => this.onPopup(popup));
-    page.on("close", (popup) => this.onPageClose(popup));
+  private onPageOpened(page: Page): void {
+    logger.debug(`New tab opened: ${page.url()}`);
+    this.pendingWindowOpen = false;
+    this.openedPages.push(page);
+    this.watchContextOf(page);
+    page.on("close", () => this.onPageClosed(page));
   }
 
-  private onPopup(popup: Page) {
-    logger.debug(`New popup opened: ${popup.url()}`);
-    this._pages.push(popup);
-    this.attachPageListeners(popup); // Chain: new page also listens for popups
-  }
+  private onPageClosed(page: Page): void {
+    this.openedPages = this.openedPages.filter((opened) => opened !== page);
+    if (page !== this.page) return;
 
-  private onPageClose(page: Page): void {
-    const index = this._pages.indexOf(page);
-    if (index !== -1) {
-      logger.debug(`Page closed: ${page.url()}`);
-      this._pages.splice(index, 1);
+    const previous = this.previousPage;
+    if (!previous || previous.isClosed()) {
+      logger.warn("Active tab was closed and the tab it came from is gone");
+      return;
     }
+
+    logger.debug(`Active tab was closed, returning to ${previous.url()}`);
+    this.page = previous;
+    this.previousPage = undefined;
+    this.resetAccessibilityTree();
+
+    // The handler cannot await, so hand the new session to whoever needs it
+    // next. The extra catch only silences the unhandled rejection warning.
+    this.cdpSessionReady = this.initCDPSession();
+    this.cdpSessionReady.catch(() => {});
   }
 
   private async initCDPSession(): Promise<void> {
     this.oopifFrameIds.clear();
     this.oopifFrames.clear();
+
+    const previous = this.client as CDPSession | undefined;
+    if (previous) {
+      try {
+        await previous.detach();
+      } catch {
+        // The target may already be closed.
+      }
+    }
+
     this.client = await this.page.context().newCDPSession(this.page);
+    await this.enablePageEvents();
     await this.enableTargetAutoAttach();
+  }
+
+  private async enablePageEvents(): Promise<void> {
+    try {
+      await this.client.send("Page.enable");
+
+      // Playwright page event fires after navigation, so it can be very slow.
+      // Use CDP instead which fires when the browser is asked to open a window.
+      this.client.on("Page.windowOpen", (event: { url: string }) => {
+        logger.debug(`Window open requested: ${event.url || "(empty)"}`);
+        this.pendingWindowOpen = true;
+      });
+
+      logger.debug("Enabled Page events for new tab detection");
+    } catch (error) {
+      logger.debug(
+        `Could not enable Page events: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   private async enableTargetAutoAttach(): Promise<void> {
@@ -187,6 +246,8 @@ export class PlaywrightDriver extends BaseDriver {
 
   @span("driver.get_accessibility_tree", spanAttrs)
   protected async fetchAccessibilityTree(): Promise<BaseAccessibilityTree> {
+    await this.switchToNewTab();
+    await this.cdpSessionReady;
     await this.waitForPageToLoad();
 
     const frameTree = (await this.client.send(
@@ -544,38 +605,32 @@ export class PlaywrightDriver extends BaseDriver {
 
   @span("driver.switch_to_next_tab", spanAttrs)
   async switchToNextTab(): Promise<void> {
-    // Brief wait to allow popup handlers to complete
-    await this.page.waitForTimeout(100);
-    if (this._pages.length <= 1) {
+    const pages = await this.openTabs();
+    if (pages.length <= 1) {
       return; // Only one tab, nothing to switch
     }
 
-    const currentIndex = this._pages.indexOf(this.page);
-    const nextIndex = (currentIndex + 1) % this._pages.length; // Wrap to first
+    const currentIndex = pages.indexOf(this.page);
+    const nextIndex = (currentIndex + 1) % pages.length; // Wrap to first
 
-    await this.switchToTab(nextIndex);
+    await this.switchToTab(pages[nextIndex]);
   }
 
   @span("driver.switch_to_previous_tab", spanAttrs)
   async switchToPreviousTab(): Promise<void> {
-    // Brief wait to allow popup handlers to complete
-    await this.page.waitForTimeout(100);
-    if (this._pages.length <= 1) {
-      return; // Only one tab, nothing to switch
-    }
+    const pages = await this.openTabs();
+    if (pages.length <= 1) return; // Only one tab, nothing to switch
 
-    const currentIndex = this._pages.indexOf(this.page);
-    const prevIndex =
-      (currentIndex - 1 + this._pages.length) % this._pages.length; // Wrap to last
+    const currentIndex = pages.indexOf(this.page);
+    const prevIndex = (currentIndex - 1 + pages.length) % pages.length; // Wrap to last
 
-    await this.switchToTab(prevIndex);
+    await this.switchToTab(pages[prevIndex]);
   }
 
   @stateful("switchToTab")
-  private async switchToTab(tabIndex: number): Promise<void> {
-    always(this._pages[tabIndex]);
-    this.page = this._pages[tabIndex];
-    await this.initCDPSession();
+  private async switchToTab(page: Page | undefined): Promise<void> {
+    always(page);
+    await this.activatePage(page);
     await this.page.waitForLoadState();
   }
 
@@ -620,24 +675,65 @@ export class PlaywrightDriver extends BaseDriver {
   ): Promise<void> {
     if (!this.autoswitchToNewTab) {
       await action();
+      this.openedPages = [];
       return;
     }
 
-    const [newPage] = await Promise.all([
-      this.page
-        .context()
-        .waitForEvent("page", { timeout: this.newTabTimeout })
-        .catch(() => null),
-      action(),
-    ]);
+    await action();
+    await sleep(NEW_TAB_DELAY);
 
-    if (newPage) {
-      logger.debug(
-        `Auto-switching to new tab ${newPage.url()} (${await newPage.title()})`,
-      );
-      this.page = newPage;
-      await this.initCDPSession();
+    if (!this.openedPages.length && this.pendingWindowOpen) {
+      await this.waitForAnnouncedTab();
     }
+    await this.switchToNewTab();
+  }
+
+  private async waitForAnnouncedTab(): Promise<void> {
+    this.pendingWindowOpen = false;
+    logger.debug("A tab is opening, waiting for the browser to report it");
+    await this.page
+      .context()
+      .waitForEvent("page", { timeout: NEW_TAB_TIMEOUT })
+      .catch(() => logger.debug("  <- No tab was reported, continuing"));
+  }
+
+  @span("driver.internal.switch_to_new_tab")
+  private async switchToNewTab(): Promise<void> {
+    await this.flushEvents();
+
+    const opened = this.openedPages.filter((page) => !page.isClosed()).pop();
+
+    this.openedPages = [];
+    if (!opened) return;
+
+    logger.debug(`Auto-switching to new tab: ${opened.url()}`);
+    await opened.waitForLoadState();
+    await this.activatePage(opened);
+  }
+
+  private async activatePage(page: Page): Promise<void> {
+    // Let a session setup that is still in flight finish.
+    await this.cdpSessionReady.catch(() => {});
+
+    if (page !== this.page) this.previousPage = this.page;
+    this.page = page;
+    this.watchContextOf(page);
+    this.resetAccessibilityTree();
+    this.cdpSessionReady = this.initCDPSession();
+    await this.cdpSessionReady;
+  }
+
+  private async openTabs(): Promise<Page[]> {
+    this.openedPages = [];
+    await this.flushEvents();
+    return this.page
+      .context()
+      .pages()
+      .filter((page) => !page.isClosed());
+  }
+
+  private async flushEvents(): Promise<void> {
+    await this.page.context().cookies();
   }
 
   private getAllFrameIds(frameInfo: CDPFrameInfo): string[] {

--- a/packages/typescript/src/llm/Lchain.serialized.types-scan.json
+++ b/packages/typescript/src/llm/Lchain.serialized.types-scan.json
@@ -1671,6 +1671,9 @@
                                                   {
                                                     "kind": "string",
                                                     "literal": false
+                                                  },
+                                                  {
+                                                    "kind": "null"
                                                   }
                                                 ]
                                               }
@@ -1738,6 +1741,24 @@
                                                   {
                                                     "kind": "string",
                                                     "literal": false
+                                                  }
+                                                ]
+                                              },
+                                              "caller": {
+                                                "kind": "field",
+                                                "optional": true,
+                                                "type": [
+                                                  {
+                                                    "kind": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "namespace": {
+                                                "kind": "field",
+                                                "optional": true,
+                                                "type": [
+                                                  {
+                                                    "kind": "null"
                                                   }
                                                 ]
                                               }

--- a/packages/typescript/src/llm/LchainSchema.ts
+++ b/packages/typescript/src/llm/LchainSchema.ts
@@ -230,7 +230,7 @@ export abstract class LchainSchema {
     status: z.union([z.literal("completed"), z.string()]),
     content: z.array(this.MetadataOutput),
     role: z.union([z.literal("assistant"), z.string()]),
-    phase: z.string().exactOptional(),
+    phase: z.union([z.string(), z.null()]).exactOptional(),
   });
 
   static OutputFunctionCall = z.object({
@@ -240,6 +240,8 @@ export abstract class LchainSchema {
     arguments: z.string(),
     call_id: z.string(),
     name: z.string(),
+    caller: z.null().exactOptional(),
+    namespace: z.null().exactOptional(),
   });
 
   static ResponseMetadataOutputItem = z.discriminatedUnion("type", [

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -76,7 +76,6 @@ export const startMcpTool = McpTool.define("start", {
             - "fullPageScreenshot" (boolean, default false) — capture full-page screenshots.
             - "headers" (object) — extra HTTP headers for every request, supported for Selenium and Playwright, e.g. {"Authorization": "Bearer token"};
             - "headless" (boolean, default false) — run browser headless, supported for Selenium and Playwright;
-            - "newTabTimeout" (number, default 200) — ms to wait for new tab detection, Playwright only;
             - "permissions" (string[]) — browser permissions to grant, Playwright only, e.g. ["camera"];
             - "planner" (boolean) — enable/disable planner agent;
             - "profile" (string) — name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in ~/.alumnium/profiles/{name}, e.g. "personal";

--- a/packages/typescript/tests/system/helpers.ts
+++ b/packages/typescript/tests/system/helpers.ts
@@ -1,5 +1,7 @@
 import { Alumni, AppiumDriver, Model, type Element } from "alumnium";
 import { never } from "alwaysly";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
@@ -17,6 +19,12 @@ export namespace Setup {
     navigate: (url: string) => Promise<void>;
     type: (element: Element | undefined, text: string) => Promise<void>;
     click: (element: Element | undefined) => Promise<void>;
+    serveSlowTabPage: () => Promise<Setup.SlowTabPage>;
+  }
+
+  export interface SlowTabPage {
+    url: string;
+    slowTabUrl: string;
   }
 }
 
@@ -49,7 +57,7 @@ export async function useSetup(props: useSetup.Props): Promise<Setup> {
   };
 
   const al = new Alumni(driver, options);
-  const $ = createHelpers(driverId, driver, al);
+  const $ = createHelpers(driverId, driver, al, onTestFinished);
 
   if (isAppiumDriver) {
     (al.driver as AppiumDriver).delay = 0.1;
@@ -124,6 +132,7 @@ function createHelpers(
   driverId: Driver.Id,
   driver: Alumni.Driver,
   al: Alumni,
+  onTestFinished: useSetup.Props["onTestFinished"],
 ): Setup.Helpers {
   const $: Setup.Helpers = {
     resolveUrl(url: string): string {
@@ -142,6 +151,40 @@ function createHelpers(
 
     async navigate(url: string) {
       await al.driver.visit($.resolveUrl(url));
+    },
+
+    async serveSlowTabPage() {
+      const server = createServer((request, response) => {
+        const isSlowTab = request.url === "/slow-tab";
+        const send = () => {
+          response.writeHead(200, {
+            "content-type": "text/html",
+            "cache-control": "no-store",
+          });
+          response.end(
+            isSlowTab
+              ? "<title>Slow Tab</title><h1>Slow Tab</h1>"
+              : `<title>Opener</title><h1>Opener</h1>
+                 <button onclick="window.open('/slow-tab', '_blank')">Open Slow Tab</button>`,
+          );
+        };
+
+        if (isSlowTab) setTimeout(send, 2000);
+        else send();
+      });
+
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+      );
+      onTestFinished(
+        () => new Promise<void>((resolve) => server.close(() => resolve())),
+      );
+
+      const { port } = server.address() as AddressInfo;
+      return {
+        url: `http://127.0.0.1:${port}/`,
+        slowTabUrl: `http://127.0.0.1:${port}/slow-tab`,
+      };
     },
 
     async type(element: Element | undefined, text: string) {

--- a/packages/typescript/tests/system/tabs.test.ts
+++ b/packages/typescript/tests/system/tabs.test.ts
@@ -15,7 +15,7 @@ describe("Tabs", () => {
     };
   });
 
-  it("switching tabs", async ({ expect, setup }) => {
+  it("switches tabs", async ({ expect, setup }) => {
     const { al, $ } = await setup({
       extraTools: [SwitchToNextTabTool, SwitchToPreviousTabTool],
     });
@@ -36,5 +36,17 @@ describe("Tabs", () => {
 
     await al.do("switch to previous browser tab");
     expect(await al.get("current page URL")).toBe("about:blank");
+  });
+
+  it("switches to a tab that opens slowly", async ({ expect, setup }) => {
+    const { al, $ } = await setup();
+    const { url, slowTabUrl } = await $.serveSlowTabPage();
+
+    await $.navigate(url);
+    await al.do("click on 'Open Slow Tab' button");
+
+    // al.get() is too slow which gives tab enough time to arrive on its own
+    expect(await al.driver.url()).toBe(slowTabUrl);
+    expect(await al.get("header text")).toBe("Slow Tab");
   });
 });

--- a/websites/docs/src/content/docs/docs/guides/mcp.mdx
+++ b/websites/docs/src/content/docs/docs/guides/mcp.mdx
@@ -223,7 +223,6 @@ Pass `alumnium:options` in capabilities to configure Alumnium and driver behavio
 | `headers`                 | Custom HTTP headers for all browser requests. Selenium and Playwright only.                                                                                        |
 | `headless`                | Run browser in headless mode. Selenium and Playwright only. Default is `false`.                                                                                    |
 | `hideKeyboardAfterTyping` | Dismiss the on-screen keyboard after typing. Appium only. Default is `false`.                                                                                      |
-| `newTabTimeout`           | Milliseconds to wait for a new tab to open after a click. Playwright only. Default is `200`.                                                                       |
 | `permissions`             | Browser permissions to grant (e.g. `["geolocation"]`). Playwright only.                                                                                            |
 | `planner`                 | Enable or disable the planning step in `do()`. Default is `true`.                                                                                                  |
 | `profile`                 | Name of a persistent browser profile; cookies, sessions, and storage are preserved across restarts in `~/.alumnium/profiles/{name}`. Selenium and Playwright only. |

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -165,10 +165,6 @@ Sets the root directory for Alumnium's persistent file store (cache, artifacts, 
 
 Set to `false` to start Playwright in headed mode. Only used in the [MCP server][3]. Default is `true`.
 
-### `ALUMNIUM_PLAYWRIGHT_NEW_TAB_TIMEOUT`
-
-Timeout in milliseconds when waiting for a new tab to open after interacting with elements using Playwright driver. Increase when Alumnium fails to detect a new tab. Default is 200.
-
 ### `ANTHROPIC_API_KEY`
 
 API key used when `ALUMNIUM_MODEL` is set to `anthropic`.


### PR DESCRIPTION
New-tab detection raced every click against a fixed 200 ms `waitForEvent("page")`, and pages that opened a tab more slowly needed 2000–5000 ms timeout.

Instead of guessing a timeout, the drivers now keep one page listener per browser context and adopt the newest reported tab right after the interaction that opened it, waiting only when the CDP `Page.windowOpen` event announced a tab that has not arrived yet.