### PR TITLE
fix(mcp): support same-second parallel sessions

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -297,7 +297,7 @@ url = "https://github.com/ollama/ollama/releases/download/v0.23.1/ollama-windows
 url_api = "https://api.github.com/repos/ollama/ollama/releases/assets/412948775"
 
 [[tools.oxfmt]]
-version = "0.48.0"
+version = "0.65.0"
 backend = "npm:oxfmt"
 
 [[tools."pipx:pyprojectsort"]]

--- a/packages/typescript/scripts/test-package.sh
+++ b/packages/typescript/scripts/test-package.sh
@@ -110,8 +110,7 @@ EOF
 		exit 1
 	fi
 
-	SMOKE_PLAYWRIGHT_VERSION="$(pnpm exec playwright --version)"
-	SMOKE_PLAYWRIGHT_VERSION="${SMOKE_PLAYWRIGHT_VERSION#Version }"
+	SMOKE_PLAYWRIGHT_VERSION="$(pnpm exec playwright --version | sed -n 's/^Version //p')"
 	if [[ "$SMOKE_PLAYWRIGHT_VERSION" != "$PLAYWRIGHT_VERSION" ]]; then
 		echo "🔴 Playwright version mismatch: expected $PLAYWRIGHT_VERSION, got $SMOKE_PLAYWRIGHT_VERSION"
 		exit 1

--- a/packages/typescript/src/mcp/McpState.ts
+++ b/packages/typescript/src/mcp/McpState.ts
@@ -32,6 +32,21 @@ export abstract class McpState {
   private static cleanupAllPromise: Promise<void> | null = null;
 
   /**
+   * Generate a unique driver ID from the given base by appending an
+   * incrementing `-N` suffix (starting at 1) until an unregistered ID is found.
+   * This keeps concurrent starts in the same second from colliding.
+   */
+  static generateDriverId(base: string): string {
+    let suffix = 1;
+    let id = `${base}-${suffix}`;
+    while (this.drivers[id]) {
+      suffix++;
+      id = `${base}-${suffix}`;
+    }
+    return id;
+  }
+
+  /**
    * Register a new driver instance.
    */
   static registerDriver(

--- a/packages/typescript/src/mcp/tools/startMcpTool.ts
+++ b/packages/typescript/src/mcp/tools/startMcpTool.ts
@@ -168,7 +168,7 @@ export const startMcpTool = McpTool.define("start", {
     // Generate driver ID from current directory and timestamp
     const cwdName = path.basename(process.cwd());
     const timestamp = Math.floor(Date.now() / 1000);
-    const id = `${cwdName}-${timestamp}`;
+    const id = McpState.generateDriverId(`${cwdName}-${timestamp}`);
 
     // Create directories
     const artifactsStore = new McpArtifactsStore(id);


### PR DESCRIPTION
Previously, if two `start` calls are issued from the same working directory at the same second, they would end up registering the same session ID. This commit appends an incrementing `-N` suffix to the session ID to prevent collisions.
