### PR TITLE
ci: replace `pull_request_target` and refine the matrix

### DIFF
--- a/.github/actions/preflight/action.yml
+++ b/.github/actions/preflight/action.yml
@@ -1,0 +1,47 @@
+name: Preflight
+description: Resolves the commit, providers, drivers and workflows the CI run should use.
+
+inputs:
+  workflow-inputs:
+    required: true
+    description: JSON object of the workflow_dispatch inputs, i.e. toJSON(inputs).
+
+outputs:
+  sha:
+    value: ${{ steps.preflight.outputs.sha }}
+    description: Commit SHA to check out in downstream workflows.
+
+  drivers:
+    value: ${{ steps.preflight.outputs.drivers }}
+    description: JSON array of drivers to run system tests with.
+
+  models:
+    value: ${{ steps.preflight.outputs.models }}
+    description: JSON array of model providers to test with.
+
+  run-eval:
+    value: ${{ steps.preflight.outputs.run-eval }}
+    description: Whether to run agent evaluations.
+
+  run-java:
+    value: ${{ steps.preflight.outputs.run-java }}
+    description: Whether to run the Java client workflow.
+
+  run-python:
+    value: ${{ steps.preflight.outputs.run-python }}
+    description: Whether to run the Python client workflow.
+
+  run-typescript:
+    value: ${{ steps.preflight.outputs.run-typescript }}
+    description: Whether to run the TypeScript client workflow.
+
+runs:
+  using: composite
+  steps:
+    - id: preflight
+      uses: actions/github-script@v8
+      with:
+        script: |
+          const workflowInputs = ${{ toJSON(inputs.workflow-inputs) }};
+          const Preflight = require("${{ github.action_path }}/preflight.js");
+          await new Preflight({ context, github, core, workflowInputs, }).run();

--- a/.github/actions/preflight/preflight.js
+++ b/.github/actions/preflight/preflight.js
@@ -1,0 +1,179 @@
+/**
+ * Resolves what a CI run should do: the commit to test, the model providers and
+ * drivers to use, and which downstream workflows to trigger.
+ *
+ * Automatic runs (pull requests, pushes, nightly schedule) use a single cheap
+ * provider. Manual runs pick providers, drivers and clients from checkbox inputs.
+ */
+class Preflight {
+  static SUPPORTED_CLIENTS = ["java", "python", "typescript"];
+  static SUPPORTED_DRIVERS = [
+    "appium-android",
+    "appium-ios",
+    "playwright",
+    "selenium",
+  ];
+  static SUPPORTED_PROVIDERS = [
+    "azure_foundry",
+    "azure_openai",
+    "anthropic",
+    "aws_anthropic",
+    "aws_meta",
+    "codex",
+    "cursor",
+    "deepseek",
+    "google",
+    "mistralai",
+    "ollama",
+    "openai",
+    "xai",
+  ];
+
+  // Keep in sync with ci-*.yml workflow_dispatch inputs default values.
+  static DEFAULT_DRIVERS = ["selenium", "playwright"];
+  static DEFAULT_PROVIDERS = ["azure_openai"];
+
+  #context;
+  #github;
+  #core;
+  #inputs;
+
+  constructor({ context, github, core, workflowInputs }) {
+    this.#context = context;
+    this.#github = github;
+    this.#core = core;
+    this.#inputs =
+      context.eventName === "workflow_dispatch"
+        ? JSON.parse(workflowInputs)
+        : {};
+  }
+
+  async run() {
+    const outputs = {
+      sha: await this.#sha(),
+      models: JSON.stringify(this.#models()),
+      drivers: JSON.stringify(this.#drivers()),
+      ...(await this.#workflows()),
+    };
+
+    for (const [name, value] of Object.entries(outputs)) {
+      this.#core.setOutput(name, value);
+    }
+
+    this.#core.info(JSON.stringify(outputs, null, 2));
+    return outputs;
+  }
+
+  get #dispatched() {
+    return this.#context.eventName === "workflow_dispatch";
+  }
+
+  get #pullRequest() {
+    return this.#context.eventName === "pull_request"
+      ? this.#context.payload.pull_request
+      : null;
+  }
+
+  /**
+   * Returns true if the workflow is running on a trusted branch or fork. This is
+   * used to determine whether to run workflows that require secrets, such as
+   * system tests and agent evaluations.
+   *
+   * Fork pull requests are untrusted because they can be modified by anyone, and
+   * they can access secrets if the workflow is not careful. We only allow forks to
+   * run build/lint/unit tests, which do not require secrets.
+   * Maintainers can run the full suite on fork pull requests via
+   * workflow_dispatch with the `pr` input after reviewing the changes.
+   */
+  get #trusted() {
+    const { owner, repo } = this.#context.repo;
+    return (
+      !this.#pullRequest ||
+      this.#pullRequest.head.repo.full_name === `${owner}/${repo}`
+    );
+  }
+
+  /**
+   * Returns the commit SHA to test. On pull requests, this is the merge commit if
+   * the PR is mergeable, or the head commit if it has conflicts. On pushes and
+   * workflow_dispatch runs, this is the commit that triggered the workflow.
+   */
+  async #sha() {
+    if (this.#inputs.pr) {
+      const { data } = await this.#github.rest.pulls.get({
+        ...this.#context.repo,
+        pull_number: Number(this.#inputs.pr),
+      });
+      return data.mergeable === false
+        ? data.head.sha
+        : (data.merge_commit_sha ?? data.head.sha);
+    }
+
+    // On pull requests this is already the merge commit.
+    return this.#context.sha;
+  }
+
+  #models() {
+    return this.#selection(
+      Preflight.SUPPORTED_PROVIDERS,
+      Preflight.DEFAULT_PROVIDERS,
+    );
+  }
+
+  #drivers() {
+    return this.#selection(
+      Preflight.SUPPORTED_DRIVERS,
+      Preflight.DEFAULT_DRIVERS,
+    );
+  }
+
+  async #workflows() {
+    const changed = await this.#changedPackages();
+    const workflows = {
+      "run-eval": this.#trusted && (!this.#dispatched || this.#inputs.eval),
+    };
+
+    for (const client of Preflight.SUPPORTED_CLIENTS) {
+      // Java and Python clients both depend on the TypeScript core.
+      const affected =
+        !this.#pullRequest || changed.has(client) || changed.has("typescript");
+      const selected = !this.#dispatched || Boolean(this.#inputs[client]);
+      workflows[`run-${client}`] = this.#trusted && selected && affected;
+    }
+
+    return workflows;
+  }
+
+  // Packages touched by the pull request, used to skip unaffected clients.
+  async #changedPackages() {
+    const changed = new Set();
+    if (!this.#pullRequest) return changed;
+
+    const files = await this.#github.paginate(
+      this.#github.rest.pulls.listFiles,
+      {
+        ...this.#context.repo,
+        pull_number: this.#pullRequest.number,
+        per_page: 100,
+      },
+    );
+
+    const pattern = new RegExp(
+      `^packages/(${Preflight.SUPPORTED_CLIENTS.join("|")})/`,
+    );
+    for (const { filename } of files) {
+      const match = filename.match(pattern);
+      if (match) changed.add(match[1]);
+    }
+
+    return changed;
+  }
+
+  #selection(available, fallback) {
+    return this.#dispatched
+      ? available.filter((name) => this.#inputs[name])
+      : fallback;
+  }
+}
+
+module.exports = Preflight;

--- a/.github/workflows/ci-eval.yml
+++ b/.github/workflows/ci-eval.yml
@@ -1,11 +1,15 @@
 name: Eval
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       sha:
         required: true
         type: string
+      models:
+        description: JSON array of model providers to test with.
+        required: false
+        type: string
+        default: '["azure_openai"]'
 
 env:
   ALUMNIUM_LOG_LEVEL: debug
@@ -15,13 +19,17 @@ env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  AZURE_FOUNDRY_API_KEY: ${{ secrets.AZURE_FOUNDRY_API_KEY }}
+  AZURE_FOUNDRY_API_VERSION: ${{ secrets.AZURE_FOUNDRY_API_VERSION }}
   AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
   AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
   AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+  CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
   DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
   eval:
@@ -38,9 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - model: azure_openai
-          - model: google
+        model: ${{ fromJSON(inputs.models) }}
 
     steps:
       - name: Git Checkout

--- a/.github/workflows/ci-java.yml
+++ b/.github/workflows/ci-java.yml
@@ -1,11 +1,20 @@
 name: Java
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       sha:
         required: true
         type: string
+      drivers:
+        description: JSON array of drivers to run system tests with.
+        required: false
+        type: string
+        default: '["playwright", "selenium"]'
+      models:
+        description: JSON array of model providers to test with.
+        required: false
+        type: string
+        default: '["azure_openai"]'
 
 env:
   ALUMNIUM_LOG_LEVEL: debug
@@ -20,13 +29,17 @@ env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  AZURE_FOUNDRY_API_KEY: ${{ secrets.AZURE_FOUNDRY_API_KEY }}
+  AZURE_FOUNDRY_API_VERSION: ${{ secrets.AZURE_FOUNDRY_API_VERSION }}
   AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
   AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
   AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+  CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
   DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
   test-system:
@@ -40,20 +53,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - driver: selenium
-            model: azure_openai
-
-          - driver: playwright
-            model: azure_openai
-
-          # TODO: Figure out why LambdaTest started to fail.
-
-          # - driver: appium-ios
-          #   model: azure_openai
-
-          # - driver: appium-android
-          #   model: azure_openai
+        driver: ${{ fromJSON(inputs.drivers) }}
+        model: ${{ fromJSON(inputs.models) }}
 
     steps:
       - name: Git Checkout
@@ -120,7 +121,7 @@ jobs:
         if: always()
         uses: ./.github/actions/alumnium-artifacts
         with:
-          name: ci-java-test-pkg-${{ matrix.model }}
+          name: ci-java-test-pkg
           package: java
 
       - name: Run Playwright Post-Setup

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,11 +1,20 @@
 name: Python
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       sha:
         required: true
         type: string
+      drivers:
+        description: JSON array of drivers to run system tests with.
+        required: false
+        type: string
+        default: '["playwright", "selenium"]'
+      models:
+        description: JSON array of model providers to test with.
+        required: false
+        type: string
+        default: '["azure_openai"]'
 
 env:
   ALUMNIUM_LOG_LEVEL: debug
@@ -19,13 +28,17 @@ env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  AZURE_FOUNDRY_API_KEY: ${{ secrets.AZURE_FOUNDRY_API_KEY }}
+  AZURE_FOUNDRY_API_VERSION: ${{ secrets.AZURE_FOUNDRY_API_VERSION }}
   AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
   AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
   AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+  CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
   DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
   test-system:
@@ -39,28 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        driver:
-          - selenium
-        model:
-          - azure_openai
-          - google
-        include:
-          - driver: selenium
-            model: azure_openai
-
-          - driver: playwright
-            model: azure_openai
-
-          - driver: playwright
-            model: google
-
-          # TODO: Figure out why LambdaTest started to fail.
-
-          # - driver: appium-ios
-          #   model: azure_openai
-
-          # - driver: appium-android
-          #   model: azure_openai
+        driver: ${{ fromJSON(inputs.drivers) }}
+        model: ${{ fromJSON(inputs.models) }}
 
     steps:
       - name: Git Checkout
@@ -131,7 +124,7 @@ jobs:
         if: always()
         uses: ./.github/actions/alumnium-artifacts
         with:
-          name: ci-python-test-pkg-${{ matrix.model }}
+          name: ci-python-test-pkg
           package: python
 
       - name: Run Playwright Post-Setup

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -1,11 +1,20 @@
 name: TypeScript
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       sha:
         required: true
         type: string
+      drivers:
+        description: JSON array of drivers to run system tests with.
+        required: false
+        type: string
+        default: '["playwright", "selenium"]'
+      models:
+        description: JSON array of model providers to test with.
+        required: false
+        type: string
+        default: '["azure_openai"]'
 
 env:
   ALUMNIUM_LOG_LEVEL: debug
@@ -19,13 +28,17 @@ env:
   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
   AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+  AZURE_FOUNDRY_API_KEY: ${{ secrets.AZURE_FOUNDRY_API_KEY }}
+  AZURE_FOUNDRY_API_VERSION: ${{ secrets.AZURE_FOUNDRY_API_VERSION }}
   AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
   AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
   AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+  CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
   DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
   GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
   MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
 
 jobs:
   test-system:
@@ -39,20 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - driver: selenium
-            model: azure_openai
-
-          - driver: playwright
-            model: azure_openai
-
-          - driver: playwright
-            model: google
-
-          # TODO: Figure out why LambdaTest started to fail.
-
-          # - driver: appium-ios
-          #   model: azure_openai
+        driver: ${{ fromJSON(inputs.drivers) }}
+        model: ${{ fromJSON(inputs.models) }}
 
     steps:
       - name: Git Checkout
@@ -122,7 +123,7 @@ jobs:
         if: always()
         uses: ./.github/actions/alumnium-artifacts
         with:
-          name: ci-typescript-test-pkg-${{ matrix.model }}
+          name: ci-typescript-test-pkg
           package: typescript
 
       - name: Run Playwright Post-Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,88 @@
 name: CI
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - main
-      - "ci-**"
-      - "ci/**"
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+    inputs:
+      pr:
+        description: >-
+          Pull request number to test instead of the selected branch. Use this to run
+          the full suite (with secrets) against a fork PR after reviewing its changes.
+        type: string
+        required: false
+        default: ""
+      eval:
+        description: Run agent evaluations
+        type: boolean
+        default: true
+      java:
+        description: Run Java client tests
+        type: boolean
+        default: true
+      typescript:
+        description: Run TypeScript client tests
+        type: boolean
+        default: true
+      python:
+        description: Run Python client tests
+        type: boolean
+        default: true
+      appium-android:
+        description: Run Appium (Android) driver tests
+        type: boolean
+        default: false
+      appium-ios:
+        description: Run Appium (iOS) driver tests
+        type: boolean
+        default: false
+      playwright:
+        description: Run Playwright driver tests
+        type: boolean
+        default: true
+      selenium:
+        description: Run Selenium driver tests
+        type: boolean
+        default: true
+      azure_openai:
+        description: Test on Azure OpenAI provider
+        type: boolean
+        default: true
+      anthropic:
+        description: Test on Anthropic provider
+        type: boolean
+        default: false
+      cursor:
+        description: Test on Cursor provider
+        type: boolean
+        default: false
+      deepseek:
+        description: Test on DeepSeek provider
+        type: boolean
+        default: false
+      google:
+        description: Test on Google provider
+        type: boolean
+        default: false
+      mistralai:
+        description: Test on MistralAI provider
+        type: boolean
+        default: false
+      openai:
+        description: Test on OpenAI provider
+        type: boolean
+        default: false
+      xai:
+        description: Test on xAI provider
+        type: boolean
+        default: false
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  group: ci-${{ inputs.pr || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ALUMNIUM_LOG_DEBUG_EXTRA: all
@@ -21,24 +91,30 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.params.outputs.sha }}
+      drivers: ${{ steps.params.outputs.drivers }}
+      models: ${{ steps.params.outputs.models }}
+      run-eval: ${{ steps.params.outputs.run-eval }}
+      run-java: ${{ steps.params.outputs.run-java }}
+      run-python: ${{ steps.params.outputs.run-python }}
+      run-typescript: ${{ steps.params.outputs.run-typescript }}
 
     permissions:
       contents: read
-      # NOTE: Needed for cache save
-      actions: write
-
-    # Prevent running the workflow for PRs from ci/ or ci- branches, since those
-    # trigger the workflow on branch push events.
-    if: >
-      github.event_name != 'pull_request_target'
-        || (!startsWith(github.event.pull_request.head.ref, 'ci/')
-          && !startsWith(github.event.pull_request.head.ref, 'ci-'))
+      pull-requests: read
 
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.pr && format('refs/pull/{0}/merge', inputs.pr) || github.sha }}
+
+      - name: Preflight
+        id: params
+        uses: ./.github/actions/preflight
+        with:
+          workflow-inputs: ${{ toJSON(inputs) }}
 
       - name: Set Up Dev Env
         uses: ./.github/actions/setup
@@ -89,95 +165,45 @@ jobs:
         if: failure() && runner.debug == '1'
         uses: mxschmitt/action-tmate@v3
 
-  preflight:
-    name: Preflight
-
-    runs-on: ubuntu-latest
-    outputs:
-      permitted: ${{ steps.check-access.outputs.require-result }}
-      ignore-changes: ${{ github.event_name == 'push' }}
-      java-changed: ${{ steps.changed-files.outputs.java_any_changed }}
-      python-changed: ${{ steps.changed-files.outputs.python_any_changed }}
-      typescript-changed: ${{ steps.changed-files.outputs.typescript_any_changed }}
-
-    permissions:
-      contents: read
-
-    # Prevent running the workflow for PRs from ci/ or ci- branches, since those
-    # trigger the workflow on branch push events.
-    if: >
-      github.event_name != 'pull_request_target'
-        || (!startsWith(github.event.pull_request.head.ref, 'ci/')
-          && !startsWith(github.event.pull_request.head.ref, 'ci-'))
-
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check Access
-        id: check-access
-        uses: actions-cool/check-user-permission@v2
-        with:
-          require: write
-          username: ${{ github.triggering_actor }}
-
-      - name: Determine Changed Files
-        id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files_yaml: |
-            java:
-              - packages/java/**
-            python:
-              - packages/python/**
-            typescript:
-              - packages/typescript/**
-
   eval:
     name: Eval
-    needs: preflight
+    needs: test
     secrets: inherit
-    if: needs.preflight.outputs.permitted == 'true'
+    if: needs.test.outputs.run-eval == 'true'
     uses: ./.github/workflows/ci-eval.yml
     with:
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      sha: ${{ needs.test.outputs.sha }}
+      models: ${{ needs.test.outputs.models }}
 
   java:
     name: Java
-    needs: preflight
+    needs: test
     secrets: inherit
-    if: >
-      needs.preflight.outputs.permitted == 'true'
-        && (needs.preflight.outputs.ignore-changes == 'true'
-          || needs.preflight.outputs.typescript-changed == 'true'
-          || needs.preflight.outputs.java-changed == 'true')
+    if: needs.test.outputs.run-java == 'true'
     uses: ./.github/workflows/ci-java.yml
     with:
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      sha: ${{ needs.test.outputs.sha }}
+      models: ${{ needs.test.outputs.models }}
+      drivers: ${{ needs.test.outputs.drivers }}
 
   python:
     name: Python
-    needs: preflight
+    needs: test
     secrets: inherit
-    if: >
-      needs.preflight.outputs.permitted == 'true'
-        && (needs.preflight.outputs.ignore-changes == 'true'
-          || needs.preflight.outputs.typescript-changed == 'true'
-          || needs.preflight.outputs.python-changed == 'true')
+    if: needs.test.outputs.run-python == 'true'
     uses: ./.github/workflows/ci-python.yml
     with:
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      sha: ${{ needs.test.outputs.sha }}
+      models: ${{ needs.test.outputs.models }}
+      drivers: ${{ needs.test.outputs.drivers }}
 
   typescript:
     name: TypeScript
-    needs: preflight
+    needs: test
     secrets: inherit
-    if: >
-      needs.preflight.outputs.permitted == 'true'
-        && (needs.preflight.outputs.ignore-changes == 'true'
-          || needs.preflight.outputs.typescript-changed == 'true')
+    if: needs.test.outputs.run-typescript == 'true'
     uses: ./.github/workflows/ci-typescript.yml
     with:
-      sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      sha: ${{ needs.test.outputs.sha }}
+      models: ${{ needs.test.outputs.models }}
+      drivers: ${{ needs.test.outputs.drivers }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,27 @@ For local development, you may need to configure the following environment varia
 5. **Maintain API parity** - If adding features to one package, consider implementing them in both Python and TypeScript.
 6. **Submit your PR** with a clear description of what it accomplishes.
 
+### 6. Continuous Integration
+
+Every pull request runs build, formatting, lint, type and unit checks. System tests and agent
+evaluations also run automatically for pull requests opened from branches in this repository,
+using the `azure_openai` provider only. Pull requests from forks do not receive API keys, so
+their system tests are skipped until a maintainer runs them explicitly (see below).
+
+Maintainers can run the full suite manually from the _Actions_ tab or with the GitHub CLI:
+
+```bash
+# Run system tests for a fork pull request after reviewing its changes
+gh workflow run ci.yml -f pr=123
+
+# Run against specific providers and clients (every provider, driver and client is a checkbox input)
+gh workflow run ci.yml -f google=true -f anthropic=true -f typescript=false -f java=false -f selenium=false -f eval=false
+```
+
+Only `azure_openai` is checked by default. Every provider from `packages/typescript/src/Model.ts` is
+available, but only some have credentials configured in CI (azure_openai, anthropic, aws_anthropic,
+aws_meta, deepseek, google, mistralai, openai); the others will fail until secrets are added.
+
 ## AI-First Testing Philosophy
 
 As contributors to an AI-powered testing tool, we value:


### PR DESCRIPTION
Switch from `pull_request_target` to `pull_request` so PR code never runs with repository secrets. Fork PRs get build/lint/unit checks only, and maintainers can dispatch the full suite against a fork's merge commit by triggering via `workflow_dispatch` with the pr input.

Refines the matrix of drivers/providers on CI. Now, only `azure_openai` is tested automatically, while other providers can be selected manually.