### PR TITLE
feat!(actor): stop clicking on expanded dropdowns

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/tool/ClickTool.java
+++ b/packages/java/src/main/java/ai/alumnium/tool/ClickTool.java
@@ -4,7 +4,10 @@ import ai.alumnium.driver.BaseDriver;
 import ai.alumnium.tool.annotation.ToolDescription;
 import ai.alumnium.tool.annotation.ToolField;
 
-@ToolDescription("Click an element. NEVER use ClickTool to upload files - use UploadTool instead.")
+@ToolDescription(
+    "Click an element. NEVER use ClickTool on comboboxes, instead proceed to click the"
+        + " desired option directly. NEVER use ClickTool to upload files - use UploadTool"
+        + " instead.")
 public record ClickTool(@ToolField(description = "Element identifier (ID)") int id)
     implements BaseTool {
   @Override

--- a/packages/java/src/main/java/ai/alumnium/tool/ClickTool.java
+++ b/packages/java/src/main/java/ai/alumnium/tool/ClickTool.java
@@ -5,8 +5,8 @@ import ai.alumnium.tool.annotation.ToolDescription;
 import ai.alumnium.tool.annotation.ToolField;
 
 @ToolDescription(
-    "Click an element. NEVER use ClickTool on comboboxes, instead proceed to click the"
-        + " desired option directly. NEVER use ClickTool to upload files - use UploadTool"
+    "Click an element. If the target element is a dropdown and is already expanded - you"
+        + " don't need to click it. NEVER use ClickTool to upload files - use UploadTool"
         + " instead.")
 public record ClickTool(@ToolField(description = "Element identifier (ID)") int id)
     implements BaseTool {

--- a/packages/java/src/test/java/ai/alumnium/unit/tool/ToolToSchemaConverterTest.java
+++ b/packages/java/src/test/java/ai/alumnium/unit/tool/ToolToSchemaConverterTest.java
@@ -23,8 +23,8 @@ class ToolToSchemaConverterTest {
         .containsEntry("name", "ClickTool")
         .containsEntry(
             "description",
-            "Click an element. NEVER use ClickTool on comboboxes, instead proceed to click"
-                + " the desired option directly. NEVER use ClickTool to upload files - use"
+            "Click an element. If the target element is a dropdown and is already expanded"
+                + " - you don't need to click it. NEVER use ClickTool to upload files - use"
                 + " UploadTool instead.");
 
     @SuppressWarnings("unchecked")

--- a/packages/java/src/test/java/ai/alumnium/unit/tool/ToolToSchemaConverterTest.java
+++ b/packages/java/src/test/java/ai/alumnium/unit/tool/ToolToSchemaConverterTest.java
@@ -23,7 +23,9 @@ class ToolToSchemaConverterTest {
         .containsEntry("name", "ClickTool")
         .containsEntry(
             "description",
-            "Click an element. NEVER use ClickTool to upload files - use UploadTool" + " instead.");
+            "Click an element. NEVER use ClickTool on comboboxes, instead proceed to click"
+                + " the desired option directly. NEVER use ClickTool to upload files - use"
+                + " UploadTool instead.");
 
     @SuppressWarnings("unchecked")
     Map<String, Object> parameters = (Map<String, Object>) function.get("parameters");

--- a/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py
+++ b/packages/python/src/alumnium/accessibility/chromium_accessibility_tree.py
@@ -119,7 +119,7 @@ class ChromiumAccessibilityTree(BaseAccessibilityTree):
         # Inline iframe content: if this element is an iframe, add its child trees
         backend_node_id = node.get("backendDOMNodeId")
         if backend_node_id and backend_node_id in iframe_children:
-            for child_root in iframe_children[backend_node_id]:
+            for child_root in iframe_children.pop(backend_node_id):
                 child_elem = self._node_to_xml(child_root, node_lookup, iframe_children)
                 elem.append(child_elem)
 

--- a/packages/python/src/alumnium/tools/click_tool.py
+++ b/packages/python/src/alumnium/tools/click_tool.py
@@ -6,7 +6,11 @@ from .upload_tool import UploadTool
 
 
 class ClickTool(BaseTool):
-    __doc__ = f"Click an element. NEVER use ClickTool to upload files - use {UploadTool.__name__} instead."
+    __doc__ = (
+        "Click an element."
+        " NEVER use ClickTool on comboboxes, instead proceed to click the desired option directly."
+        f" NEVER use ClickTool to upload files - use {UploadTool.__name__} instead."
+    )
 
     id: int = Field(description="Element identifier (ID)")
 

--- a/packages/python/src/alumnium/tools/click_tool.py
+++ b/packages/python/src/alumnium/tools/click_tool.py
@@ -8,7 +8,7 @@ from .upload_tool import UploadTool
 class ClickTool(BaseTool):
     __doc__ = (
         "Click an element."
-        " NEVER use ClickTool on comboboxes, instead proceed to click the desired option directly."
+        " If the target element is a dropdown and is already expanded - you don't need to click it."
         f" NEVER use ClickTool to upload files - use {UploadTool.__name__} instead."
     )
 

--- a/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/BaseServerAccessibilityTree.ts
@@ -187,6 +187,7 @@ export abstract class BaseServerAccessibilityTree {
         Array.from(this.genericRoles, (role) => [role, "div"]),
       ),
       preserveFalseAttrs: this.renderPreserveFalseAttrs,
+      explicitTrueAttrs: this.explicitTrueAttrs,
     });
   }
 
@@ -213,6 +214,8 @@ export abstract class BaseServerAccessibilityTree {
   protected get renderPreserveFalseAttrs(): ReadonlySet<string> {
     return this.preserveFalseAttrs;
   }
+
+  protected explicitTrueAttrs = new Set<string>();
 
   protected abstract textContentAttr(role: string): string | undefined;
 

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -320,7 +320,7 @@ describe(ServerChromiumAccessibilityTree, () => {
       const xml = tree.toXml();
 
       expect(tree.toXml()).toMatchInlineSnapshot(`
-        "<combobox expanded>
+        "<combobox expanded="true">
           <option name="One" id=3 focusable selected="false" />
         </combobox>"
       `);
@@ -349,7 +349,7 @@ describe(ServerChromiumAccessibilityTree, () => {
       `);
 
       expect(tree.toXml()).toBe(lit`
-        <combobox value="Two" expanded>
+        <combobox value="Two" expanded="true">
           <option name="One" selected="false" />
           <option selected>Two</option>
           <option name="Three" selected="false" />

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.test.ts
@@ -320,12 +320,13 @@ describe(ServerChromiumAccessibilityTree, () => {
       const xml = tree.toXml();
 
       expect(tree.toXml()).toMatchInlineSnapshot(`
-        "<combobox id=1 focusable>
+        "<combobox expanded>
           <option name="One" id=3 focusable selected="false" />
         </combobox>"
       `);
 
-      expectVisibleMappings(tree, xml, { 1: 10, 3: 12 });
+      // The combobox itself is unaddressable, only its options are.
+      expectVisibleMappings(tree, xml, { 3: 12 });
     });
 
     it("sets option selection from the options list value", () => {
@@ -348,7 +349,7 @@ describe(ServerChromiumAccessibilityTree, () => {
       `);
 
       expect(tree.toXml()).toBe(lit`
-        <combobox value="Two">
+        <combobox value="Two" expanded>
           <option name="One" selected="false" />
           <option selected>Two</option>
           <option name="Three" selected="false" />

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
@@ -52,8 +52,8 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
     "nodeId",
     "raw_id",
     "mutable",
-    // We skip 'expanded' because it often leads LLMs to click comboboxes
-    // before selecting, which is automatically handled by the SelectTool.
+    // Select comboboxes are forced to have the expanded=true.
+    // This prevents LLM from clicking to open it before selecting an option.
     "expanded",
   ]);
 
@@ -68,8 +68,25 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
   protected override parseAddressable(xmlTag: Xml.Tag): boolean {
     return (
       xmlTag.tagName !== "MenuListPopup" &&
+      !this.#isSelectCombobox(xmlTag) &&
       xmlTag.attribs.backendDOMNodeId !== undefined
     );
+  }
+
+  #isSelectCombobox(xmlTag: Xml.Tag): boolean {
+    if (xmlTag.tagName !== "combobox") return false;
+    return this.#hasDescendantTag(xmlTag, "MenuListPopup");
+  }
+
+  #hasDescendantTag(xmlTag: Xml.Tag, tagName: string): boolean {
+    return xmlTag.children.some((child) => {
+      const childTag = Xml.nodeAsTag(child);
+      if (!childTag) return false;
+      return (
+        childTag.tagName === tagName ||
+        this.#hasDescendantTag(childTag, tagName)
+      );
+    });
   }
 
   //#endregion
@@ -173,6 +190,13 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
 
   #postTransformCombobox(xmlTag: Xml.Tag): void {
     this.#postTransformList(xmlTag);
+
+    // Force to have expanded=true, so that LLMs don't
+    // click to open it before selecting an option.
+    if (!this.isRenderedAddressable(xmlTag)) {
+      delete xmlTag.attribs.focusable;
+      xmlTag.attribs.expanded = "true";
+    }
 
     const value = xmlTag.attribs.value || null;
 

--- a/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
+++ b/packages/typescript/src/server/accessibility/ServerChromiumAccessibilityTree.ts
@@ -52,9 +52,6 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
     "nodeId",
     "raw_id",
     "mutable",
-    // Select comboboxes are forced to have the expanded=true.
-    // This prevents LLM from clicking to open it before selecting an option.
-    "expanded",
   ]);
 
   protected override skipXmlAttr(
@@ -123,6 +120,8 @@ export class ServerChromiumAccessibilityTree extends BaseServerAccessibilityTree
   protected override get renderPreserveFalseAttrs(): ReadonlySet<string> {
     return new Set([...this.preserveFalseAttrs, "selected"]);
   }
+
+  protected override explicitTrueAttrs = new Set(["expanded"]);
 
   protected override textContentAttr(_role: string): string | undefined {
     return undefined;

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-150b12b183a111c.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-150b12b183a111c.snap.xml
@@ -179,7 +179,7 @@
             </div>
             <button id=293 focusable>Read 4 files, searched the codebase</button>
             <div id=297>
-              <button id=298 focusable>
+              <button id=298 focusable expanded="true">
                 <div id=299>
                   Edited
                   <strong id=301>ThemeProvider.tsx</strong>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1a8a9b9dc16782b1.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-1a8a9b9dc16782b1.snap.xml
@@ -12,7 +12,7 @@
       <search id=38>
         <div id=40>
           <div id=41>
-            <combobox name="Search" id=47 focusable focused editable="plaintext" settable autocomplete="list" controls="i0">
+            <combobox name="Search" id=47 focusable focused editable="plaintext" settable autocomplete="list" expanded="true" controls="i0">
               <div id=49 editable="plaintext">lofi beats</div>
             </combobox>
             <button name="Clear search query" id=52 focusable />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2d7b9332895066c0.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-2d7b9332895066c0.snap.xml
@@ -28,7 +28,7 @@
                   <div id=69>When</div>
                   <div id=72>5 Aug</div>
                 </button>
-                <button id=75 focusable focused>
+                <button id=75 focusable focused expanded="true">
                   <div id=78>Who</div>
                   <div id=81>Add guests</div>
                 </button>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
@@ -38,7 +38,7 @@
       <div id=50>
         <LabelText id=51>
           Dropdown (select)
-          <combobox name="Dropdown (select)" expanded>
+          <combobox name="Dropdown (select)" expanded="true">
             <option name="Open this select menu" id=56 focusable selected="false" />
             <option name="One" id=57 focusable selected="false" />
             <option name="Two" id=58 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-33c672e2de4e6fd7.snap.xml
@@ -38,7 +38,7 @@
       <div id=50>
         <LabelText id=51>
           Dropdown (select)
-          <combobox name="Dropdown (select)" id=53 focusable>
+          <combobox name="Dropdown (select)" expanded>
             <option name="Open this select menu" id=56 focusable selected="false" />
             <option name="One" id=57 focusable selected="false" />
             <option name="Two" id=58 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-3466617d627fc278.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-3466617d627fc278.snap.xml
@@ -12,7 +12,7 @@
       <div id=37>
         <search id=38>
           <div id=41>
-            <combobox name="Search" id=43 focusable editable="plaintext" settable autocomplete="list">
+            <combobox name="Search" id=43 focusable editable="plaintext" settable autocomplete="list" expanded="true">
               <div id=45 editable="plaintext">lofi beats</div>
             </combobox>
             <button name="Clear search query" id=48 focusable />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-43b3b85068ceb7c2.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-43b3b85068ceb7c2.snap.xml
@@ -911,7 +911,7 @@
       </contentinfo>
     </div>
   </div>
-  <button id=1178 focusable hasPopup="listbox">
+  <button id=1178 focusable hasPopup="listbox" expanded="true">
     <banner id=1180>
       <LabelText id=1182>Search</LabelText>
       <searchbox name="Search" id=1187 focusable focused editable="plaintext" settable autocomplete="both">

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-492a8980e94af965.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-492a8980e94af965.snap.xml
@@ -135,7 +135,7 @@
       <DescriptionList id=365>
         <div id=366>
           <term id=367>
-            <button id=368 focusable controls="_R_5p5__0">
+            <button id=368 focusable expanded="true" controls="_R_5p5__0">
               <heading id=370 level=3>Automate your path to production</heading>
             </button>
           </term>
@@ -260,7 +260,7 @@
       <DescriptionList id=567>
         <div id=568>
           <term id=569>
-            <button id=570 focusable controls="_R_5q5__0">
+            <button id=570 focusable expanded="true" controls="_R_5q5__0">
               <heading id=572 level=3>Keep track of your tasks</heading>
             </button>
           </term>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-4fa4d7ccce79898a.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-4fa4d7ccce79898a.snap.xml
@@ -21,7 +21,7 @@
                 <div id=56>
                   <div id=58>
                     <div id=59>Where</div>
-                    <combobox name="Where" id=62 focusable focused editable="plaintext" settable autocomplete="list" controls="bigsearch-query-location-listbox">
+                    <combobox name="Where" id=62 focusable focused editable="plaintext" settable autocomplete="list" expanded="true" controls="bigsearch-query-location-listbox">
                       <div id=65 editable="plaintext">Singapore</div>
                     </combobox>
                   </div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-5d35f5b60496cda9.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-5d35f5b60496cda9.snap.xml
@@ -911,7 +911,7 @@
       </contentinfo>
     </div>
   </div>
-  <button id=1178 focusable hasPopup="listbox">
+  <button id=1178 focusable hasPopup="listbox" expanded="true">
     <banner id=1180>
       <LabelText id=1182>Search</LabelText>
       <searchbox name="Search" id=1187 focusable focused editable="plaintext" settable autocomplete="both" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-789a3d5baf773baa.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-789a3d5baf773baa.snap.xml
@@ -37,7 +37,7 @@
                   <div id=97>
                     <div id=98>
                       <LabelText id=99>Search</LabelText>
-                      <combobox name="Search" id=105 focusable focused editable="plaintext" settable autocomplete="list" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results" />
+                      <combobox name="Search" id=105 focusable focused editable="plaintext" settable autocomplete="list" expanded="true" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results" />
                       <listbox name="Suggestions" id=110 focusable orientation="vertical">
                         <option name=", jump to this explore page" id=111 selected="false">Enterprise</option>
                         <option name=", jump to this explore page" id=117 selected="false">Security</option>
@@ -156,7 +156,7 @@
       <DescriptionList id=411>
         <div id=412>
           <term id=413>
-            <button id=414 focusable controls="_R_5p5__0">
+            <button id=414 focusable expanded="true" controls="_R_5p5__0">
               <heading id=416 level=3>Automate your path to production</heading>
             </button>
           </term>
@@ -281,7 +281,7 @@
       <DescriptionList id=613>
         <div id=614>
           <term id=615>
-            <button id=616 focusable controls="_R_5q5__0">
+            <button id=616 focusable expanded="true" controls="_R_5q5__0">
               <heading id=618 level=3>Keep track of your tasks</heading>
             </button>
           </term>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
@@ -40,7 +40,7 @@
       <div id=51>
         <LabelText id=52>
           Dropdown (select)
-          <combobox name="Dropdown (select)" id=54 focusable>
+          <combobox name="Dropdown (select)" expanded>
             <option name="Open this select menu" id=57 focusable selected="false" />
             <option name="One" id=58 focusable selected="false" />
             <option name="Two" id=59 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-7c953f9669c86485.snap.xml
@@ -40,7 +40,7 @@
       <div id=51>
         <LabelText id=52>
           Dropdown (select)
-          <combobox name="Dropdown (select)" expanded>
+          <combobox name="Dropdown (select)" expanded="true">
             <option name="Open this select menu" id=57 focusable selected="false" />
             <option name="One" id=58 focusable selected="false" />
             <option name="Two" id=59 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-867955265c765444.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-867955265c765444.snap.xml
@@ -24,7 +24,7 @@
                     <div id=64 editable="plaintext">Singapore</div>
                   </combobox>
                 </div>
-                <button id=67 focusable focused>
+                <button id=67 focusable focused expanded="true">
                   <div id=70>When</div>
                   <div id=73>Add dates</div>
                 </button>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b03cec15ba5db523.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-b03cec15ba5db523.snap.xml
@@ -10,7 +10,7 @@
     </div>
     <div id=37>
       <search id=38>
-        <combobox name="Search" id=43 focusable editable="plaintext" settable autocomplete="list" />
+        <combobox name="Search" id=43 focusable editable="plaintext" settable autocomplete="list" expanded="true" />
         <button name="Search" id=46 focusable />
       </search>
       <div id=50>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d6643d00ef390cf4.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-d6643d00ef390cf4.snap.xml
@@ -38,7 +38,7 @@
                     <div id=98>
                       <LabelText id=99>Search</LabelText>
                       <div id=101>
-                        <combobox name="Search" id=105 focusable focused editable="plaintext" settable autocomplete="list" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results">
+                        <combobox name="Search" id=105 focusable focused editable="plaintext" settable autocomplete="list" expanded="true" describedby="validation-34ac918b-2693-4140-aedc-7b6771cb6c94" controls="query-builder-test-results">
                           <div id=106 editable="plaintext">alumnium</div>
                         </combobox>
                         <div id=108>
@@ -161,7 +161,7 @@
       <DescriptionList id=396>
         <div id=397>
           <term id=398>
-            <button id=399 focusable controls="_R_5p5__0">
+            <button id=399 focusable expanded="true" controls="_R_5p5__0">
               <heading id=401 level=3>Automate your path to production</heading>
             </button>
           </term>
@@ -286,7 +286,7 @@
       <DescriptionList id=598>
         <div id=599>
           <term id=600>
-            <button id=601 focusable controls="_R_5q5__0">
+            <button id=601 focusable expanded="true" controls="_R_5q5__0">
               <heading id=603 level=3>Keep track of your tasks</heading>
             </button>
           </term>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e0377270879208d7.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e0377270879208d7.snap.xml
@@ -7,7 +7,7 @@
       </link>
     </div>
     <search id=28>
-      <combobox id=33 focusable editable="plaintext" settable autocomplete="list" />
+      <combobox id=33 focusable editable="plaintext" settable autocomplete="list" expanded="true" />
       <button name="Search" id=35 focusable />
     </search>
   </banner>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
@@ -42,7 +42,7 @@
       <div id=52>
         <LabelText id=53>
           Dropdown (select)
-          <combobox name="Dropdown (select)" id=55 focusable>
+          <combobox name="Dropdown (select)" expanded>
             <option name="Open this select menu" id=58 focusable selected="false" />
             <option name="One" id=59 focusable selected="false" />
             <option name="Two" id=60 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e09d97998378fde5.snap.xml
@@ -42,7 +42,7 @@
       <div id=52>
         <LabelText id=53>
           Dropdown (select)
-          <combobox name="Dropdown (select)" expanded>
+          <combobox name="Dropdown (select)" expanded="true">
             <option name="Open this select menu" id=58 focusable selected="false" />
             <option name="One" id=59 focusable selected="false" />
             <option name="Two" id=60 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e52a9f0f6595890f.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e52a9f0f6595890f.snap.xml
@@ -24,7 +24,7 @@
                     <div id=64 editable="plaintext">Singapore</div>
                   </combobox>
                 </div>
-                <button id=67 focusable>
+                <button id=67 focusable expanded="true">
                   <div id=69>
                     <div id=70>When</div>
                     <div id=73>5 Aug</div>

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
@@ -44,7 +44,7 @@
           <div id=62>
             <LabelText id=63>
               Dropdown (select)
-              <combobox name="Dropdown (select)" expanded>
+              <combobox name="Dropdown (select)" expanded="true">
                 <option name="Open this select menu" id=68 focusable selected="false" />
                 <option name="One" id=69 focusable selected="false" />
                 <option name="Two" id=70 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-e7e730cc3d930cf1.snap.xml
@@ -44,7 +44,7 @@
           <div id=62>
             <LabelText id=63>
               Dropdown (select)
-              <combobox name="Dropdown (select)" id=65 focusable>
+              <combobox name="Dropdown (select)" expanded>
                 <option name="Open this select menu" id=68 focusable selected="false" />
                 <option name="One" id=69 focusable selected="false" />
                 <option name="Two" id=70 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
@@ -46,7 +46,7 @@
           <div id=63>
             <LabelText id=64>
               Dropdown (select)
-              <combobox name="Dropdown (select)" expanded>
+              <combobox name="Dropdown (select)" expanded="true">
                 <option name="Open this select menu" id=69 focusable selected="false" />
                 <option name="One" id=70 focusable selected="false" />
                 <option name="Two" id=71 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/chrome-ecdc0e6a5a148ca.snap.xml
@@ -46,7 +46,7 @@
           <div id=63>
             <LabelText id=64>
               Dropdown (select)
-              <combobox name="Dropdown (select)" id=66 focusable>
+              <combobox name="Dropdown (select)" expanded>
                 <option name="Open this select menu" id=69 focusable selected="false" />
                 <option name="One" id=70 focusable selected="false" />
                 <option name="Two" id=71 focusable selected="false" />

--- a/packages/typescript/src/server/accessibility/__snapshots__/chrome/npm-search-results.snap.xml
+++ b/packages/typescript/src/server/accessibility/__snapshots__/chrome/npm-search-results.snap.xml
@@ -45,7 +45,7 @@
           <div id=58>
             <button id=59 focusable />
             <div id=60>
-              <combobox name="Search packages" id=62 focusable focused editable="plaintext" settable>
+              <combobox name="Search packages" id=62 focusable focused editable="plaintext" settable expanded="true">
                 <div id=65 editable="plaintext">ai</div>
               </combobox>
               <button name="Clear search" id=67 focusable>×</button>

--- a/packages/typescript/src/server/agents/ActorAgent.eval.ts
+++ b/packages/typescript/src/server/agents/ActorAgent.eval.ts
@@ -42,6 +42,7 @@ evalite<Input, ActorAgent.InvokeResult, ToolCall[]>("ActorAgent", {
   data: async () => {
     const selectOption =
       'change the "Send money to" combobox selection to "Seller"';
+    const selectStatus = 'select "Available" status';
 
     return [
       {
@@ -53,13 +54,22 @@ evalite<Input, ActorAgent.InvokeResult, ToolCall[]>("ActorAgent", {
         // Ensure we click on the correct option, not the combobox itself.
         expected: [{ name: "ClickTool", args: { id: 757 } }],
       },
+      {
+        input: {
+          goal: selectStatus,
+          step: selectStatus,
+          treeXml: await readTree("chrome/support-agent-status.xml"),
+        },
+        // Ensure we click on the status button directly since the dropdown is already expanded.
+        expected: [{ name: "ClickTool", args: { id: 379 } }],
+      },
     ];
   },
 
   scorers: [
     {
-      name: "Selects the correct option",
-      description: "Checks the expected option element is clicked.",
+      name: "Selects the correct element",
+      description: "Checks the expected element is clicked.",
       scorer: ({ output, expected }) => {
         const [, toolCalls] = output;
         const expectedCalls = new Set(formatToolCalls(expected));

--- a/packages/typescript/src/server/agents/ActorAgent.eval.ts
+++ b/packages/typescript/src/server/agents/ActorAgent.eval.ts
@@ -1,0 +1,118 @@
+import { evalite } from "evalite";
+import { nanoid } from "nanoid";
+import * as fs from "node:fs/promises";
+import type { AppId } from "../../AppId.ts";
+import { Env } from "../../Env.ts";
+import { Logger } from "../../telemetry/Logger.ts";
+import type { ToolCall } from "../../tools/BaseTool.ts";
+import { ClickTool } from "../../tools/ClickTool.ts";
+import { DragAndDropTool } from "../../tools/DragAndDropTool.ts";
+import { HoverTool } from "../../tools/HoverTool.ts";
+import { PressKeyTool } from "../../tools/PressKeyTool.ts";
+import { TypeTool } from "../../tools/TypeTool.ts";
+import { UploadTool } from "../../tools/UploadTool.ts";
+import { convertToolsToSchemas } from "../../tools/toolToSchemaConverter.ts";
+import { NullCache } from "../cache/NullCache.ts";
+import { LlmContext } from "../LlmContext.ts";
+import { LlmFactory } from "../LlmFactory.ts";
+import { SessionContext } from "../session/SessionContext.ts";
+import { ActorAgent } from "./ActorAgent.ts";
+
+Logger.level = "warning";
+
+interface Input {
+  goal: string;
+  step: string;
+  treeXml: string;
+}
+
+// NOTE: Mirrors `PlaywrightDriver#supportedTools`. It's an instance field and
+// constructing a driver opens a CDP session, so the Chromium tool set is
+// spelled out here instead of being read from the driver.
+const toolSchemas = convertToolsToSchemas({
+  ClickTool,
+  DragAndDropTool,
+  HoverTool,
+  PressKeyTool,
+  TypeTool,
+  UploadTool,
+});
+
+evalite<Input, ActorAgent.InvokeResult, ToolCall[]>("ActorAgent", {
+  data: async () => {
+    const selectOption =
+      'change the "Send money to" combobox selection to "Seller"';
+
+    return [
+      {
+        input: {
+          goal: selectOption,
+          step: selectOption,
+          treeXml: await readTree("chrome/support-order-refund.xml"),
+        },
+        // Ensure we click on the correct option, not the combobox itself.
+        expected: [{ name: "ClickTool", args: { id: 757 } }],
+      },
+    ];
+  },
+
+  scorers: [
+    {
+      name: "Selects the correct option",
+      description: "Checks the expected option element is clicked.",
+      scorer: ({ output, expected }) => {
+        const [, toolCalls] = output;
+        const expectedCalls = new Set(formatToolCalls(expected));
+        return toolCalls.some((toolCall) =>
+          expectedCalls.has(formatToolCall(toolCall)),
+        )
+          ? 1
+          : 0;
+      },
+    },
+  ],
+
+  trialCount: Env.ALUMNIUM_EVAL_TRIAL_COUNT,
+
+  columns: ({ output, expected }) => {
+    const [explanation, toolCalls] = output;
+    return [
+      { label: "Expected", value: formatToolCalls(expected).join(", ") },
+      { label: "Tools", value: formatToolCalls(toolCalls).join(", ") || "-" },
+      { label: "Explanation", value: explanation || "-" },
+    ];
+  },
+
+  task: async ({ goal, step, treeXml }) => {
+    const model = Env.ALUMNIUM_MODEL;
+    const llmContext = new LlmContext(model);
+    const sessionContext = new SessionContext({
+      app: "eval" as AppId,
+      sessionId: nanoid(),
+    });
+    const cache = new NullCache(sessionContext);
+    const llm = LlmFactory.createLlm(model, cache);
+    const agent = new ActorAgent(llmContext, llm, toolSchemas);
+
+    return agent.invoke(goal, step, treeXml);
+  },
+});
+
+async function readTree(fixtureName: string): Promise<string> {
+  const fixture = new URL(
+    `./__fixtures__/eval/${fixtureName}`,
+    import.meta.url,
+  );
+  return fs.readFile(fixture, "utf-8");
+}
+
+function formatToolCalls(toolCalls: ToolCall[] | undefined): string[] {
+  return (toolCalls ?? []).map(formatToolCall);
+}
+
+function formatToolCall({ name, args }: ToolCall): string {
+  const argsStr = Object.entries(args)
+    .map(([key, value]) => `${key}='${String(value)}'`)
+    .join(", ");
+  return `${name}(${argsStr})`;
+}

--- a/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-agent-status.xml
+++ b/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-agent-status.xml
@@ -1,0 +1,65 @@
+<RootWebArea name="Support Console" id=1 focusable url="https://support-staging.example.com">
+  <div id=342>
+    <button name="Status List Dropdown" id=343 focusable hasPopup="menu" expanded="true" controls="statusListDropdown"></button>
+    <div id=347 live="polite" atomic relevant="additions text">Current Status: Busy</div>
+    <list id=349>
+      <div id=352>
+        <div id=353>agent@example.com</div>
+        <button id=356 focusable>
+          <div id=358></div>
+          <div id=360>Select Phone</div>
+        </button>
+      </div>
+      <div id=368 focusable>
+        <listitem id=370 level=1>
+          <button id=371 focusable>On Queue</button>
+        </listitem>
+        <listitem id=378 level=1>
+          <button id=379 focusable>
+            Available
+            <div id=387></div>
+          </button>
+        </listitem>
+        <listitem id=389 level=1>
+          <button id=390 focusable focused pressed hasPopup="menu">
+            Busy
+            <div id=396></div>
+          </button>
+        </listitem>
+        <listitem id=399 level=1>
+          <button id=400 focusable hasPopup="menu">
+            Away
+            <div id=406></div>
+          </button>
+        </listitem>
+        <listitem id=409 level=1>
+          <button id=410 focusable>Break</button>
+        </listitem>
+        <listitem id=417 level=1>
+          <button id=418 focusable>Meal</button>
+        </listitem>
+        <listitem id=425 level=1>
+          <button id=426 focusable hasPopup="menu">
+            Meeting
+            <div id=432></div>
+          </button>
+        </listitem>
+        <listitem id=435 level=1>
+          <button id=436 focusable hasPopup="menu">
+            Training
+            <div id=442></div>
+          </button>
+        </listitem>
+        <listitem id=445 level=1>
+          <button id=446 focusable>Out of Office</button>
+        </listitem>
+      </div>
+      <listitem id=457 level=1>
+        <button id=458 focusable>
+          <div id=460></div>
+          <div id=462>Log Out</div>
+        </button>
+      </listitem>
+    </list>
+  </div>
+</RootWebArea>

--- a/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-order-refund.xml
+++ b/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-order-refund.xml
@@ -1,0 +1,9 @@
+<RootWebArea name="#RQ100000000 - Sample | Alex K." id=1 focusable focused url="https://support-staging.example.com/requests/RQ100000000/orders/ABCDEFGHIJ">
+  <div id=747>
+    <LabelText id=748>Send money to</LabelText>
+    <combobox name="Send money to" value="Buyer" expanded>
+      <option name="Buyer" id=756 focusable selected />
+      <option name="Seller" id=757 focusable selected="false" />
+    </combobox>
+  </div>
+</RootWebArea>

--- a/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-order-refund.xml
+++ b/packages/typescript/src/server/agents/__fixtures__/eval/chrome/support-order-refund.xml
@@ -1,7 +1,7 @@
 <RootWebArea name="#RQ100000000 - Sample | Alex K." id=1 focusable focused url="https://support-staging.example.com/requests/RQ100000000/orders/ABCDEFGHIJ">
   <div id=747>
     <LabelText id=748>Send money to</LabelText>
-    <combobox name="Send money to" value="Buyer" expanded>
+    <combobox name="Send money to" value="Buyer" expanded="true">
       <option name="Buyer" id=756 focusable selected />
       <option name="Seller" id=757 focusable selected="false" />
     </combobox>

--- a/packages/typescript/src/tools/ClickTool.ts
+++ b/packages/typescript/src/tools/ClickTool.ts
@@ -3,7 +3,7 @@ import { BaseTool } from "./BaseTool.ts";
 import { field, type FieldMetadata } from "./Field.ts";
 
 export class ClickTool extends BaseTool {
-  static description = `Click an element. NEVER use ClickTool on comboboxes, instead proceed to click the desired option directly. NEVER use ClickTool to upload files - use UploadTool instead.`;
+  static description = `Click an element. If the target element is a dropdown and is already expanded - you don't need to click it. NEVER use ClickTool to upload files - use UploadTool instead.`;
   static fields: FieldMetadata[] = [
     field({
       name: "id",

--- a/packages/typescript/src/tools/ClickTool.ts
+++ b/packages/typescript/src/tools/ClickTool.ts
@@ -3,7 +3,7 @@ import { BaseTool } from "./BaseTool.ts";
 import { field, type FieldMetadata } from "./Field.ts";
 
 export class ClickTool extends BaseTool {
-  static description = `Click an element. NEVER use ClickTool to upload files - use UploadTool instead.`;
+  static description = `Click an element. NEVER use ClickTool on comboboxes, instead proceed to click the desired option directly. NEVER use ClickTool to upload files - use UploadTool instead.`;
   static fields: FieldMetadata[] = [
     field({
       name: "id",

--- a/packages/typescript/src/xml/XmlRenderer.test.ts
+++ b/packages/typescript/src/xml/XmlRenderer.test.ts
@@ -120,6 +120,18 @@ describe("XmlRenderer", () => {
     );
   });
 
+  it("renders explicit true attributes in full", () => {
+    const root = Xml.tag("root", {
+      expanded: "true",
+      focusable: "true",
+      collapsed: "false",
+    });
+
+    expect(
+      XmlRenderer.render([root], { explicitTrueAttrs: new Set(["expanded"]) }),
+    ).toMatchInlineSnapshot(`"<root expanded="true" focusable />"`);
+  });
+
   it("preserves content under xml:space preserve", () => {
     const elements = Xml.parseRootChildren(
       '<root xml:space="preserve"> before <child> inside </child> after </root>',

--- a/packages/typescript/src/xml/XmlRenderer.ts
+++ b/packages/typescript/src/xml/XmlRenderer.ts
@@ -21,6 +21,7 @@ export namespace XmlRenderer {
     compactAttrs?: boolean;
     tagAliases?: Readonly<Record<string, string>>;
     preserveFalseAttrs?: ReadonlySet<string>;
+    explicitTrueAttrs?: ReadonlySet<string>;
   }
 }
 
@@ -189,7 +190,7 @@ export abstract class XmlRenderer {
         if (!stringValue) continue;
         if (stringValue === "false" && !options.preserveFalseAttrs?.has(key))
           continue;
-        if (stringValue === "true") {
+        if (stringValue === "true" && !options.explicitTrueAttrs?.has(key)) {
           result += ` ${key}`;
           continue;
         }


### PR DESCRIPTION
Actor tends to click `<select>` elements to open them first, while it should proceed straight to clicking `<option>` instead. To improve accuracy, select comboboxes now:

1. Don't have `id`.
2. Don't have `focusable` attribute.
3. Have `expanded` attribute.

Same issue happens for other elements (e.g. button) and a related instructions are added to the click tool.

Related evals are added with 0% to 100% accuracy improvement.