### PR TITLE
release: v0.22.0-alpha.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/typescript": {
       "name": "alumnium",
-      "version": "0.21.0",
+      "version": "0.22.0-alpha.1",
       "bin": {
         "alumnium": "./src/cli/bin.ts",
       },

--- a/packages/java/build.gradle
+++ b/packages/java/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group   = 'ai.alumnium'
-version = '0.21.0'
+version = '0.22.0-alpha.1'
 
 java {
     toolchain {

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -29,7 +29,7 @@ authors = [
     { email = "tati.shep@gmail.com", name = "Tatiana Shepeleva" },
 ]
 dependencies = [
-    "alumnium-cli==0.21.0; (sys_platform == 'linux' or sys_platform == 'darwin' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64')",
+    "alumnium-cli==0.22.0a1; (sys_platform == 'linux' or sys_platform == 'darwin' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'amd64' or platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ARM64')",
     "appium-python-client>=5.1.1,<6.0.0",
     "playwright>=1.49,<2.0",
     "portpicker>=1.6.0",
@@ -44,7 +44,7 @@ license = "MIT"
 name = "alumnium"
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
-version = "0.21.0"
+version = "0.22.0a1"
 
 [project.scripts]
 alumnium = "alumnium.cli:main"

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 
 [[package]]
 name = "alumnium"
-version = "0.21.0"
+version = "0.22.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "alumnium-cli", version = "0.21.0", source = { directory = "../typescript/dist/pip-alumnium-cli-darwin-arm64" }, marker = "(platform_machine == 'ARM64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin')" },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alumnium",
-  "version": "0.21.0",
+  "version": "0.22.0-alpha.1",
   "description": "Pave the way towards AI-powered test automation",
   "keywords": [
     "ai",


### PR DESCRIPTION
Bumps all packages (Java, Python, TypeScript) to `0.22.0-alpha.1` to trigger alpha builds.

- `packages/java/build.gradle`: `0.21.0` → `0.22.0-alpha.1`
- `packages/python/pyproject.toml`: `0.21.0` → `0.22.0a1` (+ `alumnium-cli` dep)
- `packages/typescript/package.json`: `0.21.0` → `0.22.0-alpha.1`
- Lockfiles (`uv.lock`, `bun.lock`) updated accordingly