### PR TITLE
chore: include commit sha in the version

### DIFF
--- a/packages/typescript/scripts/build.ts
+++ b/packages/typescript/scripts/build.ts
@@ -2,6 +2,7 @@
 
 // This script builds the Alumnium for multiple target platforms using Bun.
 
+import { always } from "alwaysly";
 import { $, type BunPlugin } from "bun";
 import { snakeCase } from "case-anything";
 import fs from "node:fs/promises";
@@ -332,7 +333,9 @@ const standaloneEmbeddedAssetPlugin: BunPlugin = {
 await main();
 
 async function main() {
-  console.log(`🚧 Building Alumnium ${ALUMNIUM_VERSION}...`);
+  const commitSha = await getCommitSha();
+
+  console.log(`🚧 Building Alumnium ${ALUMNIUM_VERSION}+${commitSha}...`);
 
   //#region Clean up
 
@@ -387,6 +390,7 @@ async function main() {
             standaloneEmbeddedAssetPlugin,
           ],
           define: {
+            BUILD_COMMIT_SHA: JSON.stringify(commitSha),
             SINGLE_FILE_EXECUTABLE: "true",
           },
         });
@@ -880,6 +884,18 @@ function getPipWheelTagTarget(platform: TargetPlatform): string {
 
 function getPipModuleName(pkgName: string) {
   return snakeCase(pkgName);
+}
+
+async function getCommitSha(): Promise<string> {
+  const [revParse, status] = await Promise.all([
+    $`git rev-parse --short HEAD`.cwd(REPO_ROOT_DIR).quiet().text(),
+    $`git status --porcelain`.cwd(REPO_ROOT_DIR).quiet().text(),
+  ]);
+
+  const sha = revParse.trim();
+  always(sha);
+
+  return status.trim() ? `${sha}-dirty` : sha;
 }
 
 function cwdRelPath(absPath: string) {

--- a/packages/typescript/src/cli/bin.ts
+++ b/packages/typescript/src/cli/bin.ts
@@ -1,6 +1,6 @@
 import { cac } from "cac";
 import * as ansi from "picocolors";
-import { ALUMNIUM_VERSION } from "../package.ts";
+import { ALUMNIUM_BIN_VERSION } from "../package.ts";
 import { setupEmbeddedDependencies } from "../standalone/setupEmbeddedDependencies.ts";
 
 // NOTE: Don't use logger here, so it can be configured by commands before any
@@ -23,7 +23,7 @@ async function main() {
   COMMANDS.forEach((command) => command.register(cli));
 
   cli.help();
-  cli.version(ALUMNIUM_VERSION);
+  cli.version(ALUMNIUM_BIN_VERSION);
 
   cli.addEventListener("command:*", () => {
     const invalidCommand = cli.args[0];

--- a/packages/typescript/src/package.ts
+++ b/packages/typescript/src/package.ts
@@ -1,3 +1,10 @@
 import packageJson from "../package.json" with { type: "json" };
 
+declare const BUILD_COMMIT_SHA: string | undefined;
+const COMMIT_SHA =
+  typeof BUILD_COMMIT_SHA === "undefined" ? undefined : BUILD_COMMIT_SHA;
+
 export const ALUMNIUM_VERSION = packageJson.version;
+export const ALUMNIUM_BIN_VERSION = COMMIT_SHA
+  ? `${ALUMNIUM_VERSION}+${COMMIT_SHA}`
+  : ALUMNIUM_VERSION;


### PR DESCRIPTION
Makes it easier to know which exact commit the current binary is built at:

```
$ dist/bin/alumnium-0.21.0-darwin-arm64 --version
alumnium/0.21.0+1b31a531-dirty darwin-arm64 bun-v24.3.0
```