### PR TITLE
Change default Codex model to 5.6 Luna

### DIFF
--- a/packages/java/src/main/java/ai/alumnium/Model.java
+++ b/packages/java/src/main/java/ai/alumnium/Model.java
@@ -79,7 +79,7 @@ public final class Model {
             Map.entry(Provider.ANTHROPIC, "claude-haiku-4-5-20251001"),
             Map.entry(Provider.AWS_ANTHROPIC, "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
             Map.entry(Provider.AWS_META, "us.meta.llama4-maverick-17b-instruct-v1:0"),
-            Map.entry(Provider.CODEX, "gpt-5.4-mini"),
+            Map.entry(Provider.CODEX, "gpt-5.6-luna"),
             Map.entry(Provider.CURSOR, "composer-2.5"),
             Map.entry(Provider.DEEPSEEK, "deepseek-reasoner"),
             Map.entry(Provider.GOOGLE, "gemini-3.1-flash-lite"),

--- a/packages/python/src/alumnium/models.py
+++ b/packages/python/src/alumnium/models.py
@@ -25,7 +25,7 @@ class Name:
         Provider.ANTHROPIC: "claude-haiku-4-5-20251001",
         Provider.AWS_ANTHROPIC: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         Provider.AWS_META: "us.meta.llama4-maverick-17b-instruct-v1:0",
-        Provider.CODEX: "gpt-5.4-mini",
+        Provider.CODEX: "gpt-5.6-luna",
         Provider.CURSOR: "composer-2.5",
         Provider.DEEPSEEK: "deepseek-reasoner",
         Provider.GOOGLE: "gemini-3.1-flash-lite",

--- a/packages/typescript/src/Model.ts
+++ b/packages/typescript/src/Model.ts
@@ -33,7 +33,7 @@ const defaultModels: Record<Model.Provider, string> = {
   anthropic: "claude-haiku-4-5-20251001",
   aws_anthropic: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
   aws_meta: "us.meta.llama4-maverick-17b-instruct-v1:0",
-  codex: "gpt-5.4-mini",
+  codex: "gpt-5.6-luna",
   cursor: "composer-2.5",
   deepseek: "deepseek-reasoner",
   google: "gemini-3.1-flash-lite",

--- a/websites/docs/src/content/blog/2026-05-13-release-0.20.0.md
+++ b/websites/docs/src/content/blog/2026-05-13-release-0.20.0.md
@@ -30,7 +30,7 @@ Huge shoutout to [Sasha Koss][12], who handled a massive amount of work on the T
 
 ## Codex and Qwen Models
 
-Codex is now an officially supported provider in Alumnium. Since OpenAI still allows using Codex subscriptions for third-party integrations, we've written a [langchain-codex][13] integration. It automatically handles authentication, so if you have a ChatGPT Plus/Pro subscription, you can reuse it for Alumnium calls without an API key. The default model used is `gpt-5.4-mini`, but you can change it as needed.
+Codex is now an officially supported provider in Alumnium. Since OpenAI still allows using Codex subscriptions for third-party integrations, we've written a [langchain-codex][13] integration. It automatically handles authentication, so if you have a ChatGPT Plus/Pro subscription, you can reuse it for Alumnium calls without an API key. The default model used is `gpt-5.6-luna`, but you can change it as needed.
 
 ```sh
 codex mcp add alumnium --env ALUMNIUM_MODEL=codex -- alumnium mcp

--- a/websites/docs/src/content/docs/docs/getting-started/configuration.md
+++ b/websites/docs/src/content/docs/docs/getting-started/configuration.md
@@ -10,7 +10,7 @@ Alumnium needs access to an AI model to work. The following models are supported
 | [Anthropic][1]          | Claude 4.5 Haiku        |
 | [Google][2]             | Gemini 3.1 Flash Lite   |
 | [OpenAI][3] _(default)_ | GPT-5 Nano              |
-| [Codex][22]             | GPT-5.4 Mini            |
+| [Codex][22]             | GPT-5.6 Luna            |
 | [DeepSeek][12]          | DeepSeek R1             |
 | [Meta][8]               | Llama 4 Maverick 17B    |
 | [MistralAI][16]         | Mistral Medium 3        |

--- a/websites/docs/src/content/docs/docs/reference.md
+++ b/websites/docs/src/content/docs/docs/reference.md
@@ -114,7 +114,7 @@ Select AI provider and model to use.
 | azure_openai  | gpt-5-nano                                  | Self-hosted Azure OpenAI API. Recommended model version is _2025-08-07_. |
 | aws_anthropic | us.anthropic.claude-haiku-4-5-20251001-v1:0 | Serverless Amazon Bedrock API.                                           |
 | aws_meta      | us.meta.llama4-maverick-17b-instruct-v1:0   | Serverless Amazon Bedrock API.                                           |
-| codex         | gpt-5.4-mini                                | OpenAI models via ChatGPT Plus/Pro OAuth.                                |
+| codex         | gpt-5.6-luna                                | OpenAI models via ChatGPT Plus/Pro OAuth.                                |
 | cursor        | composer-2.5                                | Cursor models via Cursor Agents SDK (local runtime).                     |
 | deepseek      | deepseek-reasoner                           | DeepSeek Platform.                                                       |
 | google        | gemini-3.1-flash-lite                       | Google AI Studio API.                                                    |


### PR DESCRIPTION
## Summary

Change default Codex model to 5.6 Luna

## Motivation

Latest versions of Codex don't ship with 5.4-mini which means that out of the box, the default Codex setup won't work on latest version. 

In addition Luna is both more performant (scores better on benchmarks and is newer model) and ~3.5x cheaper than 5.4-mini, as of the time of this change.

## Type of Change

Mark the relevant options.

- [x] Bug fix
- [ ] New feature (non-breaking changes, test coverage, refactoring)
- [ ] Breaking change (fix, refactoring, or feature that would cause existing functionality to change)
- [ ] Cleanup (documentation, formatting)

## Checklist

Please verify the following before submitting:

- [x] I have read the [Contributing Guidelines](https://github.com/alumnium-hq/alumnium/blob/main/CONTRIBUTING.md)
- [x] I have added or updated relevant documentation
- ~[ ] I have written or updated necessary tests~
- [ ] I have tested the changes locally
- [x] The changes follow the project's coding style and structure
- [x] I have not included any sensitive or credential-related information
- ~[ ] I have ensured these changes maintain or improve accessibility (for UI changes)~
- [x] I have considered security implications of these changes
