### PR TITLE
fix: keep current tab when autoswitch is off and a new tab opens in the background

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
@@ -479,7 +479,6 @@ public final class PlaywrightDriver extends BaseDriver {
   private void autoswitchToNewTabAction(Runnable action) {
     if (!autoswitchToNewTab) {
       action.run();
-      openedPages.clear();
       return;
     }
 
@@ -509,6 +508,11 @@ public final class PlaywrightDriver extends BaseDriver {
   }
 
   private void switchToNewTab() {
+    if (!autoswitchToNewTab) {
+      openedPages.clear();
+      return;
+    }
+
     flushEvents();
 
     Page opened = null;

--- a/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
@@ -76,7 +76,12 @@ public final class SeleniumDriver extends BaseDriver {
 
   @Override
   protected ChromiumAccessibilityTree fetchAccessibilityTree() {
+    // Switch to default content to ensure we're at the top level for frame enumeration
     driver.switchTo().defaultContent();
+
+    // A new tab might take the foreground and leave the current one hidden.
+    driver.switchTo().window(driver.getWindowHandle());
+
     waitForPageToLoad();
 
     Map<String, Object> frameTreeResp = executeCdp("Page.getFrameTree", Map.of());

--- a/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/BaseTest.java
@@ -6,6 +6,7 @@ import ai.alumnium.tool.BaseTool;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.options.UiAutomator2Options;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 
@@ -39,6 +41,7 @@ public class BaseTest {
 
   private static Playwright playwright;
   private static Browser browser;
+  private static WebDriver webDriver;
 
   @RegisterExtension
   static final AlumniCacheExtension cacheAfterEach = new AlumniCacheExtension(() -> al);
@@ -144,7 +147,10 @@ public class BaseTest {
         al = new Alumni(buildAndroidDriver(), options);
         ((AppiumDriver) al.driver()).delay = 0.1;
       }
-      default -> al = new Alumni(new ChromeDriver(), options);
+      default -> {
+        webDriver = new ChromeDriver();
+        al = new Alumni(webDriver, options);
+      }
     }
   }
 
@@ -156,6 +162,55 @@ public class BaseTest {
 
   protected static void navigate(String url) {
     al.driver().visit(url);
+  }
+
+  protected static int tabCount() {
+    if (browser != null) {
+      return browser.contexts().get(0).pages().size();
+    } else if (webDriver != null) {
+      return webDriver.getWindowHandles().size();
+    } else {
+      throw new UnsupportedOperationException("Tabs are not implemented in Appium yet");
+    }
+  }
+
+  protected static void waitForTabCount(int count) {
+    long deadline = System.currentTimeMillis() + 10_000;
+    while (tabCount() < count) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError("Timed out waiting for " + count + " tabs to open");
+      }
+      pause();
+    }
+  }
+
+  protected static void closeExtraTabs() {
+    if (browser != null) {
+      List<Page> pages = browser.contexts().get(0).pages();
+      for (Page page : pages.subList(1, pages.size())) {
+        page.close();
+      }
+    } else if (webDriver != null) {
+      List<String> handles = List.copyOf(webDriver.getWindowHandles());
+      for (String handle : handles.subList(1, handles.size())) {
+        webDriver.switchTo().window(handle);
+        webDriver.close();
+      }
+      webDriver.switchTo().window(handles.get(0));
+    }
+  }
+
+  private static void pause() {
+    if (browser != null) {
+      browser.contexts().get(0).pages().get(0).waitForTimeout(50);
+    } else {
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException(e);
+      }
+    }
   }
 
   protected static void type(Object element, String text) {

--- a/packages/java/src/test/java/ai/alumnium/system/SlowTabPage.java
+++ b/packages/java/src/test/java/ai/alumnium/system/SlowTabPage.java
@@ -1,0 +1,63 @@
+package ai.alumnium.system;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+
+/** Serves a page whose button opens a tab that only navigates after a delay. */
+final class SlowTabPage implements AutoCloseable {
+
+  private static final String OPENER =
+      "<title>Opener</title><h1>Opener</h1>"
+          + "<button onclick=\"window.open('/slow-tab', '_blank')\">Open Slow Tab</button>";
+  private static final String SLOW_TAB = "<title>Slow Tab</title><h1>Slow Tab</h1>";
+
+  private final HttpServer server;
+  final String url;
+  final String slowTabUrl;
+
+  private SlowTabPage(HttpServer server) {
+    this.server = server;
+    int port = server.getAddress().getPort();
+    this.url = "http://127.0.0.1:" + port + "/";
+    this.slowTabUrl = "http://127.0.0.1:" + port + "/slow-tab";
+  }
+
+  static SlowTabPage start() throws IOException {
+    HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", SlowTabPage::respond);
+
+    // The slow tab blocks its own request, so it must not block the opener
+    server.setExecutor(Executors.newCachedThreadPool());
+    server.start();
+    return new SlowTabPage(server);
+  }
+
+  private static void respond(com.sun.net.httpserver.HttpExchange exchange) throws IOException {
+    boolean isSlowTab = exchange.getRequestURI().getPath().equals("/slow-tab");
+    if (isSlowTab) {
+      try {
+        Thread.sleep(2000);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException(e);
+      }
+    }
+
+    byte[] body = (isSlowTab ? SLOW_TAB : OPENER).getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().add("content-type", "text/html");
+    exchange.getResponseHeaders().add("cache-control", "no-store");
+    exchange.sendResponseHeaders(200, body.length);
+    try (OutputStream out = exchange.getResponseBody()) {
+      out.write(body);
+    }
+  }
+
+  @Override
+  public void close() {
+    server.stop(0);
+  }
+}

--- a/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/TabsTest.java
@@ -1,9 +1,13 @@
 package ai.alumnium.system;
 
+import ai.alumnium.driver.PlaywrightDriver;
+import ai.alumnium.driver.SeleniumDriver;
 import ai.alumnium.tool.SwitchToNextTabTool;
 import ai.alumnium.tool.SwitchToPreviousTabTool;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
@@ -17,6 +21,12 @@ public class TabsTest extends BaseTest {
 
   private static final String MULTI_TAB_URL =
       new File("../python/examples/support/pages/multi_tab_page.html").toURI().toString();
+
+  @AfterEach
+  void restoreTabs() {
+    setAutoswitchToNewTab(true);
+    closeExtraTabs();
+  }
 
   @Test
   void testSwitchingTabs() {
@@ -36,5 +46,44 @@ public class TabsTest extends BaseTest {
 
     al.act("switch to previous browser tab");
     Assertions.assertEquals("about:blank", al.get("current page URL"));
+  }
+
+  @Test
+  void testSwitchingToSlowlyOpeningTab() throws IOException {
+    try (SlowTabPage page = SlowTabPage.start()) {
+      navigate(page.url);
+
+      al.act("click on 'Open Slow Tab' button");
+
+      // al.get() is too slow which gives tab enough time to arrive on its own
+      Assertions.assertEquals(page.slowTabUrl, al.driver().url());
+      Assertions.assertEquals("Slow Tab", al.get("header text"));
+    }
+  }
+
+  @Test
+  void testStayingOnTabWhenAutoswitchIsOff() throws IOException {
+    setAutoswitchToNewTab(false);
+
+    try (SlowTabPage page = SlowTabPage.start()) {
+      navigate(page.url);
+
+      al.act("click on 'Open Slow Tab' button");
+
+      // Only assert once the tab is really there, otherwise nothing can be
+      // picked up and the test passes even when the switch is ignored
+      waitForTabCount(2);
+
+      Assertions.assertEquals("Opener", al.get("header text"));
+      Assertions.assertEquals(page.url, al.driver().url());
+    }
+  }
+
+  private static void setAutoswitchToNewTab(boolean value) {
+    if (al.driver() instanceof PlaywrightDriver playwrightDriver) {
+      playwrightDriver.autoswitchToNewTab = value;
+    } else if (al.driver() instanceof SeleniumDriver seleniumDriver) {
+      seleniumDriver.autoswitchToNewTab = value;
+    }
   }
 }

--- a/packages/python/examples/pytest/conftest.py
+++ b/packages/python/examples/pytest/conftest.py
@@ -1,6 +1,10 @@
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from os import getenv
 from pathlib import Path
+from threading import Thread
+from time import monotonic, sleep
+from typing import NamedTuple
 
 from appium.options.android import UiAutomator2Options
 from appium.options.ios import XCUITestOptions
@@ -193,6 +197,77 @@ def navigate(al):
     return __navigate
 
 
+class SlowTabPage(NamedTuple):
+    url: str
+    slow_tab_url: str
+
+
+@fixture
+def slow_tab_page():
+    """Serves a page whose button opens a tab that only navigates after a delay."""
+    opener = (
+        b"<title>Opener</title><h1>Opener</h1>"
+        b"<button onclick=\"window.open('/slow-tab', '_blank')\">Open Slow Tab</button>"
+    )
+    slow_tab = b"<title>Slow Tab</title><h1>Slow Tab</h1>"
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            is_slow_tab = self.path == "/slow-tab"
+            if is_slow_tab:
+                sleep(2)
+
+            body = slow_tab if is_slow_tab else opener
+            self.send_response(200)
+            self.send_header("content-type", "text/html")
+            self.send_header("cache-control", "no-store")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            pass
+
+    # The slow tab blocks its own request, so it must not block the opener
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    Thread(target=server.serve_forever, daemon=True).start()
+
+    port = server.server_port
+    yield SlowTabPage(f"http://127.0.0.1:{port}/", f"http://127.0.0.1:{port}/slow-tab")
+
+    server.shutdown()
+    server.server_close()
+
+
+@fixture
+def wait_for_tab_count(driver):
+    def __wait_for_tab_count(count: int):
+        deadline = monotonic() + 10
+        while _tab_count(driver) < count:
+            if monotonic() > deadline:
+                raise AssertionError(f"Timed out waiting for {count} tabs to open")
+            _pause(driver)
+
+    return __wait_for_tab_count
+
+
+@fixture(autouse=True)
+def close_extra_tabs(al, driver):
+    yield
+    if isinstance(driver, Page):
+        al.driver.autoswitch_to_new_tab = True
+        for page in driver.context.pages:
+            if page is not driver:
+                page.close()
+    elif isinstance(driver, SeleniumWebDriver):
+        al.driver.autoswitch_to_new_tab = True
+        original, *extra = driver.window_handles
+        for handle in extra:
+            driver.switch_to.window(handle)
+            driver.close()
+        driver.switch_to.window(original)
+
+
 @fixture
 def execute_script(al):
     return lambda script: al.driver.execute_script(script)
@@ -249,3 +324,19 @@ def pytest_sessionfinish(session, exitstatus):
     if exitstatus != 1 or test_results["errors"]:
         return
     session.exitstatus = process_pass_threshold(test_results["passed"], test_results["failed"])
+
+
+def _tab_count(driver) -> int:
+    if isinstance(driver, Page):
+        return len(driver.context.pages)
+    elif isinstance(driver, SeleniumWebDriver):
+        return len(driver.window_handles)
+    else:
+        raise NotImplementedError("Tabs are not implemented in Appium yet")
+
+
+def _pause(driver):
+    if isinstance(driver, Page):
+        driver.wait_for_timeout(50)
+    else:
+        sleep(0.05)

--- a/packages/python/examples/pytest/tabs_test.py
+++ b/packages/python/examples/pytest/tabs_test.py
@@ -33,3 +33,36 @@ def test_switching_tabs(al_factory, navigate):
 
     al.do("switch to previous browser tab")
     assert al.get("current page URL") == "about:blank"
+
+
+@mark.xfail(
+    "appium" in getenv("ALUMNIUM_DRIVER", "selenium"),
+    reason="Appium doesn't support tab manipulation yet",
+)
+def test_switching_to_slowly_opening_tab(al, navigate, slow_tab_page):
+    navigate(slow_tab_page.url)
+
+    al.do("click on 'Open Slow Tab' button")
+
+    # al.get() is too slow which gives tab enough time to arrive on its own
+    assert al.driver.url == slow_tab_page.slow_tab_url
+    assert al.get("header text") == "Slow Tab"
+
+
+@mark.xfail(
+    "appium" in getenv("ALUMNIUM_DRIVER", "selenium"),
+    reason="Appium doesn't support tab manipulation yet",
+)
+def test_staying_on_tab_when_autoswitch_is_off(al, navigate, slow_tab_page, wait_for_tab_count):
+    al.driver.autoswitch_to_new_tab = False
+
+    navigate(slow_tab_page.url)
+
+    al.do("click on 'Open Slow Tab' button")
+
+    # Only assert once the tab is really there, otherwise nothing can be
+    # picked up and the test passes even when the switch is ignored
+    wait_for_tab_count(2)
+
+    assert al.get("header text") == "Opener"
+    assert al.driver.url == slow_tab_page.url

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -284,7 +284,6 @@ class PlaywrightAsyncDriver(BaseDriver):
     async def _autoswitch_to_new_tab(self):
         if not self.autoswitch_to_new_tab:
             yield
-            self._opened_pages.clear()
             return
 
         # Page.windowOpen is watched on the CDP session, so it has to be live
@@ -308,6 +307,10 @@ class PlaywrightAsyncDriver(BaseDriver):
             logger.debug("  <- No tab was reported, continuing")
 
     async def _switch_to_new_tab(self):
+        if not self.autoswitch_to_new_tab:
+            self._opened_pages.clear()
+            return
+
         await self._flush_events()
 
         opened = [page for page in self._opened_pages if not page.is_closed()]

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -231,7 +231,6 @@ class PlaywrightDriver(BaseDriver):
     def _autoswitch_to_new_tab(self):
         if not self.autoswitch_to_new_tab:
             yield
-            self._opened_pages.clear()
             return
 
         # Page.windowOpen is watched on the CDP session, so it has to be live
@@ -255,6 +254,10 @@ class PlaywrightDriver(BaseDriver):
             logger.debug("  <- No tab was reported, continuing")
 
     def _switch_to_new_tab(self):
+        if not self.autoswitch_to_new_tab:
+            self._opened_pages.clear()
+            return
+
         self._flush_events()
         opened = [page for page in self._opened_pages if not page.is_closed()]
         self._opened_pages.clear()

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -56,6 +56,10 @@ class SeleniumDriver(BaseDriver):
     def _fetch_accessibility_tree(self) -> ChromiumAccessibilityTree:
         # Switch to default content to ensure we're at the top level for frame enumeration
         self.driver.switch_to.default_content()
+
+        # A new tab might take the foreground and leave the current one hidden.
+        self.driver.switch_to.window(self.driver.current_window_handle)
+
         self._wait_for_page_to_load()
 
         # Get frame tree to enumerate all frames

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -673,13 +673,9 @@ export class PlaywrightDriver extends BaseDriver {
   private async autoswitchToNewTabAction(
     action: () => Promise<void>,
   ): Promise<void> {
-    if (!this.autoswitchToNewTab) {
-      await action();
-      this.openedPages = [];
-      return;
-    }
-
     await action();
+    if (!this.autoswitchToNewTab) return;
+
     await sleep(NEW_TAB_DELAY);
 
     if (!this.openedPages.length && this.pendingWindowOpen) {
@@ -699,6 +695,11 @@ export class PlaywrightDriver extends BaseDriver {
 
   @span("driver.internal.switch_to_new_tab")
   private async switchToNewTab(): Promise<void> {
+    if (!this.autoswitchToNewTab) {
+      this.openedPages = [];
+      return;
+    }
+
     await this.flushEvents();
 
     const opened = this.openedPages.filter((page) => !page.isClosed()).pop();

--- a/packages/typescript/src/drivers/SeleniumDriver.test.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.test.ts
@@ -33,7 +33,11 @@ describe("SeleniumDriver", () => {
       return {};
     });
     const webdriver = {
-      switchTo: () => ({ defaultContent: vi.fn(async () => undefined) }),
+      switchTo: () => ({
+        defaultContent: vi.fn(async () => undefined),
+        window: vi.fn(async () => undefined),
+      }),
+      getWindowHandle: vi.fn(async () => "window-1"),
       executeScript: vi.fn(async () => undefined),
       executeAsyncScript: vi.fn(async () => undefined),
       sendAndGetDevToolsCommand,

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -76,7 +76,7 @@ const WAIT_FOR_SCRIPT = waitForScriptSource;
 export class SeleniumDriver extends BaseDriver {
   protected driver: ChromiumWebDriver;
   public platform: Driver.Platform = "chromium";
-  #autoswitchToNewTabEnabled = true;
+  public autoswitchToNewTab = true;
   #shadowChildToHostMap: Partial<Record<number, number>> = {};
   public fullPageScreenshot = Env.ALUMNIUM_FULL_PAGE_SCREENSHOT;
   public supportedTools: Set<ToolClass> = new Set([
@@ -97,6 +97,10 @@ export class SeleniumDriver extends BaseDriver {
   protected async fetchAccessibilityTree(): Promise<BaseAccessibilityTree> {
     // Switch to default content to ensure we're at the top level for frame enumeration
     await this.driver.switchTo().defaultContent();
+
+    // A new tab might take the foreground and leave the current one hidden.
+    await this.driver.switchTo().window(await this.driver.getWindowHandle());
+
     logger.debug("Waiting for page to load before getting accessibility tree");
     await this.waitForPageToLoad();
     logger.debug("Page loaded, retrieving accessibility tree");
@@ -190,7 +194,7 @@ export class SeleniumDriver extends BaseDriver {
   @span("driver.click", spanAttrs)
   @stateful
   async click(id: number): Promise<void> {
-    await this.#autoswitchToNewTab(async () => {
+    await this.#autoswitchToNewTabAction(async () => {
       const element = await this.findElement(id);
       try {
         const actions = this.driver.actions({ async: true });
@@ -238,7 +242,7 @@ export class SeleniumDriver extends BaseDriver {
   @span("driver.press_key", spanAttrs)
   @stateful
   pressKey(key: Keys.Key): Promise<void> {
-    return this.#autoswitchToNewTab(async () => {
+    return this.#autoswitchToNewTabAction(async () => {
       const keyMap: Record<Keys.Key, string> = {
         Backspace: SeleniumKey.BACK_SPACE,
         Enter: SeleniumKey.ENTER,
@@ -478,10 +482,10 @@ export class SeleniumDriver extends BaseDriver {
     await this.driver.switchTo().window(handles[tabIndex]);
   }
 
-  async #autoswitchToNewTab<Result>(
+  async #autoswitchToNewTabAction<Result>(
     fn: () => Promise<Result>,
   ): Promise<Result> {
-    if (!this.#autoswitchToNewTabEnabled) {
+    if (!this.autoswitchToNewTab) {
       return await fn();
     }
 

--- a/packages/typescript/tests/system/helpers.ts
+++ b/packages/typescript/tests/system/helpers.ts
@@ -5,13 +5,14 @@ import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
-import type { Locator } from "playwright-core";
-import { Builder, WebElement } from "selenium-webdriver";
+import type { Locator, Page } from "playwright-core";
+import { Builder, WebElement, type WebDriver } from "selenium-webdriver";
 import { Options } from "selenium-webdriver/chrome.js";
 import { inject, it as vitestIt } from "vitest";
 import { attach, type Browser } from "webdriverio";
 import { Driver } from "../../src/drivers/Driver.ts";
 import { Env } from "../../src/Env.ts";
+import { sleep } from "../../src/utils/timers.ts";
 
 export namespace Setup {
   export interface Helpers {
@@ -20,6 +21,7 @@ export namespace Setup {
     type: (element: Element | undefined, text: string) => Promise<void>;
     click: (element: Element | undefined) => Promise<void>;
     serveSlowTabPage: () => Promise<Setup.SlowTabPage>;
+    waitForTabCount: (count: number) => Promise<void>;
   }
 
   export interface SlowTabPage {
@@ -134,6 +136,23 @@ function createHelpers(
   al: Alumni,
   onTestFinished: useSetup.Props["onTestFinished"],
 ): Setup.Helpers {
+  async function tabCount(): Promise<number> {
+    switch (driverId) {
+      case "selenium":
+        return (await (driver as WebDriver).getAllWindowHandles()).length;
+
+      case "playwright":
+        return (driver as Page).context().pages().length;
+
+      case "appium-ios":
+      case "appium-android":
+        throw new Error("Tabs are not implemented in Appium yet");
+
+      default:
+        never();
+    }
+  }
+
   const $: Setup.Helpers = {
     resolveUrl(url: string): string {
       if (url.startsWith("http")) {
@@ -176,15 +195,26 @@ function createHelpers(
       await new Promise<void>((resolve) =>
         server.listen(0, "127.0.0.1", resolve),
       );
-      onTestFinished(
-        () => new Promise<void>((resolve) => server.close(() => resolve())),
-      );
+      onTestFinished(() => {
+        server.closeAllConnections();
+        server.close();
+      });
 
       const { port } = server.address() as AddressInfo;
       return {
         url: `http://127.0.0.1:${port}/`,
         slowTabUrl: `http://127.0.0.1:${port}/slow-tab`,
       };
+    },
+
+    async waitForTabCount(count: number) {
+      const deadline = Date.now() + 10_000;
+      while ((await tabCount()) < count) {
+        if (Date.now() > deadline) {
+          throw new Error(`Timed out waiting for ${count} tabs to open`);
+        }
+        await sleep(50);
+      }
     },
 
     async type(element: Element | undefined, text: string) {

--- a/packages/typescript/tests/system/tabs.test.ts
+++ b/packages/typescript/tests/system/tabs.test.ts
@@ -1,4 +1,9 @@
-import { SwitchToNextTabTool, SwitchToPreviousTabTool } from "alumnium";
+import {
+  type PlaywrightDriver,
+  type SeleniumDriver,
+  SwitchToNextTabTool,
+  SwitchToPreviousTabTool,
+} from "alumnium";
 import { describe } from "vitest";
 import { baseIt } from "./helpers.ts";
 
@@ -48,5 +53,25 @@ describe("Tabs", () => {
     // al.get() is too slow which gives tab enough time to arrive on its own
     expect(await al.driver.url()).toBe(slowTabUrl);
     expect(await al.get("header text")).toBe("Slow Tab");
+  });
+
+  it("stays on the current tab when autoswitch is off", async ({
+    expect,
+    setup,
+  }) => {
+    const { al, $ } = await setup();
+    const { url } = await $.serveSlowTabPage();
+    const driver = al.driver as PlaywrightDriver | SeleniumDriver;
+    driver.autoswitchToNewTab = false;
+
+    await $.navigate(url);
+    await al.do("click on 'Open Slow Tab' button");
+
+    // Only assert once the tab is really there, otherwise nothing can be
+    // picked up and the test passes even when the switch is ignored
+    await $.waitForTabCount(2);
+
+    expect(await al.get("header text")).toBe("Opener");
+    expect(await al.driver.url()).toBe(url);
   });
 });


### PR DESCRIPTION
Regression since #431 when Playwright driver would switch to a new tab that opens in the background (e.g. slowly navigating tab) even though `autoswitchToNewTab` is set to `false.