### PR TITLE
Fix Java Area.get() missing null/noop check

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/Area.java
+++ b/packages/java/src/main/java/ai/alumnium/Area.java
@@ -3,6 +3,7 @@ package ai.alumnium;
 import ai.alumnium.Alumni.CheckOptions;
 import ai.alumnium.Alumni.GetOptions;
 import ai.alumnium.accessibility.BaseAccessibilityTree;
+import ai.alumnium.client.Data;
 import ai.alumnium.client.FindElementResult;
 import ai.alumnium.client.HttpClient;
 import ai.alumnium.client.HttpClient.ActionResult;
@@ -163,7 +164,11 @@ public class Area {
                   vision ? driver.screenshot() : null,
                   driver.app());
 
-          return result.result().toObject();
+          Data value = result.result();
+          if (value == null || value.isNoop()) {
+            return new Data.StringData(result.explanation());
+          }
+          return value.toObject();
         });
   }
 

--- a/packages/java/src/main/java/ai/alumnium/Area.java
+++ b/packages/java/src/main/java/ai/alumnium/Area.java
@@ -166,7 +166,7 @@ public class Area {
 
           Data value = result.result();
           if (value == null || value.isNoop()) {
-            return new Data.StringData(result.explanation());
+            return result.explanation();
           }
           return value.toObject();
         });


### PR DESCRIPTION
# Fix Java `Area.get()` missing null/noop check

## Summary

When the server cannot extract requested data, it returns a `NOOP` result. Java's `Area.get()` was returning `null` instead of the server's explanation string, while every other implementation already handles this correctly.

---

## The Bug

`Area.get()` was calling `result.result().toObject()` directly:

```java
return result.result().toObject();
```

When the server returns a `NOOP` result, `result.result()` is `Data.NoopData.INSTANCE`, and `toObject()` returns `null`. As a result, callers receive `null` instead of the explanation returned by the server.

This behavior is inconsistent with the other SDK implementations, which correctly detect `NOOP` responses and return the explanation string.

---

## The Fix

Check whether the returned value is `null` or a `NOOP` before calling `toObject()`. If so, return the server's explanation wrapped in `Data.StringData`.

```java
Data value = result.result();

if (value == null || value.isNoop()) {
    return new Data.StringData(result.explanation());
}

return value.toObject();
```

This preserves the server-provided explanation instead of silently returning `null`.

---

## Why This Change?

- Prevents unexpected `null` values from being returned.
- Preserves the server's explanation for `NOOP` responses.
- Aligns the Java implementation with the behavior of the other SDKs.

---

## Test Plan

- Existing tests pass.
- Manually verified that when the server returns a `NOOP` result, `Area.get()` now returns the explanation string instead of `null`.