### PR TITLE
feat: scroll element into view before interacting

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/PlaywrightDriver.java
@@ -136,23 +136,34 @@ public final class PlaywrightDriver extends BaseDriver {
       Locator parentSelect = element.locator("xpath=ancestor::select");
       autoswitchToNewTabAction(() -> parentSelect.selectOption(String.valueOf(value)));
     } else {
-      autoswitchToNewTabAction(() -> element.click(new Locator.ClickOptions().setForce(true)));
+      autoswitchToNewTabAction(
+          () -> {
+            scrollElementIntoCenter(element);
+            element.click(new Locator.ClickOptions().setForce(true));
+          });
     }
   }
 
   @Override
   public void dragSlider(int id, double value) {
-    findElement(id).fill(stripTrailingZeros(value));
+    Locator element = findElement(id);
+    scrollElementIntoCenter(element);
+    element.fill(stripTrailingZeros(value));
   }
 
   @Override
   public void dragAndDrop(int fromId, int toId) {
-    findElement(fromId).dragTo(findElement(toId));
+    Locator fromElement = findElement(fromId);
+    Locator toElement = findElement(toId);
+    scrollElementIntoCenter(fromElement);
+    fromElement.dragTo(toElement);
   }
 
   @Override
   public void hover(int id) {
-    findElement(id).hover();
+    Locator element = findElement(id);
+    scrollElementIntoCenter(element);
+    element.hover();
   }
 
   @Override
@@ -183,7 +194,7 @@ public final class PlaywrightDriver extends BaseDriver {
 
   @Override
   public void scrollTo(int id) {
-    findElement(id).scrollIntoViewIfNeeded();
+    scrollElementIntoCenter(findElement(id));
   }
 
   @Override
@@ -193,7 +204,9 @@ public final class PlaywrightDriver extends BaseDriver {
 
   @Override
   public void type(int id, String text) {
-    findElement(id).fill(text);
+    Locator element = findElement(id);
+    scrollElementIntoCenter(element);
+    element.fill(text);
   }
 
   @Override
@@ -289,6 +302,10 @@ public final class PlaywrightDriver extends BaseDriver {
 
   // endregion
   // region Internals
+
+  private void scrollElementIntoCenter(Locator element) {
+    element.evaluate("el => el.scrollIntoView({block: 'center'})");
+  }
 
   private void initCDPSession() {
     oopifFrames.clear();

--- a/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
+++ b/packages/java/src/main/java/ai/alumnium/driver/SeleniumDriver.java
@@ -140,6 +140,7 @@ public final class SeleniumDriver extends BaseDriver {
     withTabAutoswitch(
         () -> {
           WebElement element = findElement(id);
+          scrollElementIntoCenter(element);
           try {
             new Actions(driver).moveToElement(element).click().perform();
           } catch (RuntimeException e) {
@@ -151,6 +152,7 @@ public final class SeleniumDriver extends BaseDriver {
   @Override
   public void dragSlider(int id, double value) {
     WebElement element = findElement(id);
+    scrollElementIntoCenter(element);
     ((JavascriptExecutor) driver)
         .executeScript(
             "arguments[0].value = arguments[1];arguments[0].dispatchEvent(new"
@@ -162,12 +164,17 @@ public final class SeleniumDriver extends BaseDriver {
 
   @Override
   public void dragAndDrop(int fromId, int toId) {
-    new Actions(driver).dragAndDrop(findElement(fromId), findElement(toId)).perform();
+    WebElement fromElement = findElement(fromId);
+    WebElement toElement = findElement(toId);
+    scrollElementIntoCenter(fromElement);
+    new Actions(driver).dragAndDrop(fromElement, toElement).perform();
   }
 
   @Override
   public void hover(int id) {
-    new Actions(driver).moveToElement(findElement(id)).perform();
+    WebElement element = findElement(id);
+    scrollElementIntoCenter(element);
+    new Actions(driver).moveToElement(element).perform();
   }
 
   @Override
@@ -214,7 +221,7 @@ public final class SeleniumDriver extends BaseDriver {
 
   @Override
   public void scrollTo(int id) {
-    ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView();", findElement(id));
+    scrollElementIntoCenter(findElement(id));
   }
 
   @Override
@@ -225,6 +232,7 @@ public final class SeleniumDriver extends BaseDriver {
   @Override
   public void type(int id, String text) {
     WebElement element = findElement(id);
+    scrollElementIntoCenter(element);
     element.clear();
     element.sendKeys(text);
   }
@@ -333,6 +341,11 @@ public final class SeleniumDriver extends BaseDriver {
 
   // endregion
   // region Internals
+
+  private void scrollElementIntoCenter(WebElement element) {
+    ((JavascriptExecutor) driver)
+        .executeScript("arguments[0].scrollIntoView({block: 'center'});", element);
+  }
 
   private void switchToFrameChain(List<Integer> chain) {
     driver.switchTo().defaultContent();

--- a/packages/java/src/test/java/ai/alumnium/system/ObscuredElementTest.java
+++ b/packages/java/src/test/java/ai/alumnium/system/ObscuredElementTest.java
@@ -1,0 +1,21 @@
+package ai.alumnium.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+
+@DisabledIfEnvironmentVariable(named = "ALUMNIUM_DRIVER", matches = "appium.*")
+public class ObscuredElementTest extends BaseTest {
+
+  private static final String OBSCURED_ELEMENT_URL =
+      new File("../python/examples/support/pages/obscured_element.html").toURI().toString();
+
+  @Test
+  void testClickElementCoveredByStickyBar() {
+    navigate(OBSCURED_ELEMENT_URL);
+    al.act("click the 'Click Me' button");
+    assertThat(al.get("status message")).asString().contains("button clicked");
+  }
+}

--- a/packages/python/examples/pytest/obscured_element_test.py
+++ b/packages/python/examples/pytest/obscured_element_test.py
@@ -1,0 +1,13 @@
+from os import getenv
+
+from pytest import mark
+
+
+@mark.xfail(
+    "appium" in getenv("ALUMNIUM_DRIVER", "selenium"),
+    reason="Not supported on Appium driver yet",
+)
+def test_click_element_covered_by_sticky_bar(al, navigate):
+    navigate("obscured_element.html")
+    al.do("click the 'Click Me' button")
+    assert "button clicked" in al.get("status message")

--- a/packages/python/examples/support/pages/obscured_element.html
+++ b/packages/python/examples/support/pages/obscured_element.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Obscured Element Test Page</title>
+    <style>
+      body {
+        margin: 0;
+      }
+      /* Both bars are tall enough to cover an element scrolled to the very top
+         or the very bottom edge of the viewport. */
+      #header,
+      #footer {
+        position: fixed;
+        left: 0;
+        right: 0;
+        height: 30vh;
+        background: #333;
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #header {
+        top: 0;
+      }
+      #footer {
+        bottom: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="header" onclick="clicked('header')">Sticky Header</div>
+
+    <!-- The button is inside the viewport from the start, so drivers see no
+         reason to scroll, but the sticky footer covers it and swallows the
+         click. Only scrolling it to the center of the viewport uncovers it. -->
+    <div style="height: 80vh"></div>
+    <button id="target" onclick="clicked('button')">Click Me</button>
+    <p id="status">Status: nothing clicked</p>
+    <div style="height: 120vh"></div>
+
+    <div id="footer" onclick="clicked('footer')">Sticky Footer</div>
+
+    <script>
+      function clicked(what) {
+        document.getElementById("status").textContent =
+          `Status: ${what} clicked`;
+      }
+    </script>
+  </body>
+</html>

--- a/packages/python/src/alumnium/drivers/playwright_async_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_async_driver.py
@@ -112,6 +112,7 @@ class PlaywrightAsyncDriver(BaseDriver):
                 await element.locator("xpath=ancestor::select").select_option(value)
         else:
             async with self._autoswitch_to_new_tab():
+                await self._scroll_element_into_center(element)
                 await element.click(force=True)
 
     def drag_slider(self, id: int, value: float):
@@ -119,6 +120,7 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     async def _drag_slider(self, id: int, value: float):
         element = await self._find_element(id)
+        await self._scroll_element_into_center(element)
         await element.fill(f"{value:g}")
 
     def drag_and_drop(self, from_id: int, to_id: int):
@@ -127,6 +129,7 @@ class PlaywrightAsyncDriver(BaseDriver):
     async def _drag_and_drop(self, from_id: int, to_id: int):
         from_element = await self._find_element(from_id)
         to_element = await self._find_element(to_id)
+        await self._scroll_element_into_center(from_element)
         await from_element.drag_to(to_element)
 
     def hover(self, id: int):
@@ -134,6 +137,7 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     async def _hover(self, id: int):
         element = await self._find_element(id)
+        await self._scroll_element_into_center(element)
         await element.hover()
 
     def press_key(self, key: Key):
@@ -175,7 +179,7 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     async def _scroll_to(self, id: int):
         element = await self._find_element(id)
-        await element.scroll_into_view_if_needed()
+        await self._scroll_element_into_center(element)
 
     @property
     def title(self) -> str:
@@ -190,6 +194,7 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     async def _type(self, id: int, text: str):
         element = await self._find_element(id)
+        await self._scroll_element_into_center(element)
         await element.fill(text)
 
     def upload(self, id: int, paths: list[str]):
@@ -263,6 +268,9 @@ class PlaywrightAsyncDriver(BaseDriver):
 
     async def _print_to_pdf(self, filepath: str):
         await self.page.pdf(path=filepath)
+
+    async def _scroll_element_into_center(self, element: Locator):
+        await element.evaluate("el => el.scrollIntoView({block: 'center'})")
 
     async def _wait_for_page_to_load(self):
         logger.debug("Waiting for page to finish loading:")

--- a/packages/python/src/alumnium/drivers/playwright_driver.py
+++ b/packages/python/src/alumnium/drivers/playwright_driver.py
@@ -111,19 +111,23 @@ class PlaywrightDriver(BaseDriver):
                 element.locator("xpath=ancestor::select").select_option(value)
         else:
             with self._autoswitch_to_new_tab():
+                self._scroll_element_into_center(element)
                 element.click(force=True)
 
     def drag_slider(self, id: int, value: float):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         element.fill(f"{value:g}")
 
     def drag_and_drop(self, from_id: int, to_id: int):
         from_element = self.find_element(from_id)
         to_element = self.find_element(to_id)
+        self._scroll_element_into_center(from_element)
         from_element.drag_to(to_element)
 
     def hover(self, id: int):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         element.hover()
 
     def press_key(self, key: Key):
@@ -145,7 +149,7 @@ class PlaywrightDriver(BaseDriver):
 
     def scroll_to(self, id: int):
         element = self.find_element(id)
-        element.scroll_into_view_if_needed()
+        self._scroll_element_into_center(element)
 
     @property
     def title(self) -> str:
@@ -153,6 +157,7 @@ class PlaywrightDriver(BaseDriver):
 
     def type(self, id: int, text: str):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         element.fill(text)
 
     def upload(self, id: int, paths: list[str]):
@@ -210,6 +215,9 @@ class PlaywrightDriver(BaseDriver):
 
     def print_to_pdf(self, filepath: str):
         self.page.pdf(path=filepath)
+
+    def _scroll_element_into_center(self, element: Locator):
+        element.evaluate("el => el.scrollIntoView({block: 'center'})")
 
     def _wait_for_page_to_load(self):
         logger.debug("Waiting for page to finish loading:")

--- a/packages/python/src/alumnium/drivers/selenium_driver.py
+++ b/packages/python/src/alumnium/drivers/selenium_driver.py
@@ -132,6 +132,7 @@ class SeleniumDriver(BaseDriver):
     @_autoswitch_to_new_tab
     def click(self, id: int):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         try:
             ActionChains(self.driver).move_to_element(element).click().perform()
         except ElementNotInteractableException:
@@ -140,6 +141,7 @@ class SeleniumDriver(BaseDriver):
 
     def drag_slider(self, id: int, value: float):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         self.driver.execute_script(
             "arguments[0].value = arguments[1];"
             "arguments[0].dispatchEvent(new Event('input', {bubbles: true}));"
@@ -149,15 +151,17 @@ class SeleniumDriver(BaseDriver):
         )
 
     def drag_and_drop(self, from_id: int, to_id: int):
+        from_element = self.find_element(from_id)
+        to_element = self.find_element(to_id)
+        self._scroll_element_into_center(from_element)
         actions = ActionChains(self.driver)
-        actions.drag_and_drop(
-            self.find_element(from_id),
-            self.find_element(to_id),
-        ).perform()
+        actions.drag_and_drop(from_element, to_element).perform()
 
     def hover(self, id: int):
+        element = self.find_element(id)
+        self._scroll_element_into_center(element)
         actions = ActionChains(self.driver)
-        actions.move_to_element(self.find_element(id)).perform()
+        actions.move_to_element(element).perform()
 
     @_autoswitch_to_new_tab
     def press_key(self, key: Key):
@@ -197,7 +201,7 @@ class SeleniumDriver(BaseDriver):
 
     def scroll_to(self, id: int):
         element = self.find_element(id)
-        self.driver.execute_script("arguments[0].scrollIntoView();", element)
+        self._scroll_element_into_center(element)
 
     @property
     def title(self) -> str:
@@ -205,6 +209,7 @@ class SeleniumDriver(BaseDriver):
 
     def type(self, id: int, text: str):
         element = self.find_element(id)
+        self._scroll_element_into_center(element)
         element.clear()
         element.send_keys(text)
 
@@ -266,6 +271,9 @@ class SeleniumDriver(BaseDriver):
         # needs to remain in its frame context for subsequent operations (click, type, etc.)
 
         return element
+
+    def _scroll_element_into_center(self, element: WebElement):
+        self.driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
 
     def _switch_to_frame_chain(self, frame_chain: list[int]):
         """Switch through a chain of nested iframes."""

--- a/packages/typescript/src/drivers/PlaywrightDriver.ts
+++ b/packages/typescript/src/drivers/PlaywrightDriver.ts
@@ -61,6 +61,14 @@ interface CDPFrameTree {
   frameTree: CDPFrameInfo;
 }
 
+interface HTMLElement {
+  tagName: string;
+  value: string;
+  scrollIntoView: (options: {
+    block: "start" | "center" | "end" | "nearest";
+  }) => void;
+}
+
 const CONTEXT_WAS_DESTROYED_ERROR = "Execution context was destroyed";
 
 const WAITER_SCRIPT = waiterScriptSource; // await readScript("waiter.js");
@@ -304,16 +312,15 @@ export class PlaywrightDriver extends BaseDriver {
   @stateful
   async click(id: number): Promise<void> {
     const element = await this.findElement(id);
-    const tagName = await element.evaluate(
-      (el: { tagName: string }) => el.tagName,
-    );
+    const tagName = await element.evaluate((el: HTMLElement) => el.tagName);
     if (tagName?.toLowerCase() === "option") {
-      const value = await element.evaluate((el: { value: string }) => el.value);
+      const value = await element.evaluate((el: HTMLElement) => el.value);
       await this.autoswitchToNewTabAction(async () => {
         await element.locator("xpath=ancestor::select").selectOption(value);
       });
     } else {
       await this.autoswitchToNewTabAction(async () => {
+        await this.#scrollElementIntoCenter(element);
         await element.click({ force: true });
       });
     }
@@ -323,6 +330,7 @@ export class PlaywrightDriver extends BaseDriver {
   @stateful
   async dragSlider(id: number, value: number): Promise<void> {
     const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     await element.fill(String(value));
   }
 
@@ -331,6 +339,7 @@ export class PlaywrightDriver extends BaseDriver {
   async dragAndDrop(fromId: number, toId: number): Promise<void> {
     const fromElement = await this.findElement(fromId);
     const toElement = await this.findElement(toId);
+    await this.#scrollElementIntoCenter(fromElement);
     await fromElement.dragTo(toElement);
   }
 
@@ -338,6 +347,7 @@ export class PlaywrightDriver extends BaseDriver {
   @stateful
   async hover(id: number): Promise<void> {
     const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     await element.hover();
   }
 
@@ -377,7 +387,7 @@ export class PlaywrightDriver extends BaseDriver {
   @stateful
   async scrollTo(id: number): Promise<void> {
     const element = await this.findElement(id);
-    await element.scrollIntoViewIfNeeded();
+    await this.#scrollElementIntoCenter(element);
   }
 
   @span("driver.screenshot", spanAttrs)
@@ -399,6 +409,7 @@ export class PlaywrightDriver extends BaseDriver {
   @stateful
   async type(id: number, text: string): Promise<void> {
     const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     await element.fill(text);
   }
 
@@ -465,6 +476,12 @@ export class PlaywrightDriver extends BaseDriver {
     // TODO: We need to remove the attribute after we are done with the element,
     // but Playwright locator is lazy and we cannot guarantee when it is safe to do so.
     return frame.locator(`css=[data-alumnium-id='${backendNodeId}']`);
+  }
+
+  async #scrollElementIntoCenter(element: Locator): Promise<void> {
+    await element.evaluate((el: HTMLElement) => {
+      el.scrollIntoView({ block: "center" });
+    });
   }
 
   private isOopifFrame(frame: Frame): boolean {

--- a/packages/typescript/src/drivers/SeleniumDriver.ts
+++ b/packages/typescript/src/drivers/SeleniumDriver.ts
@@ -196,6 +196,7 @@ export class SeleniumDriver extends BaseDriver {
   async click(id: number): Promise<void> {
     await this.#autoswitchToNewTabAction(async () => {
       const element = await this.findElement(id);
+      await this.#scrollElementIntoCenter(element);
       try {
         const actions = this.driver.actions({ async: true });
         await actions.move({ origin: element }).click().perform();
@@ -214,6 +215,7 @@ export class SeleniumDriver extends BaseDriver {
   @stateful
   async dragSlider(id: number, value: number): Promise<void> {
     const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     await this.driver.executeScript(
       "arguments[0].value = arguments[1];" +
         "arguments[0].dispatchEvent(new Event('input', {bubbles: true}));" +
@@ -226,17 +228,20 @@ export class SeleniumDriver extends BaseDriver {
   @span("driver.drag_and_drop", spanAttrs)
   @stateful
   async dragAndDrop(fromId: number, toId: number): Promise<void> {
+    const fromElement = await this.findElement(fromId);
+    const toElement = await this.findElement(toId);
+    await this.#scrollElementIntoCenter(fromElement);
     const actions = this.driver.actions({ async: true });
-    await actions
-      .dragAndDrop(await this.findElement(fromId), await this.findElement(toId))
-      .perform();
+    await actions.dragAndDrop(fromElement, toElement).perform();
   }
 
   @span("driver.hover", spanAttrs)
   @stateful
   async hover(id: number): Promise<void> {
+    const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     const actions = this.driver.actions({ async: true });
-    await actions.move({ origin: await this.findElement(id) }).perform();
+    await actions.move({ origin: element }).perform();
   }
 
   @span("driver.press_key", spanAttrs)
@@ -284,7 +289,7 @@ export class SeleniumDriver extends BaseDriver {
   @stateful
   async scrollTo(id: number): Promise<void> {
     const element = await this.findElement(id);
-    await this.driver.executeScript("arguments[0].scrollIntoView();", element);
+    await this.#scrollElementIntoCenter(element);
   }
 
   @span("driver.screenshot", spanAttrs)
@@ -309,6 +314,7 @@ export class SeleniumDriver extends BaseDriver {
   @stateful
   async type(id: number, text: string): Promise<void> {
     const element = await this.findElement(id);
+    await this.#scrollElementIntoCenter(element);
     await element.clear();
     await element.sendKeys(text);
   }
@@ -438,6 +444,13 @@ export class SeleniumDriver extends BaseDriver {
   @span("driver.wait_for_selector", spanAttrs)
   async waitForSelector(): Promise<void> {
     throw new Error("waitForSelector not supported for this driver");
+  }
+
+  async #scrollElementIntoCenter(element: WebElement): Promise<void> {
+    await this.driver.executeScript(
+      "arguments[0].scrollIntoView({block: 'center'});",
+      element,
+    );
   }
 
   @span("driver.internal.cdp_command", (cmd) => ({

--- a/packages/typescript/tests/system/obscuredElement.test.ts
+++ b/packages/typescript/tests/system/obscuredElement.test.ts
@@ -1,0 +1,23 @@
+import { describe } from "vitest";
+import { baseIt } from "./helpers.ts";
+
+describe("Obscured Element", () => {
+  const it = baseIt.override("setup", async ({ setup, skip }) => {
+    return async (options) => {
+      const result = await setup(options);
+      const { isAppiumDriver } = result;
+
+      if (isAppiumDriver) skip("Not supported on Appium driver yet");
+
+      return result;
+    };
+  });
+
+  it("clicks an element covered by a sticky bar", async ({ expect, setup }) => {
+    const { al, $ } = await setup();
+
+    await $.navigate("obscured_element.html");
+    await al.do("click the 'Click Me' button");
+    expect(await al.get("status message")).toContain("button clicked");
+  });
+});


### PR DESCRIPTION
This solves a nasty bug when element is visible, but obscured by another element which receives the clicks. This commit ensures that the element is scrolled into the center of the viewport before interacting with it, which should make it clickable.
